### PR TITLE
fix: remove gap between Send and MoreMenu buttons

### DIFF
--- a/web/src/components/plan/PlanPanel.tsx
+++ b/web/src/components/plan/PlanPanel.tsx
@@ -701,6 +701,7 @@ export function PlanPanel({ criteriaSidebarOpen: externalCriteriaSidebarOpen, on
               Abort
             </button>
           )}
+                <div>
                 <button
                   type="button"
                   onClick={() => {
@@ -745,6 +746,7 @@ export function PlanPanel({ criteriaSidebarOpen: externalCriteriaSidebarOpen, on
                   criteria={session?.criteria ?? []}
                 />
               </div>
+                </div>
             </div>
         <div className="mt-3 flex items-center justify-between">
           <div className="flex items-center gap-2">

--- a/web/src/components/plan/PlanPanel.tsx
+++ b/web/src/components/plan/PlanPanel.tsx
@@ -701,7 +701,7 @@ export function PlanPanel({ criteriaSidebarOpen: externalCriteriaSidebarOpen, on
               Abort
             </button>
           )}
-                <div>
+                <div className="flex items-center">
                 <button
                   type="button"
                   onClick={() => {


### PR DESCRIPTION
Make the Send and three-dots (MoreMenu) sit flush against each other again. Was introduced unintentionally in my feature/stop-button branch.