### PR TITLE
fix: persist theme setting to DB and restore on reload

### DIFF
--- a/src/server/db/settings.ts
+++ b/src/server/db/settings.ts
@@ -22,6 +22,7 @@ export const SETTINGS_DEFAULTS: Record<string, string> = {
   [SETTINGS_KEYS.DISPLAY_SHOW_STATS]: 'true',
   [SETTINGS_KEYS.DISPLAY_SHOW_AGENT_DEFINITIONS]: 'true',
   [SETTINGS_KEYS.DISPLAY_SHOW_WORKFLOW_BARS]: 'true',
+  [SETTINGS_KEYS.DISPLAY_THEME]: JSON.stringify({ preset: 'dark' }),
 }
 
 export type SettingsKey = typeof SETTINGS_KEYS[keyof typeof SETTINGS_KEYS]

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -201,21 +201,32 @@ function App() {
   }, [configFetched, providers.length])
 
   useEffect(() => {
-    const { applySavedTheme, saveTheme } = useThemeStore.getState()
+    const { applyPreset, applyTokens } = useThemeStore.getState()
     const serverTheme = displaySettings[SETTINGS_KEYS.DISPLAY_THEME]
     const serverPresets = displaySettings[SETTINGS_KEYS.DISPLAY_USER_PRESETS]
 
-    if (serverTheme) {
-      localStorage.setItem('openfox:theme', serverTheme)
-    }
     if (serverPresets) {
       localStorage.setItem('openfox:userPresets', serverPresets)
     }
 
     if (serverTheme) {
-      applySavedTheme()
+      localStorage.setItem('openfox:theme', serverTheme)
+      try {
+        const parsed = JSON.parse(serverTheme) as { preset?: string; tokens?: Record<string, string> }
+        if (parsed.preset && parsed.tokens) {
+          applyPreset(parsed.preset)
+          useThemeStore.setState({ basePreset: parsed.preset })
+          applyTokens(parsed.tokens)
+        } else if (parsed.preset) {
+          applyPreset(parsed.preset)
+        } else if (parsed.tokens) {
+          applyTokens(parsed.tokens)
+        }
+      } catch {
+        applyPreset('dark')
+      }
     } else {
-      saveTheme(JSON.stringify({ preset: 'dark' }))
+      applyPreset('dark')
     }
   }, [displaySettings[SETTINGS_KEYS.DISPLAY_THEME], displaySettings[SETTINGS_KEYS.DISPLAY_USER_PRESETS]])
 

