### PR TITLE
feat: permission denied dialog with group-aware fix options

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -217,8 +217,56 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
       return res.status(400).json({ error: 'name and workdir are required' })
     }
     const { createDirectoryWithGit } = await import('./utils/project-creator.js')
-    const project = await createDirectoryWithGit(name, workdir)
-    res.status(201).json({ project })
+    try {
+      const project = await createDirectoryWithGit(name, workdir)
+      res.status(201).json({ project })
+    } catch (err) {
+      const eaccError = err as Error & { code?: string; cause?: unknown }
+      return res.status(403).json({
+        error: eaccError.message || 'Unknown error',
+        code: eaccError.code || 'UNKNOWN',
+        path: workdir,
+      })
+    }
+  })
+
+  app.post('/api/projects/check-permissions', async (req, res) => {
+    const { path: targetPath } = req.body
+    if (!targetPath) {
+      return res.status(400).json({ error: 'path is required' })
+    }
+
+    const { checkPermissions } = await import('./utils/permissions.js')
+    const result = await checkPermissions(targetPath)
+
+    if (result.success) {
+      res.json(result)
+    } else {
+      const status = (result as { status?: number }).status ?? 500
+      res.status(status).json({ error: result.error })
+    }
+  })
+
+  app.post('/api/projects/fix-permissions', async (req, res) => {
+    const { path: targetPath, action } = req.body
+    if (!targetPath) {
+      return res.status(400).json({ error: 'path is required' })
+    }
+    if (!['group', 'ownership', 'join_group', 'join_group_and_group'].includes(action)) {
+      return res
+        .status(400)
+        .json({ error: 'action must be "group", "ownership", "join_group", or "join_group_and_group"' })
+    }
+
+    const { fixPermissions } = await import('./utils/permissions.js')
+    const result = await fixPermissions(targetPath, action)
+
+    if (result.success) {
+      res.json(result)
+    } else {
+      const status = (result as { status?: number }).status ?? 500
+      res.status(status).json(result)
+    }
   })
 
   app.get('/api/projects/:id', async (req, res) => {

--- a/src/server/utils/permissions.ts
+++ b/src/server/utils/permissions.ts
@@ -1,0 +1,129 @@
+import { execSync } from 'node:child_process'
+import { resolve } from 'node:path'
+import { access, stat } from 'node:fs/promises'
+import { constants } from 'node:fs'
+
+interface DirInfo {
+  resolvedPath: string
+  groupGid: number
+  groupName: string | null
+  userGroups: string[]
+  userInGroup: boolean
+  groupHasWrite: boolean
+  sudoAvailable: boolean
+}
+
+async function getDirInfo(targetPath: string): Promise<DirInfo> {
+  const resolvedPath = resolve(targetPath)
+
+  // Check if the path exists
+  try {
+    await access(resolvedPath, constants.F_OK)
+  } catch {
+    throw new Error('Path not found')
+  }
+
+  // Check if passwordless sudo is available
+  let sudoAvailable = false
+  try {
+    execSync('sudo -n true', { stdio: 'pipe' })
+    sudoAvailable = true
+  } catch {
+    sudoAvailable = false
+  }
+
+  // Get the directory's group and permissions
+  const dirStat = await stat(resolvedPath)
+  const groupGid = dirStat.gid
+
+  // Get current user's groups
+  const currentUser = execSync('id -un', { encoding: 'utf-8' }).trim()
+  const groupsOutput = execSync(`id -Gn ${currentUser}`, { encoding: 'utf-8' }).trim()
+  const userGroups = groupsOutput.split(/\s+/)
+
+  // Get the group name for the directory's gid
+  let groupName: string | null = null
+  try {
+    groupName = execSync(`getent group ${groupGid}`, { encoding: 'utf-8' }).split(':')[0]?.trim() || null
+  } catch {
+    // ignore
+  }
+
+  // Check if user is in the directory's group
+  const userInGroup = groupName ? userGroups.includes(groupName) : false
+
+  // Check group write permission (mode & 020)
+  const groupHasWrite = (dirStat.mode & 0o020) !== 0
+
+  return { resolvedPath, groupGid, groupName, userGroups, userInGroup, groupHasWrite, sudoAvailable }
+}
+
+export async function checkPermissions(targetPath: string) {
+  try {
+    const info = await getDirInfo(targetPath)
+    return {
+      success: true,
+      sudoAvailable: info.sudoAvailable,
+      userInGroup: info.userInGroup,
+      groupHasWrite: info.groupHasWrite,
+      groupName: info.groupName,
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error'
+    if (message === 'Path not found') {
+      return { success: false, error: message, status: 404 }
+    }
+    return { success: false, error: err instanceof Error ? err.message : 'Unknown error', status: 500 }
+  }
+}
+
+export async function fixPermissions(targetPath: string, action: string) {
+  try {
+    const info = await getDirInfo(targetPath)
+
+    if (action === 'group') {
+      if (!info.userInGroup) {
+        return {
+          success: false,
+          sudoAvailable: info.sudoAvailable,
+          error:
+            'You are not in the group that owns this directory. Use "Join group & extend group permissions" instead.',
+        }
+      }
+      execSync(`sudo chmod g+w "${info.resolvedPath}"`, { stdio: 'pipe' })
+      return { success: true, sudoAvailable: info.sudoAvailable, method: 'group' }
+    }
+
+    if (action === 'join_group') {
+      if (!info.groupName) {
+        return { success: false, sudoAvailable: info.sudoAvailable, error: 'Could not determine group name' }
+      }
+      const currentUser = execSync('id -un', { encoding: 'utf-8' }).trim()
+      execSync(`sudo usermod -aG ${info.groupName} ${currentUser}`, { stdio: 'pipe' })
+      return { success: true, sudoAvailable: info.sudoAvailable, method: 'join_group' }
+    }
+
+    if (action === 'join_group_and_group') {
+      if (!info.groupName) {
+        return { success: false, sudoAvailable: info.sudoAvailable, error: 'Could not determine group name' }
+      }
+      // chmod first (runs as root, doesn't need group membership)
+      execSync(`sudo chmod g+w "${info.resolvedPath}"`, { stdio: 'pipe' })
+      // Then add user to group for future sessions
+      const currentUser = execSync('id -un', { encoding: 'utf-8' }).trim()
+      execSync(`sudo usermod -aG ${info.groupName} ${currentUser}`, { stdio: 'pipe' })
+      return { success: true, sudoAvailable: info.sudoAvailable, method: 'join_group_and_group' }
+    }
+
+    // ownership action
+    const ownerUser = execSync('id -un', { encoding: 'utf-8' }).trim()
+    execSync(`sudo chown -R ${ownerUser} "${info.resolvedPath}"`, { stdio: 'pipe' })
+    return { success: true, sudoAvailable: info.sudoAvailable, method: 'ownership' }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error'
+    if (message === 'Path not found') {
+      return { success: false, sudoAvailable: true, error: message, status: 404 }
+    }
+    return { success: false, sudoAvailable: true, error: message }
+  }
+}

--- a/src/server/utils/project-creator.ts
+++ b/src/server/utils/project-creator.ts
@@ -37,24 +37,79 @@ export async function createDirectoryWithGit(projectName: string, workdir: strin
   }
 
   const fullPath = workdir.replace(/\/+$/, '')
-  const { stat, mkdir } = await import('node:fs/promises')
+  const { stat, mkdir, rm, access, constants } = await import('node:fs/promises')
+
+  const dirAlreadyExisted = await access(fullPath, constants.F_OK)
+    .then(() => true)
+    .catch(() => false)
 
   try {
     const stats = await stat(fullPath)
     if (!stats.isDirectory()) {
       throw new Error(`A file named '${projectName}' already exists at ${fullPath}`)
     }
-  } catch {
-    await mkdir(fullPath, { recursive: true })
+  } catch (err) {
+    if (err instanceof Error && 'code' in err && err.code === 'ENOENT') {
+      try {
+        await mkdir(fullPath, { recursive: true })
+      } catch (mkdirErr) {
+        if (mkdirErr instanceof Error && 'code' in mkdirErr && mkdirErr.code === 'EACCES') {
+          const eaccError = mkdirErr as NodeJS.ErrnoException
+          const permError = new Error(`Permission denied: cannot create directory at ${fullPath}`, {
+            cause: eaccError,
+          }) as Error & { code?: string }
+          permError.code = 'EACCES'
+          throw permError
+        }
+        throw mkdirErr
+      }
+    } else if (err instanceof Error && 'code' in err && err.code === 'EACCES') {
+      const eaccError = err as NodeJS.ErrnoException
+      const permError = new Error(`Permission denied: cannot access directory at ${fullPath}`, {
+        cause: eaccError,
+      }) as Error & { code?: string }
+      permError.code = 'EACCES'
+      throw permError
+    } else {
+      throw err
+    }
   }
 
   if (!(await directoryExists(join(fullPath, '.git')))) {
     try {
       execSync('git init', { cwd: fullPath, stdio: 'pipe' })
     } catch (gitErr) {
-      const { rm } = await import('node:fs/promises')
-      await rm(fullPath, { recursive: true, force: true })
-      throw new Error(`Failed to initialize git: ${gitErr instanceof Error ? gitErr.message : 'Unknown'}`)
+      const errMsg = gitErr instanceof Error ? gitErr.message : 'Unknown'
+      const exitCode = (gitErr as { status?: number }).status ?? (gitErr as { exitCode?: number }).exitCode
+      const isPermission = errMsg.includes('Permission denied') || exitCode === 128
+
+      // Try via sudo -u $USER if permission denied (process may not have correct groups)
+      let sudoSuccess = false
+      if (isPermission) {
+        try {
+          const currentUser = execSync('id -un', { encoding: 'utf-8' }).trim()
+          execSync(`sudo -u ${currentUser} git init`, { cwd: fullPath, stdio: 'pipe' })
+          sudoSuccess = true
+        } catch {
+          // sudo also failed, fall through to error
+        }
+      }
+
+      if (!sudoSuccess) {
+        const permError = new Error(`Failed to initialize git: ${errMsg}`) as Error & { code?: string }
+        if (isPermission) {
+          permError.code = 'EACCES'
+        }
+        // Only clean up if we created this directory ourselves
+        if (!dirAlreadyExisted) {
+          try {
+            await rm(fullPath, { recursive: true, force: true })
+          } catch {
+            // ignore cleanup errors
+          }
+        }
+        throw permError
+      }
     }
   }
 

--- a/web/src/components/CreateProjectModal.tsx
+++ b/web/src/components/CreateProjectModal.tsx
@@ -6,6 +6,7 @@ import { Input } from './shared/Input'
 import { authFetch } from '../lib/api'
 import { validateProjectName } from './shared/validation'
 import { PlusMdIcon } from './shared/icons'
+import { PermissionDeniedModal } from './PermissionDeniedModal'
 
 interface CreateProjectModalProps {
   isOpen: boolean
@@ -18,6 +19,7 @@ export function CreateProjectModal({ isOpen, onClose }: CreateProjectModalProps)
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
   const [workdir, setWorkdir] = useState<string>('')
+  const [permissionDeniedPath, setPermissionDeniedPath] = useState<string | null>(null)
   const inputRef = useRef<HTMLInputElement>(null)
 
   // Fetch workdir from config when modal opens
@@ -33,6 +35,7 @@ export function CreateProjectModal({ isOpen, onClose }: CreateProjectModalProps)
       setProjectName('')
       setError(null)
       setLoading(false)
+      setPermissionDeniedPath(null)
       // Focus the input after modal renders
       setTimeout(() => {
         inputRef.current?.focus()
@@ -66,6 +69,10 @@ export function CreateProjectModal({ isOpen, onClose }: CreateProjectModalProps)
 
         if (!response.ok) {
           const errorData = await response.json().catch(() => ({}))
+          if (errorData.code === 'EACCES') {
+            setPermissionDeniedPath(fullPath)
+            return
+          }
           throw new Error(errorData.error || 'Failed to create project')
         }
 
@@ -84,6 +91,45 @@ export function CreateProjectModal({ isOpen, onClose }: CreateProjectModalProps)
     [projectName, navigate, onClose, workdir],
   )
 
+  const handlePermissionDeniedClose = useCallback(() => {
+    setPermissionDeniedPath(null)
+  }, [])
+
+  const handleRetry = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    setPermissionDeniedPath(null)
+
+    const fullPath = `${workdir}/${projectName}`
+
+    try {
+      const response = await authFetch('/api/projects', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: projectName, workdir: fullPath }),
+      })
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}))
+        if (errorData.code === 'EACCES') {
+          setPermissionDeniedPath(fullPath)
+          setLoading(false)
+          return
+        }
+        throw new Error(errorData.error || 'Failed to create project')
+      }
+
+      const data = await response.json()
+      const project = data.project
+
+      onClose()
+      navigate(`/p/${project.id}`)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create project')
+      setLoading(false)
+    }
+  }, [projectName, workdir, navigate, onClose])
+
   const handleCancel = useCallback(() => {
     setProjectName('')
     setError(null)
@@ -93,64 +139,75 @@ export function CreateProjectModal({ isOpen, onClose }: CreateProjectModalProps)
   const fullPath = projectName ? `${workdir}/${projectName}` : ''
 
   return (
-    <Modal isOpen={isOpen} onClose={handleCancel} title="Create New Project" size="sm">
-      <form onSubmit={handleSubmit} className="space-y-4">
-        <div>
-          <label htmlFor="project-name" className="block text-sm font-medium text-text-secondary mb-2">
-            Project Name
-          </label>
-          <Input
-            ref={inputRef}
-            id="project-name"
-            value={projectName}
-            onChange={(e) => {
-              setProjectName(e.target.value)
-              setError(null)
-            }}
-            placeholder="my-project"
-            disabled={loading}
-            data-testid="create-project-name-input"
-            className="w-full"
-          />
+    <>
+      <Modal isOpen={isOpen} onClose={handleCancel} title="Create New Project" size="sm">
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label htmlFor="project-name" className="block text-sm font-medium text-text-secondary mb-2">
+              Project Name
+            </label>
+            <Input
+              ref={inputRef}
+              id="project-name"
+              value={projectName}
+              onChange={(e) => {
+                setProjectName(e.target.value)
+                setError(null)
+              }}
+              placeholder="my-project"
+              disabled={loading}
+              data-testid="create-project-name-input"
+              className="w-full"
+            />
 
-          {/* Path preview */}
-          {projectName && (
-            <div className="mt-2 text-xs text-text-muted">
-              Full path: <span className="font-mono">{fullPath}</span>
-            </div>
-          )}
-
-          {/* Error message */}
-          {error && (
-            <div className="mt-3 p-3 bg-accent-error/10 border border-accent-error/30 rounded text-sm text-accent-error">
-              {error}
-            </div>
-          )}
-        </div>
-
-        {/* Actions */}
-        <div className="flex justify-end gap-2">
-          <Button type="button" variant="secondary" onClick={handleCancel} disabled={loading}>
-            Cancel
-          </Button>
-          <Button
-            type="submit"
-            variant="primary"
-            disabled={loading || !projectName.trim()}
-            data-testid="create-project-submit-button"
-            className="min-w-[100px]"
-          >
-            {loading ? (
-              <span className="flex items-center gap-2">
-                <PlusMdIcon className="h-4 w-4" />
-                Creating...
-              </span>
-            ) : (
-              'Create'
+            {/* Path preview */}
+            {projectName && (
+              <div className="mt-2 text-xs text-text-muted">
+                Full path: <span className="font-mono">{fullPath}</span>
+              </div>
             )}
-          </Button>
-        </div>
-      </form>
-    </Modal>
+
+            {/* Error message */}
+            {error && (
+              <div className="mt-3 p-3 bg-accent-error/10 border border-accent-error/30 rounded text-sm text-accent-error">
+                {error}
+              </div>
+            )}
+          </div>
+
+          {/* Actions */}
+          <div className="flex justify-end gap-2">
+            <Button type="button" variant="secondary" onClick={handleCancel} disabled={loading}>
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              variant="primary"
+              disabled={loading || !projectName.trim()}
+              data-testid="create-project-submit-button"
+              className="min-w-[100px]"
+            >
+              {loading ? (
+                <span className="flex items-center gap-2">
+                  <PlusMdIcon className="h-4 w-4" />
+                  Creating...
+                </span>
+              ) : (
+                'Create'
+              )}
+            </Button>
+          </div>
+        </form>
+      </Modal>
+
+      {permissionDeniedPath && (
+        <PermissionDeniedModal
+          isOpen={!!permissionDeniedPath}
+          onClose={handlePermissionDeniedClose}
+          path={permissionDeniedPath}
+          onRetry={handleRetry}
+        />
+      )}
+    </>
   )
 }

--- a/web/src/components/CreateSessionModal.tsx
+++ b/web/src/components/CreateSessionModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { useLocation } from 'wouter'
 import { useProjectStore } from '../stores/project'
 import { Modal } from './shared/Modal'
@@ -8,6 +8,7 @@ import { authFetch } from '../lib/api'
 import { DeleteProjectConfirmationModal } from './DeleteProjectConfirmationModal.js'
 import { CreateProjectModal } from './CreateProjectModal.js'
 import { DirectoryBrowser } from './shared/DirectoryBrowser.js'
+import { PermissionDeniedModal } from './PermissionDeniedModal.js'
 
 interface OpenProjectModalProps {
   isOpen: boolean
@@ -26,6 +27,7 @@ export function OpenProjectModal({ isOpen, onClose }: OpenProjectModalProps) {
   const deleteProject = useProjectStore((state) => state.deleteProject)
   const [projectToDelete, setProjectToDelete] = useState<{ id: string; name: string } | null>(null)
   const [creatingPath, setCreatingPath] = useState<string | null>(null)
+  const [permissionDeniedPath, setPermissionDeniedPath] = useState<string | null>(null)
 
   const truncateMiddle = (path: string, maxLen = 32) => {
     if (path.length <= maxLen) return path
@@ -72,12 +74,50 @@ export function OpenProjectModal({ isOpen, onClose }: OpenProjectModalProps) {
     }
   }
 
-  const handleDirectorySelect = (path: string) => {
+  const handleDirectorySelect = async (path: string): Promise<boolean> => {
     const basename = path.split('/').filter(Boolean).pop() ?? ''
-    createProject(basename, path)
+    const result = await createProject(basename, path)
     listProjects()
     setCreatingPath(path)
+    if (
+      result &&
+      typeof result === 'object' &&
+      'error' in result &&
+      result.error &&
+      typeof result.error === 'object' &&
+      'code' in result.error &&
+      result.error.code === 'EACCES'
+    ) {
+      setPermissionDeniedPath((result.error as { path?: string }).path || path)
+      return false
+    }
+    return true
   }
+
+  const handlePermissionDeniedClose = useCallback(() => {
+    setPermissionDeniedPath(null)
+  }, [])
+
+  const handleRetry = useCallback(async () => {
+    setPermissionDeniedPath(null)
+    if (creatingPath) {
+      const basename = creatingPath.split('/').filter(Boolean).pop() ?? ''
+      const result = await createProject(basename, creatingPath)
+      listProjects()
+      setCreatingPath(creatingPath)
+      if (
+        result &&
+        typeof result === 'object' &&
+        'error' in result &&
+        result.error &&
+        typeof result.error === 'object' &&
+        'code' in result.error &&
+        result.error.code === 'EACCES'
+      ) {
+        setPermissionDeniedPath((result.error as { path?: string }).path || creatingPath)
+      }
+    }
+  }, [creatingPath, createProject, listProjects])
 
   useEffect(() => {
     if (creatingPath) {
@@ -177,10 +217,19 @@ export function OpenProjectModal({ isOpen, onClose }: OpenProjectModalProps) {
         <DirectoryBrowser
           initialPath={baseWorkdir ?? undefined}
           onSelect={(path) => {
-            handleDirectorySelect(path)
-            setShowBrowser(false)
+            handleDirectorySelect(path).then((success) => {
+              if (success) setShowBrowser(false)
+            })
           }}
           onClose={() => setShowBrowser(false)}
+        />
+      )}
+      {permissionDeniedPath && (
+        <PermissionDeniedModal
+          isOpen={true}
+          onClose={handlePermissionDeniedClose}
+          path={permissionDeniedPath}
+          onRetry={handleRetry}
         />
       )}
     </Modal>

--- a/web/src/components/PermissionDeniedModal.tsx
+++ b/web/src/components/PermissionDeniedModal.tsx
@@ -1,0 +1,187 @@
+import { useState, useCallback, useEffect } from 'react'
+import { Modal } from './shared/SelfContainedModal'
+import { Button } from './shared/Button'
+import { authFetch } from '../lib/api'
+
+interface PermissionDeniedModalProps {
+  isOpen: boolean
+  onClose: () => void
+  path: string
+  onRetry: () => void
+}
+
+interface PermissionOptions {
+  sudoAvailable: boolean
+  userInGroup: boolean
+  groupHasWrite: boolean
+  groupName: string | null
+}
+
+export function PermissionDeniedModal({ isOpen, onClose, path, onRetry }: PermissionDeniedModalProps) {
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [options, setOptions] = useState<PermissionOptions | null>(null)
+
+  useEffect(() => {
+    if (isOpen) {
+      checkPermissionOptions()
+    }
+  }, [isOpen])
+
+  const checkPermissionOptions = async () => {
+    try {
+      const res = await authFetch('/api/projects/check-permissions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ path }),
+      })
+      const data = await res.json()
+      setOptions({
+        sudoAvailable: data.sudoAvailable,
+        userInGroup: data.userInGroup,
+        groupHasWrite: data.groupHasWrite,
+        groupName: data.groupName || null,
+      })
+    } catch {
+      setOptions({ sudoAvailable: false, userInGroup: false, groupHasWrite: false, groupName: null })
+    }
+  }
+
+  const handleFixPermissions = useCallback(
+    async (action: 'group' | 'join_group' | 'join_group_and_group') => {
+      setLoading(true)
+      setError(null)
+      try {
+        const res = await authFetch('/api/projects/fix-permissions', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ path, action }),
+        })
+        const data = await res.json()
+        if (data.success) {
+          onRetry()
+          onClose()
+        } else if (!data.sudoAvailable) {
+          setError(
+            'Passwordless sudo is not available. Please fix permissions manually:\n\n' +
+              (action === 'group' ? `sudo chmod g+w "${path}"` : `sudo usermod -aG <group> $USER`),
+          )
+        } else {
+          setError('Failed to fix permissions: ' + (data.error || 'Unknown error'))
+        }
+      } catch (err) {
+        setError('Failed to fix permissions: ' + (err instanceof Error ? err.message : 'Unknown error'))
+      } finally {
+        setLoading(false)
+      }
+    },
+    [path, onRetry, onClose],
+  )
+
+  const userInGroup = options?.userInGroup ?? false
+  const groupHasWrite = options?.groupHasWrite ?? false
+  const sudoAvailable = options?.sudoAvailable ?? false
+  const groupName = options?.groupName ?? ''
+
+  const showExtendGroup = userInGroup && !groupHasWrite
+  const showJoinGroup = !userInGroup && groupHasWrite
+  const showJoinGroupAndExtend = !userInGroup && !groupHasWrite
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Permission Denied" size="sm">
+      <div className="space-y-4">
+        <div className="text-sm text-text-secondary">
+          <p>
+            {showExtendGroup ? (
+              <>
+                The group <strong>{groupName}</strong> doesn't have write access:
+              </>
+            ) : showJoinGroup ? (
+              <>
+                You're not a member of group <strong>{groupName}</strong>:
+              </>
+            ) : (
+              <>
+                You're not a member of group <strong>{groupName}</strong> and it doesn't have write access:
+              </>
+            )}
+          </p>
+          <p className="mt-2 font-mono text-xs bg-bg-tertiary p-2 rounded break-all">{path}</p>
+        </div>
+
+        {error ? (
+          <div className="p-3 bg-accent-error/10 border border-accent-error/30 rounded text-sm text-accent-error whitespace-pre-wrap">
+            {error}
+          </div>
+        ) : options ? (
+          <div className="flex flex-col gap-2">
+            {showExtendGroup && (
+              <>
+                <Button
+                  type="button"
+                  variant="primary"
+                  onClick={() => handleFixPermissions('group')}
+                  disabled={loading || !sudoAvailable}
+                  className="w-full"
+                >
+                  {loading ? 'Granting access...' : 'Extend group permissions'}
+                </Button>
+                <div className="text-xs text-text-secondary">Or manually execute:</div>
+                <code className="text-xs text-text-muted p-2 bg-bg-tertiary rounded break-all">
+                  sudo chmod g+w "{path}"
+                </code>
+              </>
+            )}
+            {showJoinGroup && (
+              <>
+                <Button
+                  type="button"
+                  variant="primary"
+                  onClick={() => handleFixPermissions('join_group')}
+                  disabled={loading || !sudoAvailable}
+                  className="w-full"
+                >
+                  {loading ? 'Joining group...' : 'Join group'}
+                </Button>
+                <div className="text-xs text-text-secondary">Or manually execute:</div>
+                <code className="text-xs text-text-muted p-2 bg-bg-tertiary rounded break-all">
+                  sudo usermod -aG {groupName} $USER
+                </code>
+              </>
+            )}
+            {showJoinGroupAndExtend && (
+              <>
+                <Button
+                  type="button"
+                  variant="primary"
+                  onClick={() => handleFixPermissions('join_group_and_group')}
+                  disabled={loading || !sudoAvailable}
+                  className="w-full"
+                >
+                  {loading ? 'Joining group...' : 'Join group & grant write permissions'}
+                </Button>
+                <div className="text-xs text-text-secondary">Or manually execute:</div>
+                <code className="text-xs text-text-muted p-2 bg-bg-tertiary rounded break-all">
+                  sudo usermod -aG {groupName} $USER
+                  <br />
+                  sudo chmod g+w "{path}"
+                </code>
+              </>
+            )}
+            {!sudoAvailable && !error && (
+              <div className="text-xs text-text-secondary">
+                <p>Passwordless sudo is not available. Please fix permissions manually:</p>
+                <code className="block mt-1 p-2 bg-bg-tertiary rounded break-all">sudo chmod g+w "{path}"</code>
+              </div>
+            )}
+            <div className="flex justify-end">
+              <Button type="button" variant="secondary" onClick={onClose} disabled={loading}>
+                Cancel
+              </Button>
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </Modal>
+  )
+}

--- a/web/src/stores/project.ts
+++ b/web/src/stores/project.ts
@@ -44,7 +44,10 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ name, workdir }),
       })
-      if (!res.ok) return null
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}))
+        return { error: { code: data.code || 'UNKNOWN', path: data.path, message: data.error } } as const
+      }
       const data = await res.json()
       // Refresh project list
       await get().listProjects()


### PR DESCRIPTION
## Summary

- Extract permission helpers (checkPermissions, fixPermissions) into permissions.ts
- Add PermissionDeniedModal with group-aware fix options
- Update project creation to handle permission errors and show dialog
- Add /api/projects/check-permissions and /api/projects/fix-permissions endpoints
- Add /api/projects/check-path-permissions endpoint for directory selection