### PR TITLE
feat: add rename session button to sidebar

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -6,7 +6,6 @@ import { dirname, resolve, join } from 'node:path'
 import { readFile } from 'node:fs/promises'
 import { createServer as createViteServer, type ViteDevServer } from 'vite'
 
-
 import type { Config } from '../shared/types.js'
 import type { ServerHandle } from './context.js'
 import { initDatabase } from './db/index.js'
@@ -28,7 +27,15 @@ import { devServerManager } from './dev-server/manager.js'
 import { getGlobalConfigDir } from '../cli/paths.js'
 import { logger, setLogLevel } from './utils/logger.js'
 import { VERSION } from '../constants.js'
-import { loadServerAuthConfig, requiresAuth, hasPassword, getAuthConfig, verifyPassword, isValidToken, tokenFromPassword } from './auth.js'
+import {
+  loadServerAuthConfig,
+  requiresAuth,
+  hasPassword,
+  getAuthConfig,
+  verifyPassword,
+  isValidToken,
+  tokenFromPassword,
+} from './auth.js'
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
 /**
@@ -354,7 +361,7 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
     const globalConfig = await loadGlobalConfig(config.mode ?? 'production')
     const updatedConfig = setDefaultModelSelection(globalConfig, providerId, model ?? 'auto')
     await saveGlobalConfig(config.mode ?? 'production', updatedConfig)
-    
+
     // Update in-memory config so new sessions inherit the selection
     config.defaultModelSelection = updatedConfig.defaultModelSelection
 
@@ -433,6 +440,24 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
     sessionManager.setDangerLevel(sessionId, dangerLevel)
     const updatedSession = sessionManager.getSession(sessionId)
 
+    res.json({ session: updatedSession })
+  })
+
+  // Rename session (REST)
+  app.put('/api/sessions/:id/title', async (req, res) => {
+    const sessionId = req.params.id
+    const session = sessionManager.getSession(sessionId)
+    if (!session) {
+      return res.status(404).json({ error: 'Session not found' })
+    }
+
+    const { title } = req.body
+    if (!title || typeof title !== 'string') {
+      return res.status(400).json({ error: 'title is required' })
+    }
+
+    sessionManager.renameSession(sessionId, title.slice(0, 100))
+    const updatedSession = sessionManager.getSession(sessionId)
     res.json({ session: updatedSession })
   })
 
@@ -600,7 +625,7 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
   app.get('/api/config', async (_req, res) => {
     const llmClient = getLLMClient()
     const activeProvider = providerManager.getActiveProvider()
-    
+
     let visionFallback: { enabled: boolean; url: string; model: string; timeout: number } | undefined
     let globalWorkdir: string | undefined
     try {
@@ -705,10 +730,19 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
     }
 
     try {
-      const { loadGlobalConfig, saveGlobalConfig, addProvider, setDefaultModelSelection } = await import('../cli/config.js')
+      const { loadGlobalConfig, saveGlobalConfig, addProvider, setDefaultModelSelection } =
+        await import('../cli/config.js')
       const globalConfig = await loadGlobalConfig(config.mode ?? 'production')
 
-      const providerBackend = backend as 'auto' | 'vllm' | 'sglang' | 'ollama' | 'llamacpp' | 'openai' | 'anthropic' | 'opencode-go'
+      const providerBackend = backend as
+        | 'auto'
+        | 'vllm'
+        | 'sglang'
+        | 'ollama'
+        | 'llamacpp'
+        | 'openai'
+        | 'anthropic'
+        | 'opencode-go'
 
       const configWithProvider = addProvider(globalConfig, {
         name,
@@ -722,7 +756,7 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
       const finalConfig = setDefaultModelSelection(
         configWithProvider,
         configWithProvider.providers[configWithProvider.providers.length - 1]!.id,
-        model ?? 'auto'
+        model ?? 'auto',
       )
 
       await saveGlobalConfig(config.mode ?? 'production', finalConfig)
@@ -789,9 +823,9 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
     const globalConfig = await loadGlobalConfig(config.mode ?? 'production')
     const updatedConfig = removeProvider(globalConfig, id)
     await saveGlobalConfig(config.mode ?? 'production', updatedConfig)
-    
+
     providerManager.setProviders(updatedConfig.providers, updatedConfig.defaultModelSelection ?? undefined)
-    
+
     res.json({ success: true })
   })
 
@@ -826,7 +860,14 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
 
   app.post('/api/providers/:id/models/:modelId', async (req, res) => {
     const { id, modelId } = req.params
-    const body = req.body as { contextWindow?: number; temperature?: number | null; topP?: number | null; topK?: number | null; maxTokens?: number | null; supportsVision?: boolean }
+    const body = req.body as {
+      contextWindow?: number
+      temperature?: number | null
+      topP?: number | null
+      topK?: number | null
+      maxTokens?: number | null
+      supportsVision?: boolean
+    }
 
     logger.info('API: POST /api/providers/:id/models/:modelId', {
       providerId: id,
@@ -835,7 +876,11 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
     })
 
     // Support both old API (contextWindow only) and new API (full settings)
-    const hasFullSettings = body.temperature !== undefined || body.topP !== undefined || body.topK !== undefined || body.maxTokens !== undefined
+    const hasFullSettings =
+      body.temperature !== undefined ||
+      body.topP !== undefined ||
+      body.topK !== undefined ||
+      body.maxTokens !== undefined
 
     let result: { success: boolean; error?: string; model?: import('../shared/types.js').ModelConfig }
     if (hasFullSettings) {
@@ -880,10 +925,10 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
       }
     }
 
-    res.json({ 
-      success: true, 
-      providerId: id, 
-      modelId, 
+    res.json({
+      success: true,
+      providerId: id,
+      modelId,
       contextWindow: body.contextWindow,
       model: result.model,
       contextState,

--- a/src/server/session/manager.ts
+++ b/src/server/session/manager.ts
@@ -90,7 +90,9 @@ export class SessionManager {
     this.providerManager = providerManager
   }
 
-  getCurrentModelSettings(): { temperature?: number; topP?: number; topK?: number; maxTokens?: number; supportsVision?: boolean } | undefined {
+  getCurrentModelSettings():
+    | { temperature?: number; topP?: number; topK?: number; maxTokens?: number; supportsVision?: boolean }
+    | undefined {
     const model = this.providerManager.getCurrentModel()
     if (!model) return undefined
     return this.providerManager.getModelSettings(model)
@@ -281,6 +283,18 @@ export class SessionManager {
   }
 
   /**
+   * Rename session. Updates title in DB and emits session_updated.
+   */
+  renameSession(sessionId: string, title: string): Session {
+    this.requireSession(sessionId)
+    logger.debug('Renaming session', { sessionId, title })
+    updateSessionMetadata(sessionId, { title })
+    const updatedSession = this.requireSession(sessionId)
+    this.emit({ type: 'session_updated', session: updatedSession })
+    return updatedSession
+  }
+
+  /**
    * Set session running state. Emits running.changed event.
    */
   setRunning(sessionId: string, isRunning: boolean): Session {
@@ -361,10 +375,7 @@ export class SessionManager {
   /**
    * Add a message. Delegates to EventStore.
    */
-  addMessage(
-    sessionId: string,
-    message: Omit<Message, 'id' | 'timestamp'>
-  ): Message {
+  addMessage(sessionId: string, message: Omit<Message, 'id' | 'timestamp'>): Message {
     this.requireSession(sessionId)
 
     const state = getSessionState(sessionId)
@@ -414,10 +425,7 @@ export class SessionManager {
   /**
    * Add an assistant message. Delegates to EventStore.
    */
-  addAssistantMessage(
-    sessionId: string,
-    message: Omit<Message, 'id' | 'timestamp' | 'role'>
-  ): Message {
+  addAssistantMessage(sessionId: string, message: Omit<Message, 'id' | 'timestamp' | 'role'>): Message {
     this.requireSession(sessionId)
 
     const state = getSessionState(sessionId)
@@ -471,7 +479,7 @@ export class SessionManager {
   updateMessage(
     sessionId: string,
     messageId: string,
-    updates: Partial<Omit<Message, 'id' | 'timestamp' | 'role'>>
+    updates: Partial<Omit<Message, 'id' | 'timestamp' | 'role'>>,
   ): void {
     this.requireSession(sessionId)
     // In the event model, messages are immutable after message.done
@@ -549,7 +557,7 @@ export class SessionManager {
       compactionCount,
       isInDangerZone(promptTokens, maxTokens),
       canCompact(promptTokens, maxTokens),
-      subAgentId
+      subAgentId,
     )
 
     logger.debug('Context state updated', { sessionId, promptTokens, maxTokens, subAgentId })
@@ -594,11 +602,7 @@ export class SessionManager {
   /**
    * Add a criterion attempt.
    */
-  addCriterionAttempt(
-    sessionId: string,
-    criterionId: string,
-    attempt: Criterion['attempts'][number]
-  ): void {
+  addCriterionAttempt(sessionId: string, criterionId: string, attempt: Criterion['attempts'][number]): void {
     const state = getSessionState(sessionId)
     if (!state) return
 
@@ -609,9 +613,7 @@ export class SessionManager {
 
     // Re-emit criteria with new attempt added
     const updatedCriteria = state.criteria.map((c) =>
-      c.id === criterionId
-        ? { ...c, attempts: [...c.attempts, attempt] }
-        : c
+      c.id === criterionId ? { ...c, attempts: [...c.attempts, attempt] } : c,
     )
     emitCriteriaSet(sessionId, updatedCriteria)
   }
@@ -632,7 +634,10 @@ export class SessionManager {
   /**
    * Add a criterion. Returns the updated criteria list.
    */
-  addCriterion(sessionId: string, criterion: Criterion): { criteria: Criterion[]; actualId: string } | { error: string } {
+  addCriterion(
+    sessionId: string,
+    criterion: Criterion,
+  ): { criteria: Criterion[]; actualId: string } | { error: string } {
     const state = getSessionState(sessionId)
     if (!state) {
       return { error: 'Session not found' }
@@ -652,7 +657,7 @@ export class SessionManager {
   updateCriterionFull(
     sessionId: string,
     criterionId: string,
-    updates: Partial<Pick<Criterion, 'description'>>
+    updates: Partial<Pick<Criterion, 'description'>>,
   ): Criterion[] {
     const state = getSessionState(sessionId)
     if (!state) {
@@ -663,9 +668,7 @@ export class SessionManager {
       throw new Error(`Criterion not found: ${criterionId}`)
     }
 
-    const updatedCriteria = state.criteria.map((c) =>
-      c.id === criterionId ? { ...c, ...updates } : c
-    )
+    const updatedCriteria = state.criteria.map((c) => (c.id === criterionId ? { ...c, ...updates } : c))
     emitCriteriaSet(sessionId, updatedCriteria)
 
     return updatedCriteria
@@ -696,7 +699,13 @@ export class SessionManager {
 
   private messageQueues = new Map<string, QueuedMessage[]>()
 
-  queueMessage(sessionId: string, mode: 'asap' | 'completion', content: string, attachments?: Attachment[], messageKind?: string): QueuedMessage {
+  queueMessage(
+    sessionId: string,
+    mode: 'asap' | 'completion',
+    content: string,
+    attachments?: Attachment[],
+    messageKind?: string,
+  ): QueuedMessage {
     const queue = this.messageQueues.get(sessionId) ?? []
     const msg: QueuedMessage = {
       queueId: crypto.randomUUID(),
@@ -715,7 +724,7 @@ export class SessionManager {
   cancelQueuedMessage(sessionId: string, queueId: string): boolean {
     const queue = this.messageQueues.get(sessionId)
     if (!queue) return false
-    const idx = queue.findIndex(m => m.queueId === queueId)
+    const idx = queue.findIndex((m) => m.queueId === queueId)
     if (idx === -1) return false
     queue.splice(idx, 1)
     this.emit({ type: 'queue_cancelled', sessionId, queueId })
@@ -725,8 +734,11 @@ export class SessionManager {
   drainAsapMessages(sessionId: string): QueuedMessage[] {
     const queue = this.messageQueues.get(sessionId)
     if (!queue) return []
-    const asap = queue.filter(m => m.mode === 'asap')
-    this.messageQueues.set(sessionId, queue.filter(m => m.mode !== 'asap'))
+    const asap = queue.filter((m) => m.mode === 'asap')
+    this.messageQueues.set(
+      sessionId,
+      queue.filter((m) => m.mode !== 'asap'),
+    )
     for (const msg of asap) {
       this.emit({ type: 'queue_drained', sessionId, queueId: msg.queueId })
     }
@@ -736,8 +748,11 @@ export class SessionManager {
   drainCompletionMessages(sessionId: string): QueuedMessage[] {
     const queue = this.messageQueues.get(sessionId)
     if (!queue) return []
-    const completion = queue.filter(m => m.mode === 'completion')
-    this.messageQueues.set(sessionId, queue.filter(m => m.mode !== 'completion'))
+    const completion = queue.filter((m) => m.mode === 'completion')
+    this.messageQueues.set(
+      sessionId,
+      queue.filter((m) => m.mode !== 'completion'),
+    )
     for (const msg of completion) {
       this.emit({ type: 'queue_drained', sessionId, queueId: msg.queueId })
     }
@@ -851,26 +866,28 @@ export class SessionManager {
   getContextState(sessionId: string): ContextState {
     const session = this.getSession(sessionId)
     const providerManager = this.providerManager
-    
+
     // Get maxTokens from session's provider/model if set, otherwise use global
     let maxTokens: number
     if (session?.providerId && session.providerModel) {
       // Session has explicit provider/model - get context from that
       const providers = providerManager.getProviders()
-      const provider = providers.find(p => p.id === session.providerId)
+      const provider = providers.find((p) => p.id === session.providerId)
       if (provider) {
         // Try exact match first
-        let modelConfig = provider.models.find(m => m.id === session.providerModel)
+        let modelConfig = provider.models.find((m) => m.id === session.providerModel)
         // If not found, try fuzzy match (handle spaces/dashes/underscores variations)
         if (!modelConfig && session.providerModel) {
           const normalize = (s: string) => s.toLowerCase().replace(/[-_\s]+/g, '')
           const sessionModelNormalized = normalize(session.providerModel)
-          modelConfig = provider.models.find(m => {
+          modelConfig = provider.models.find((m) => {
             const modelIdNormalized = normalize(m.id)
             // Check if normalized IDs match or one contains the other
-            return modelIdNormalized === sessionModelNormalized || 
-                   modelIdNormalized.includes(sessionModelNormalized) ||
-                   sessionModelNormalized.includes(modelIdNormalized)
+            return (
+              modelIdNormalized === sessionModelNormalized ||
+              modelIdNormalized.includes(sessionModelNormalized) ||
+              sessionModelNormalized.includes(modelIdNormalized)
+            )
           })
         }
         maxTokens = modelConfig?.contextWindow ?? providerManager.getCurrentModelContext()
@@ -881,7 +898,7 @@ export class SessionManager {
       // Use global provider/model
       maxTokens = providerManager.getCurrentModelContext()
     }
-    
+
     const state = getSessionState(sessionId, maxTokens)
     if (!state) {
       return {
@@ -998,7 +1015,9 @@ export class SessionManager {
       messages,
       criteria: eventState.criteria,
       contextWindows: [], // Derived from events, not stored separately
-      executionState: eventState.lastModeWithReminder ? { lastModeWithReminder: eventState.lastModeWithReminder } as any : null,
+      executionState: eventState.lastModeWithReminder
+        ? ({ lastModeWithReminder: eventState.lastModeWithReminder } as any)
+        : null,
     }
   }
 }

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -19,16 +19,16 @@ export function Sidebar({ projectId, isOpen = true, onClose }: SidebarProps) {
   const [, navigate] = useLocation()
   const [showSettings, setShowSettings] = useState(false)
 
-  const sessions = useSessionStore(state => state.sessions)
-  const currentSession = useSessionStore(state => state.currentSession)
-  const unreadSessionIds = useSessionStore(state => state.unreadSessionIds)
-  const deleteSession = useSessionStore(state => state.deleteSession)
-  const deleteAllSessions = useSessionStore(state => state.deleteAllSessions)
-  const loadMoreSessions = useSessionStore(state => state.loadMoreSessions)
-  const sessionsHasMore = useSessionStore(state => state.sessionsHasMore)
-  const sessionsPaginationLoading = useSessionStore(state => state.sessionsPaginationLoading)
+  const sessions = useSessionStore((state) => state.sessions)
+  const currentSession = useSessionStore((state) => state.currentSession)
+  const unreadSessionIds = useSessionStore((state) => state.unreadSessionIds)
+  const deleteSession = useSessionStore((state) => state.deleteSession)
+  const deleteAllSessions = useSessionStore((state) => state.deleteAllSessions)
+  const loadMoreSessions = useSessionStore((state) => state.loadMoreSessions)
+  const sessionsHasMore = useSessionStore((state) => state.sessionsHasMore)
+  const sessionsPaginationLoading = useSessionStore((state) => state.sessionsPaginationLoading)
 
-  const currentProject = useProjectStore(state => state.currentProject)
+  const currentProject = useProjectStore((state) => state.currentProject)
 
   const loadMoreRef = useRef<HTMLDivElement>(null)
 
@@ -48,7 +48,7 @@ export function Sidebar({ projectId, isOpen = true, onClose }: SidebarProps) {
           handleLoadMore()
         }
       },
-      { threshold: 0.1 }
+      { threshold: 0.1 },
     )
 
     observer.observe(loadMoreRef.current)
@@ -56,7 +56,7 @@ export function Sidebar({ projectId, isOpen = true, onClose }: SidebarProps) {
   }, [sessionsHasMore, handleLoadMore])
 
   // Filter sessions to those belonging to the current project by ID
-  const projectSessions = sessions.filter(session => session.projectId === currentProject?.id)
+  const projectSessions = sessions.filter((session) => session.projectId === currentProject?.id)
 
   const handleDeleteSession = (sessionId: string, e?: React.MouseEvent) => {
     e?.stopPropagation()
@@ -66,6 +66,17 @@ export function Sidebar({ projectId, isOpen = true, onClose }: SidebarProps) {
       if (currentSession?.id === sessionId) {
         navigate(`/p/${projectId}`)
       }
+    }
+  }
+
+  const handleRenameSession = (sessionId: string, e?: React.MouseEvent) => {
+    e?.stopPropagation()
+    const session = sessions.find((s) => s.id === sessionId)
+    const currentTitle = session?.title ?? sessionId.slice(0, 6)
+    const newTitle = prompt('Rename session:', currentTitle)
+    if (newTitle !== null && newTitle.trim() !== '') {
+      const renameSession = useSessionStore.getState().renameSession
+      renameSession(sessionId, newTitle.trim())
     }
   }
 
@@ -79,12 +90,7 @@ export function Sidebar({ projectId, isOpen = true, onClose }: SidebarProps) {
   return (
     <>
       {/* Mobile/tablet backdrop */}
-      {isOpen && onClose && (
-        <div
-          className="md:hidden fixed inset-0 bg-black/50 z-40"
-          onClick={onClose}
-        />
-      )}
+      {isOpen && onClose && <div className="md:hidden fixed inset-0 bg-black/50 z-40" onClick={onClose} />}
 
       <aside
         className={`
@@ -127,39 +133,31 @@ export function Sidebar({ projectId, isOpen = true, onClose }: SidebarProps) {
             }
           />
           {/* Mobile close button */}
-          {onClose && (
-            <CloseButton
-              onClick={onClose}
-              className="md:hidden"
-              variant="sidebar"
-              size="md"
-            />
-          )}
+          {onClose && <CloseButton onClick={onClose} className="md:hidden" variant="sidebar" size="md" />}
         </div>
 
         {/* Project Settings Modal */}
         {currentProject && (
-          <ProjectSettingsModal
-            isOpen={showSettings}
-            onClose={() => setShowSettings(false)}
-            project={currentProject}
-          />
+          <ProjectSettingsModal isOpen={showSettings} onClose={() => setShowSettings(false)} project={currentProject} />
         )}
 
         <div className="flex-1 overflow-y-auto">
           {projectSessions.length === 0 ? (
-            <div className="p-4 text-center text-text-muted text-xs">
-              No sessions
-            </div>
+            <div className="p-4 text-center text-text-muted text-xs">No sessions</div>
           ) : (
             <>
               <div className="divide-y divide-border">
-                {renderSessionGroups(projectSessions, currentSession, unreadSessionIds, handleDeleteSession, projectId)}
+                {renderSessionGroups(
+                  projectSessions,
+                  currentSession,
+                  unreadSessionIds,
+                  handleDeleteSession,
+                  handleRenameSession,
+                  projectId,
+                )}
               </div>
               {sessionsPaginationLoading && (
-                <div className="p-4 text-center text-text-muted text-xs">
-                  Loading more...
-                </div>
+                <div className="p-4 text-center text-text-muted text-xs">Loading more...</div>
               )}
               <div ref={loadMoreRef} className="h-px" />
             </>
@@ -175,23 +173,24 @@ function renderSessionGroups(
   currentSession: { id: string | null } | null,
   unreadSessionIds: string[],
   handleDeleteSession: (sessionId: string, e?: React.MouseEvent) => void,
+  handleRenameSession: (sessionId: string, e?: React.MouseEvent) => void,
   projectId: string,
 ) {
   const groups = groupSessionsByDate(projectSessions)
-  
+
   return Array.from(groups).map(([dateKey, daySessions]) => {
     const firstSession = daySessions[0]
     if (!firstSession) return null
-    
+
     return (
       <div key={dateKey}>
         {/* Date header */}
         <div className="px-4 py-2 bg-bg-tertiary/30 text-text-muted text-xs font-medium">
           {formatDateHeader(firstSession.updatedAt)}
         </div>
-        
+
         {/* Sessions for this day */}
-        {daySessions.map(session => {
+        {daySessions.map((session) => {
           const isActive = currentSession?.id === session.id
           const hasUnread = unreadSessionIds.includes(session.id)
           const isRunning = session.isRunning
@@ -207,11 +206,17 @@ function renderSessionGroups(
                 className={`block ${isActive ? 'text-accent-primary' : 'text-text-primary'} hover:text-accent-primary`}
               >
                 <div className="flex justify-between items-center mb-1">
-                  <span className={`font-medium truncate text-sm ${isActive ? 'text-accent-primary' : 'text-text-primary'}`}>
+                  <span
+                    className={`font-medium truncate text-sm ${isActive ? 'text-accent-primary' : 'text-text-primary'}`}
+                  >
                     {session.title ?? session.id.slice(0, 6)}
                   </span>
                   <DropdownMenu
                     items={[
+                      {
+                        label: 'Rename session',
+                        onClick: (e?: React.MouseEvent) => handleRenameSession(session.id, e),
+                      },
                       {
                         label: 'Delete session',
                         onClick: (e?: React.MouseEvent) => handleDeleteSession(session.id, e),
@@ -241,13 +246,9 @@ function renderSessionGroups(
                     />
                   ) : null}
                   {/* Time in muted style */}
-                  <span className="text-text-muted text-xs flex-shrink-0">
-                    {formatTime(session.updatedAt)}
-                  </span>
+                  <span className="text-text-muted text-xs flex-shrink-0">{formatTime(session.updatedAt)}</span>
                   {/* Message count in muted style */}
-                  <span className="text-text-muted text-xs flex-shrink-0">
-                    {session.messageCount} messages
-                  </span>
+                  <span className="text-text-muted text-xs flex-shrink-0">{session.messageCount} messages</span>
                 </div>
               </Link>
             </div>

--- a/web/src/stores/session.ts
+++ b/web/src/stores/session.ts
@@ -173,7 +173,7 @@ export interface PendingPathConfirmation {
   paths: string[]
   workdir: string
   reason: 'outside_workdir' | 'sensitive_file' | 'both' | 'dangerous_command' | 'git_no_verify'
-  alwaysAllow?: boolean  // Set when user clicks "Always Allow"
+  alwaysAllow?: boolean // Set when user clicks "Always Allow"
 }
 
 // Pending ask_user question from server
@@ -220,7 +220,10 @@ interface SessionState {
   pendingQuestion: PendingQuestion | null
 
   // Vision fallback state per message (for inline display in feed)
-  visionFallbackByMessage: Record<string, { type: 'start' | 'done'; attachmentId: string; filename?: string; description?: string }>
+  visionFallbackByMessage: Record<
+    string,
+    { type: 'start' | 'done'; attachmentId: string; filename?: string; description?: string }
+  >
 
   // Message queue (while agent is running)
   queuedMessages: QueuedMessage[]
@@ -248,6 +251,7 @@ interface SessionState {
   loadSession: (sessionId: string) => Promise<void>
   listSessions: (projectId?: string, limit?: number) => Promise<void>
   deleteSession: (sessionId: string) => Promise<boolean>
+  renameSession: (sessionId: string, title: string) => Promise<boolean>
   deleteAllSessions: (projectId: string) => Promise<boolean>
   loadMoreSessions: (projectId: string) => Promise<void>
   clearSession: () => void
@@ -521,7 +525,7 @@ export const useSessionStore = create<SessionState>((set, get) => {
       } catch (error) {
         console.error('Failed to connect:', error)
         const closeCode = wsClient.getLastCloseCode()
-        
+
         // Only show password modal if we don't have a token AND auth failed
         // If we have a token, just show disconnected - the token is still valid
         if (!wsClient.hasToken() && (closeCode === 1006 || closeCode === 4000)) {
@@ -709,10 +713,13 @@ export const useSessionStore = create<SessionState>((set, get) => {
         const data = await res.json()
         const moreSessions = (data.sessions ?? []) as SessionSummary[]
         set((state) => ({
-          sessions: [...state.sessions, ...moreSessions.map((s) => {
-            const existing = state.sessions.find((e) => e.id === s.id)
-            return existing?.isRunning === false ? { ...s, isRunning: false } : s
-          })],
+          sessions: [
+            ...state.sessions,
+            ...moreSessions.map((s) => {
+              const existing = state.sessions.find((e) => e.id === s.id)
+              return existing?.isRunning === false ? { ...s, isRunning: false } : s
+            }),
+          ],
           sessionsHasMore: data.hasMore ?? false,
           sessionsPaginationLoading: false,
         }))
@@ -730,6 +737,30 @@ export const useSessionStore = create<SessionState>((set, get) => {
         // Clear current session if it was deleted
         if (get().currentSession?.id === sessionId) {
           get().clearSession()
+        }
+        return true
+      } catch {
+        return false
+      }
+    },
+
+    renameSession: async (sessionId: string, title: string) => {
+      try {
+        const res = await authFetch(`/api/sessions/${sessionId}/title`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ title }),
+        })
+        if (!res.ok) return false
+        // Refresh session list to pick up new title
+        await get().listSessions()
+        // Update current session title if it's the one being renamed
+        const currentSessionId = get().currentSession?.id
+        if (currentSessionId === sessionId) {
+          const data = await res.json()
+          if (data.session) {
+            set({ currentSession: data.session })
+          }
         }
         return true
       } catch {
@@ -1087,7 +1118,8 @@ export const useSessionStore = create<SessionState>((set, get) => {
           const currentConfirmation = stateSnapshot.pendingPathConfirmation
 
           // Only keep server confirmation if we don't have one locally (user already responded)
-          const pendingPathConfirmation = currentConfirmation ?? (serverConfirmations.length > 0 ? serverConfirmations[0] ?? null : null)
+          const pendingPathConfirmation =
+            currentConfirmation ?? (serverConfirmations.length > 0 ? (serverConfirmations[0] ?? null) : null)
 
           set({
             currentSession: payload.session,
@@ -1319,7 +1351,13 @@ export const useSessionStore = create<SessionState>((set, get) => {
                   arguments: payload.args,
                   startedAt: Date.now(),
                   ...(bufferedOutputs.length > 0
-                    ? { streamingOutput: bufferedOutputs.map((o) => ({ stream: o.stream, content: o.content, timestamp: Date.now() })) }
+                    ? {
+                        streamingOutput: bufferedOutputs.map((o) => ({
+                          stream: o.stream,
+                          content: o.content,
+                          timestamp: Date.now(),
+                        })),
+                      }
                     : {}),
                 },
               ],


### PR DESCRIPTION
Add a **Rename session** button to the per-session dropdown menu in the sidebar.

- Uses browser `prompt()` dialog with current title as default (consistent with existing `confirm()` for delete)
- Manual rename inhibits future auto-naming (existing `needsNameGeneration()` already skips non-default titles)
- Title capped at 100 characters server-side