### PR TITLE
fix: replace intrusive Ctrl/Shift double-press with Ctrl+J and Ctrl+K

### DIFF
--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -326,20 +326,13 @@ export function Header({ onMenuClick, onCriteriaToggle }: HeaderProps) {
 
   
 
-  // Double Ctrl opens terminal
-  const lastCtrlRef = useRef<number>(0)
+  // Ctrl+J opens terminal
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Control' && !e.shiftKey && !e.metaKey && !e.altKey) {
-        const now = Date.now()
-        if (now - lastCtrlRef.current < 300) {
-          e.preventDefault()
-          e.stopPropagation()
-          useTerminalStore.getState().toggleOpen()
-          lastCtrlRef.current = 0
-        } else {
-          lastCtrlRef.current = now
-        }
+      if (e.key === 'j' && (e.ctrlKey || e.metaKey)) {
+        e.preventDefault()
+        e.stopPropagation()
+        useTerminalStore.getState().toggleOpen()
       }
     }
     window.addEventListener('keydown', handleKeyDown, true)

--- a/web/src/components/plan/PlanPanel.tsx
+++ b/web/src/components/plan/PlanPanel.tsx
@@ -215,19 +215,12 @@ export function PlanPanel({ criteriaSidebarOpen: externalCriteriaSidebarOpen, on
     return () => window.removeEventListener('keydown', handleEscape)
   }, [isRunning, stopGeneration, isAutoScrollActive])
 
-  // Double Shift opens quick action modal
-  const lastShiftRef = useRef<number>(0)
+  // Ctrl+K opens quick action modal
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Shift' && !e.ctrlKey && !e.metaKey && !e.altKey) {
-        const now = Date.now()
-        if (now - lastShiftRef.current < 300) {
-          e.preventDefault()
-          setShowQuickAction(true)
-          lastShiftRef.current = 0
-        } else {
-          lastShiftRef.current = now
-        }
+      if (e.key === 'k' && (e.ctrlKey || e.metaKey)) {
+        e.preventDefault()
+        setShowQuickAction(true)
       }
     }
     window.addEventListener('keydown', handleKeyDown)

--- a/web/src/components/plan/PlanPanel.tsx
+++ b/web/src/components/plan/PlanPanel.tsx
@@ -204,7 +204,8 @@ export function PlanPanel({ criteriaSidebarOpen: externalCriteriaSidebarOpen, on
   // Escape key to stop generation
   useEffect(() => {
     const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && isRunning) {
+      const popupOpen = showQuickAction || showCommandsModal || showWorkflowsModal || showMessageSearch
+      if (e.key === 'Escape' && isRunning && !popupOpen) {
         stopGeneration()
       }
       if (e.key === 'ScrollLock') {
@@ -213,7 +214,7 @@ export function PlanPanel({ criteriaSidebarOpen: externalCriteriaSidebarOpen, on
     }
     window.addEventListener('keydown', handleEscape)
     return () => window.removeEventListener('keydown', handleEscape)
-  }, [isRunning, stopGeneration, isAutoScrollActive])
+  }, [isRunning, stopGeneration, isAutoScrollActive, showQuickAction, showCommandsModal, showWorkflowsModal, showMessageSearch])
 
   // Ctrl+K opens quick action modal
   useEffect(() => {


### PR DESCRIPTION
## Summary
  
- Replace double-press Ctrl (terminal) and Shift (quick action) with standard **Ctrl+J** and **Ctrl+K** shortcuts
- On Windows, holding Ctrl/Shift to type frequently causes these handlers to misfire, especially with sticky keys enabled
- ESC to abort generation is now gated: it won't fire when any popup is open (quick action, commands, workflows, message search), preventing accidental aborts when closing a modal
- ESC to close terminal (Ctrl+J) works as before — it's in a separate handler in TerminalDrawer