--- a/web/src/components/settings/ThemeEditor.tsx
+++ b/web/src/components/settings/ThemeEditor.tsx
@@ -172,7 +172,7 @@ export function ThemeEditor() {
 
   const handlePresetSelect = (presetId: string) => {
     applyPreset(presetId)
-    saveTheme(JSON.stringify({ preset: presetId }))
+    saveTheme(JSON.stringify({ preset: presetId })).catch(() => {})
   }
 
   const handleUserPresetSelect = (index: number) => {

--- a/web/src/stores/theme.ts
+++ b/web/src/stores/theme.ts
@@ -153,7 +153,7 @@ interface ThemeState {
   getActiveTheme: () => Record<string, string>
   applyTheme: () => void
   getSavedTheme: () => string | null
-  saveTheme: (themeJson: string) => void
+  saveTheme: (themeJson: string) => Promise<void>
   clearCustomTheme: () => void
   reset: () => void
 
@@ -206,7 +206,7 @@ export const useThemeStore = create<ThemeState>((set, get) => ({
   },
 
   applyPreset: (presetId: string) => {
-    const preset = THEME_PRESETS.find(p => p.id === presetId)
+    const preset = THEME_PRESETS.find((p) => p.id === presetId)
     if (preset) {
       set({ currentPreset: presetId, basePreset: '', customTokens: {}, isCustom: false, isCustomizing: false })
       get().applyTheme()
@@ -215,7 +215,7 @@ export const useThemeStore = create<ThemeState>((set, get) => ({
 
   startCustomizing: () => {
     const { currentPreset } = get()
-    const presetTokens = THEME_PRESETS.find(p => p.id === currentPreset)?.tokens ?? {}
+    const presetTokens = THEME_PRESETS.find((p) => p.id === currentPreset)?.tokens ?? {}
     set({
       basePreset: currentPreset,
       customTokens: { ...presetTokens },
@@ -225,7 +225,7 @@ export const useThemeStore = create<ThemeState>((set, get) => ({
   },
 
   setCustomToken: (key: string, value: string) => {
-    set(state => ({
+    set((state) => ({
       customTokens: { ...state.customTokens, [key]: value },
     }))
     get().applyTheme()
@@ -237,7 +237,9 @@ export const useThemeStore = create<ThemeState>((set, get) => ({
 
   saveCustomTheme: () => {
     const { customTokens } = get()
-    get().saveTheme(JSON.stringify({ tokens: customTokens }))
+    get()
+      .saveTheme(JSON.stringify({ tokens: customTokens }))
+      .catch(() => {})
     set({ isCustomizing: false })
   },
 
@@ -249,13 +251,13 @@ export const useThemeStore = create<ThemeState>((set, get) => ({
   getActiveTheme: () => {
     const { basePreset, customTokens, isCustom } = get()
     if (isCustom && basePreset) {
-      const base = THEME_PRESETS.find(p => p.id === basePreset)?.tokens ?? {}
+      const base = THEME_PRESETS.find((p) => p.id === basePreset)?.tokens ?? {}
       return { ...base, ...customTokens }
     }
     if (isCustom) {
       return { ...THEME_TOKENS.reduce((acc, t) => ({ ...acc, [t.key]: t.defaultValue }), {}), ...customTokens }
     }
-    const preset = THEME_PRESETS.find(p => p.id === get().currentPreset)
+    const preset = THEME_PRESETS.find((p) => p.id === get().currentPreset)
     return preset?.tokens ?? THEME_PRESETS[0]?.tokens ?? {}
   },
 
@@ -271,14 +273,15 @@ export const useThemeStore = create<ThemeState>((set, get) => ({
   getSavedTheme: () => {
     try {
       const saved = localStorage.getItem('openfox:theme')
-      if (saved) {
-        const parsed = JSON.parse(saved)
-        if (parsed.preset) {
-          return JSON.stringify({ preset: parsed.preset })
-        }
-        if (parsed.tokens) {
-          return JSON.stringify({ tokens: parsed.tokens })
-        }
+      if (!saved) return null
+      // Handle both plain preset name and JSON format
+      if (saved[0] !== '{') return JSON.stringify({ preset: saved })
+      const parsed = JSON.parse(saved)
+      if (parsed.preset) {
+        return JSON.stringify({ preset: parsed.preset })
+      }
+      if (parsed.tokens) {
+        return JSON.stringify({ tokens: parsed.tokens })
       }
     } catch {
       return null
@@ -286,12 +289,10 @@ export const useThemeStore = create<ThemeState>((set, get) => ({
     return null
   },
 
-  saveTheme: (themeJson: string) => {
+  saveTheme: async (themeJson: string) => {
     localStorage.setItem('openfox:theme', themeJson)
-    // Fire-and-forget sync to server
-    import('./settings').then(({ useSettingsStore }) => {
-      useSettingsStore.getState().setSetting(SETTINGS_KEYS.DISPLAY_THEME, themeJson).catch(() => {})
-    })
+    const { useSettingsStore } = await import('./settings')
+    await useSettingsStore.getState().setSetting(SETTINGS_KEYS.DISPLAY_THEME, themeJson)
   },
 
   clearCustomTheme: () => {
@@ -334,7 +335,9 @@ export const useThemeStore = create<ThemeState>((set, get) => ({
         isCustomizing: false,
       })
       get().applyTheme()
-      get().saveTheme(JSON.stringify({ preset: preset.basePreset, tokens: preset.tokens }))
+      get()
+        .saveTheme(JSON.stringify({ preset: preset.basePreset, tokens: preset.tokens }))
+        .catch(() => {})
     }
   },
 
@@ -352,7 +355,10 @@ export const useThemeStore = create<ThemeState>((set, get) => ({
     localStorage.setItem('openfox:userPresets', JSON.stringify(get().userPresets))
     // Fire-and-forget sync to server
     import('./settings').then(({ useSettingsStore }) => {
-      useSettingsStore.getState().setSetting(SETTINGS_KEYS.DISPLAY_USER_PRESETS, JSON.stringify(get().userPresets)).catch(() => {})
+      useSettingsStore
+        .getState()
+        .setSetting(SETTINGS_KEYS.DISPLAY_USER_PRESETS, JSON.stringify(get().userPresets))
+        .catch(() => {})
     })
   },
 }))


### PR DESCRIPTION
## Summary

- Persist selected theme to the server database (not just localStorage) so it survives tab/server restarts
- Make `saveTheme` async so the DB write is awaited, not fire-and-forget
- Handle both plain preset names and JSON format in `getSavedTheme` to support legacy values
- Apply server theme directly on reload instead of a localStorage round-trip