### PR TITLE
fix: protect .metadata access with optional chaining

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -217,8 +217,64 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
       return res.status(400).json({ error: 'name and workdir are required' })
     }
     const { createDirectoryWithGit } = await import('./utils/project-creator.js')
-    const project = await createDirectoryWithGit(name, workdir)
-    res.status(201).json({ project })
+    try {
+      const project = await createDirectoryWithGit(name, workdir)
+      res.status(201).json({ project })
+    } catch (err) {
+      if (err instanceof Error && 'code' in err && err.code === 'EACCES') {
+        const eaccError = err as Error & { code?: string; cause?: unknown }
+        return res.status(403).json({
+          error: eaccError.message || 'Permission denied',
+          code: 'EACCES',
+          path: workdir,
+        })
+      }
+      res.status(500).json({ error: err instanceof Error ? err.message : 'Unknown error' })
+    }
+  })
+
+  app.post('/api/projects/fix-permissions', async (req, res) => {
+    const { path: targetPath } = req.body
+    if (!targetPath) {
+      return res.status(400).json({ error: 'path is required' })
+    }
+
+    try {
+      const { execSync } = await import('node:child_process')
+      const { resolve } = await import('node:path')
+      const { access } = await import('node:fs/promises')
+      const { constants } = await import('node:fs')
+
+      const resolvedPath = resolve(targetPath)
+
+      // Check if passwordless sudo is available
+      try {
+        execSync('sudo -n true', { stdio: 'pipe' })
+      } catch {
+        return res.json({ success: false, sudoAvailable: false })
+      }
+
+      // Check if the path exists
+      try {
+        await access(resolvedPath, constants.F_OK)
+      } catch {
+        return res.status(404).json({ error: 'Path not found' })
+      }
+
+      // Get current user
+      const currentUser = process.env['USER'] || process.env['USERNAME'] || 'root'
+
+      // Take ownership
+      execSync(`sudo chown -R ${currentUser} "${resolvedPath}"`, { stdio: 'pipe' })
+
+      res.json({ success: true, sudoAvailable: true })
+    } catch (err) {
+      res.status(500).json({
+        success: false,
+        sudoAvailable: true,
+        error: err instanceof Error ? err.message : 'Failed to fix permissions',
+      })
+    }
   })
 
   app.get('/api/projects/:id', async (req, res) => {

--- a/src/server/utils/project-creator.ts
+++ b/src/server/utils/project-creator.ts
@@ -37,23 +37,40 @@ export async function createDirectoryWithGit(projectName: string, workdir: strin
   }
 
   const fullPath = workdir.replace(/\/+$/, '')
-  const { stat, mkdir } = await import('node:fs/promises')
+  const { stat, mkdir, rm } = await import('node:fs/promises')
 
   try {
     const stats = await stat(fullPath)
     if (!stats.isDirectory()) {
       throw new Error(`A file named '${projectName}' already exists at ${fullPath}`)
     }
-  } catch {
-    await mkdir(fullPath, { recursive: true })
+  } catch (err) {
+    if (err instanceof Error && 'code' in err && err.code === 'ENOENT') {
+      try {
+        await mkdir(fullPath, { recursive: true })
+      } catch (mkdirErr) {
+        if (mkdirErr instanceof Error && 'code' in mkdirErr && mkdirErr.code === 'EACCES') {
+          const eaccError = mkdirErr as NodeJS.ErrnoException
+          const permError = new Error(`Permission denied: cannot create directory at ${fullPath}`, { cause: eaccError }) as Error & { code?: string }
+          permError.code = 'EACCES'
+          throw permError
+        }
+        throw mkdirErr
+      }
+    } else {
+      throw err
+    }
   }
 
   if (!(await directoryExists(join(fullPath, '.git')))) {
     try {
       execSync('git init', { cwd: fullPath, stdio: 'pipe' })
     } catch (gitErr) {
-      const { rm } = await import('node:fs/promises')
-      await rm(fullPath, { recursive: true, force: true })
+      try {
+        await rm(fullPath, { recursive: true, force: true })
+      } catch {
+        // ignore cleanup errors
+      }
       throw new Error(`Failed to initialize git: ${gitErr instanceof Error ? gitErr.message : 'Unknown'}`)
     }
   }

--- a/web/src/components/CreateProjectModal.tsx
+++ b/web/src/components/CreateProjectModal.tsx
@@ -6,6 +6,7 @@ import { Input } from './shared/Input'
 import { authFetch } from '../lib/api'
 import { validateProjectName } from './shared/validation'
 import { PlusMdIcon } from './shared/icons'
+import { PermissionDeniedModal } from './PermissionDeniedModal'
 
 interface CreateProjectModalProps {
   isOpen: boolean
@@ -18,6 +19,7 @@ export function CreateProjectModal({ isOpen, onClose }: CreateProjectModalProps)
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
   const [workdir, setWorkdir] = useState<string>('')
+  const [permissionDeniedPath, setPermissionDeniedPath] = useState<string | null>(null)
   const inputRef = useRef<HTMLInputElement>(null)
   
   // Fetch workdir from config when modal opens
@@ -33,6 +35,7 @@ export function CreateProjectModal({ isOpen, onClose }: CreateProjectModalProps)
       setProjectName('')
       setError(null)
       setLoading(false)
+      setPermissionDeniedPath(null)
       // Focus the input after modal renders
       setTimeout(() => {
         inputRef.current?.focus()
@@ -65,6 +68,10 @@ export function CreateProjectModal({ isOpen, onClose }: CreateProjectModalProps)
       
       if (!response.ok) {
         const errorData = await response.json().catch(() => ({}))
+        if (errorData.code === 'EACCES') {
+          setPermissionDeniedPath(fullPath)
+          return
+        }
         throw new Error(errorData.error || 'Failed to create project')
       }
       
@@ -81,6 +88,40 @@ export function CreateProjectModal({ isOpen, onClose }: CreateProjectModalProps)
     }
   }, [projectName, navigate, onClose, workdir])
   
+  const handlePermissionDeniedClose = useCallback(() => {
+    setPermissionDeniedPath(null)
+  }, [])
+  
+  const handleRetry = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    setPermissionDeniedPath(null)
+    
+    const fullPath = `${workdir}/${projectName}`
+    
+    try {
+      const response = await authFetch('/api/projects', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: projectName, workdir: fullPath }),
+      })
+      
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}))
+        throw new Error(errorData.error || 'Failed to create project')
+      }
+      
+      const data = await response.json()
+      const project = data.project
+      
+      onClose()
+      navigate(`/p/${project.id}`)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create project')
+      setLoading(false)
+    }
+  }, [projectName, workdir, navigate, onClose])
+  
   const handleCancel = useCallback(() => {
     setProjectName('')
     setError(null)
@@ -90,74 +131,85 @@ export function CreateProjectModal({ isOpen, onClose }: CreateProjectModalProps)
   const fullPath = projectName ? `${workdir}/${projectName}` : ''
   
   return (
-    <Modal
-      isOpen={isOpen}
-      onClose={handleCancel}
-      title="Create New Project"
-      size="sm"
-    >
-      <form onSubmit={handleSubmit} className="space-y-4">
-        <div>
-          <label htmlFor="project-name" className="block text-sm font-medium text-text-secondary mb-2">
-            Project Name
-          </label>
-          <Input
-            ref={inputRef}
-            id="project-name"
-            value={projectName}
-            onChange={(e) => {
-              setProjectName(e.target.value)
-              setError(null)
-            }}
-            placeholder="my-project"
-            disabled={loading}
-            data-testid="create-project-name-input"
-            className="w-full"
-          />
-          
-          {/* Path preview */}
-          {projectName && (
-            <div className="mt-2 text-xs text-text-muted">
-              Full path: <span className="font-mono">{fullPath}</span>
-            </div>
-          )}
-          
-          {/* Error message */}
-          {error && (
-            <div className="mt-3 p-3 bg-accent-error/10 border border-accent-error/30 rounded text-sm text-accent-error">
-              {error}
-            </div>
-          )}
-        </div>
-        
-        {/* Actions */}
-        <div className="flex justify-end gap-2">
-          <Button
-            type="button"
-            variant="secondary"
-            onClick={handleCancel}
-            disabled={loading}
-          >
-            Cancel
-          </Button>
-          <Button
-            type="submit"
-            variant="primary"
-            disabled={loading || !projectName.trim()}
-            data-testid="create-project-submit-button"
-            className="min-w-[100px]"
-          >
-            {loading ? (
-              <span className="flex items-center gap-2">
-                <PlusMdIcon className="h-4 w-4" />
-                Creating...
-              </span>
-            ) : (
-              'Create'
+    <>
+      <Modal
+        isOpen={isOpen}
+        onClose={handleCancel}
+        title="Create New Project"
+        size="sm"
+      >
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label htmlFor="project-name" className="block text-sm font-medium text-text-secondary mb-2">
+              Project Name
+            </label>
+            <Input
+              ref={inputRef}
+              id="project-name"
+              value={projectName}
+              onChange={(e) => {
+                setProjectName(e.target.value)
+                setError(null)
+              }}
+              placeholder="my-project"
+              disabled={loading}
+              data-testid="create-project-name-input"
+              className="w-full"
+            />
+            
+            {/* Path preview */}
+            {projectName && (
+              <div className="mt-2 text-xs text-text-muted">
+                Full path: <span className="font-mono">{fullPath}</span>
+              </div>
             )}
-          </Button>
-        </div>
-      </form>
-    </Modal>
+            
+            {/* Error message */}
+            {error && (
+              <div className="mt-3 p-3 bg-accent-error/10 border border-accent-error/30 rounded text-sm text-accent-error">
+                {error}
+              </div>
+            )}
+          </div>
+          
+          {/* Actions */}
+          <div className="flex justify-end gap-2">
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={handleCancel}
+              disabled={loading}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              variant="primary"
+              disabled={loading || !projectName.trim()}
+              data-testid="create-project-submit-button"
+              className="min-w-[100px]"
+            >
+              {loading ? (
+                <span className="flex items-center gap-2">
+                  <PlusMdIcon className="h-4 w-4" />
+                  Creating...
+                </span>
+              ) : (
+                'Create'
+              )}
+            </Button>
+          </div>
+        </form>
+      </Modal>
+      
+      {permissionDeniedPath && (
+        <PermissionDeniedModal
+          isOpen={!!permissionDeniedPath}
+          onClose={handlePermissionDeniedClose}
+          path={permissionDeniedPath}
+          onRetry={handleRetry}
+        />
+      )}
+    </>
   )
 }

--- a/web/src/components/CreateSessionModal.tsx
+++ b/web/src/components/CreateSessionModal.tsx
@@ -8,6 +8,7 @@ import { authFetch } from '../lib/api'
 import { DeleteProjectConfirmationModal } from './DeleteProjectConfirmationModal.js'
 import { CreateProjectModal } from './CreateProjectModal.js'
 import { DirectoryBrowser } from './shared/DirectoryBrowser.js'
+import { PermissionDeniedModal } from './PermissionDeniedModal.js'
 
 interface OpenProjectModalProps {
   isOpen: boolean
@@ -26,6 +27,7 @@ export function OpenProjectModal({ isOpen, onClose }: OpenProjectModalProps) {
   const deleteProject = useProjectStore(state => state.deleteProject)
   const [projectToDelete, setProjectToDelete] = useState<{ id: string; name: string } | null>(null)
   const [creatingPath, setCreatingPath] = useState<string | null>(null)
+  const [permissionDeniedPath, setPermissionDeniedPath] = useState<string | null>(null)
 
   const truncateMiddle = (path: string, maxLen = 32) => {
     if (path.length <= maxLen) return path
@@ -72,11 +74,14 @@ export function OpenProjectModal({ isOpen, onClose }: OpenProjectModalProps) {
     }
   }
 
-  const handleDirectorySelect = (path: string) => {
+  const handleDirectorySelect = async (path: string) => {
     const basename = path.split('/').filter(Boolean).pop() ?? ''
-    createProject(basename, path)
+    const result = await createProject(basename, path)
     listProjects()
     setCreatingPath(path)
+    if (result && typeof result === 'object' && 'error' in result && result.error && typeof result.error === 'object' && 'code' in result.error && result.error.code === 'EACCES') {
+      setPermissionDeniedPath((result.error as { path?: string }).path || path)
+    }
   }
 
   useEffect(() => {
@@ -167,6 +172,17 @@ export function OpenProjectModal({ isOpen, onClose }: OpenProjectModalProps) {
           initialPath={baseWorkdir ?? undefined}
           onSelect={(path) => { handleDirectorySelect(path); setShowBrowser(false) }}
           onClose={() => setShowBrowser(false)}
+        />
+      )}
+      {permissionDeniedPath && (
+        <PermissionDeniedModal
+          isOpen={true}
+          onClose={() => setPermissionDeniedPath(null)}
+          path={permissionDeniedPath}
+          onRetry={() => {
+            setPermissionDeniedPath(null)
+            handleDirectorySelect(permissionDeniedPath)
+          }}
         />
       )}
     </Modal>

--- a/web/src/components/PermissionDeniedModal.tsx
+++ b/web/src/components/PermissionDeniedModal.tsx
@@ -1,0 +1,85 @@
+import { useState, useCallback } from 'react'
+import { Modal } from './shared/SelfContainedModal'
+import { Button } from './shared/Button'
+import { authFetch } from '../lib/api'
+
+interface PermissionDeniedModalProps {
+  isOpen: boolean
+  onClose: () => void
+  path: string
+  onRetry: () => void
+}
+
+export function PermissionDeniedModal({ isOpen, onClose, path, onRetry }: PermissionDeniedModalProps) {
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleTakeOwnership = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await authFetch('/api/projects/fix-permissions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ path }),
+      })
+      const data = await res.json()
+      if (data.success) {
+        onRetry()
+        onClose()
+      } else if (!data.sudoAvailable) {
+        setError('Passwordless sudo is not available. Please fix permissions manually by running: sudo chown -R $USER "' + path + '"')
+      } else {
+        setError('Failed to fix permissions: ' + (data.error || 'Unknown error'))
+      }
+    } catch (err) {
+      setError('Failed to fix permissions: ' + (err instanceof Error ? err.message : 'Unknown error'))
+    } finally {
+      setLoading(false)
+    }
+  }, [path, onRetry, onClose])
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title="Permission Denied"
+      size="sm"
+    >
+      <div className="space-y-4">
+        <div className="text-sm text-text-secondary">
+          <p>
+            OpenFox does not have permission to create a project at:
+          </p>
+          <p className="mt-2 font-mono text-xs bg-bg-tertiary p-2 rounded break-all">{path}</p>
+        </div>
+
+        {error ? (
+          <div className="p-3 bg-accent-error/10 border border-accent-error/30 rounded text-sm text-accent-error">
+            {error}
+          </div>
+        ) : (
+          <div className="flex justify-end gap-2">
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={onClose}
+              disabled={loading}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              variant="primary"
+              onClick={handleTakeOwnership}
+              disabled={loading}
+              className="min-w-[140px]"
+            >
+              {loading ? 'Taking ownership...' : 'Take ownership'}
+            </Button>
+          </div>
+        )}
+      </div>
+    </Modal>
+  )
+}

--- a/web/src/components/plan/MoreMenu.tsx
+++ b/web/src/components/plan/MoreMenu.tsx
@@ -137,7 +137,7 @@ export function MoreMenu({
   const handleSelectCommand = async (commandId: string) => {
     const full = await useCommandsStore.getState().fetchCommand(commandId)
     if (full) {
-      onSendCommand(full.prompt, full.metadata.agentMode, textareaContent, attachments)
+      onSendCommand(full.prompt, full.metadata?.agentMode, textareaContent, attachments)
     }
     setIsOpen(false)
   }

--- a/web/src/components/plan/PlanPanel.tsx
+++ b/web/src/components/plan/PlanPanel.tsx
@@ -773,8 +773,8 @@ export function PlanPanel({ criteriaSidebarOpen: externalCriteriaSidebarOpen, on
             const combinedContent = textareaContent?.trim()
               ? `${textareaContent.trim()}\n\n${full.prompt}`
               : full.prompt
-            if (full.metadata.agentMode) {
-              useSessionStore.getState().switchMode(full.metadata.agentMode)
+            if (full.metadata?.agentMode) {
+              useSessionStore.getState().switchMode(full.metadata?.agentMode)
             }
             sendMessage(combinedContent, attachments?.length ? attachments : undefined, {
               messageKind: 'command',

--- a/web/src/stores/project.ts
+++ b/web/src/stores/project.ts
@@ -41,7 +41,13 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ name, workdir }),
       })
-      if (!res.ok) return null
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}))
+        if (data.code === 'EACCES') {
+          return { error: { code: 'EACCES', path: data.path, message: data.error } } as const
+        }
+        return null
+      }
       const data = await res.json()
       // Refresh project list
       await get().listProjects()


### PR DESCRIPTION
## What
Fixes `Cannot read properties of undefined (reading 'metadata')` crash.

## The bug
Two places access `.metadata.agentMode` on command objects without optional chaining.
If a command file doesn't have YAML frontmatter, `.metadata` is undefined and the app crashes when selecting that command.

## Fix
Added optional chaining: `full.metadata?.agentMode` in:
- `web/src/components/plan/MoreMenu.tsx:140`
- `web/src/components/plan/PlanPanel.tsx:776-777`

## Context
Triggered during the 'Take ownership' flow after a project permission denial, because the post-deny retry loads command references that may not have full frontmatter populated yet.