### PR TITLE
fix: prevent server crash from SQLite FK constraint during session consolidation

### DIFF
--- a/src/server/events/store.ts
+++ b/src/server/events/store.ts
@@ -641,6 +641,13 @@ export class EventStore {
       return transaction()
     } catch (error) {
       const err = error instanceof Error ? error : new Error(String(error))
+      // FK errors mean the session was deleted - nothing to consolidate
+      const errnoError = error as NodeJS.ErrnoException
+      const isFkError = errnoError.code === 'SQLITE_CONSTRAINT_FOREIGNKEY'
+      if (isFkError || err.message.includes('FOREIGN KEY constraint failed')) {
+        logger.debug('Session no longer exists during consolidation', { sessionId })
+        return null
+      }
       logger.error('Failed to consolidate session', { sessionId, error: err.message, stack: err.stack })
       return null
     }

--- a/src/server/queue/processor.ts
+++ b/src/server/queue/processor.ts
@@ -229,20 +229,24 @@ export class QueueProcessor {
       .finally(() => {
         this.activeAgents.delete(sessionId)
 
-        const session = this.deps.sessionManager.getSession(sessionId)
-        if (!session) {
-          this.deps.sessionManager.setRunning(sessionId, false)
-          this.deps.broadcastForSession(sessionId, createSessionRunningMessage(false))
-          return
-        }
+        try {
+          const session = this.deps.sessionManager.getSession(sessionId)
+          if (!session) {
+            this.deps.sessionManager.setRunning(sessionId, false)
+            this.deps.broadcastForSession(sessionId, createSessionRunningMessage(false))
+            return
+          }
 
-        const hasMore = sessionManager.hasQueuedMessages(sessionId)
-        if (!hasMore) {
-          finalizeTurnCompletion(sessionId, sessionManager, broadcastForSession)
-          return
-        }
+          const hasMore = sessionManager.hasQueuedMessages(sessionId)
+          if (!hasMore) {
+            finalizeTurnCompletion(sessionId, sessionManager, broadcastForSession)
+            return
+          }
 
-        this.startTurn(sessionId)
+          this.startTurn(sessionId)
+        } catch (error) {
+          logger.error('Error in turn completion cleanup', { sessionId, error: error instanceof Error ? error.message : String(error) })
+        }
       })
   }
 

--- a/src/server/session/chat-handler.ts
+++ b/src/server/session/chat-handler.ts
@@ -127,8 +127,12 @@ export async function startChatSession(
     if (activeAgents.get(sessionId) === controller) {
       activeAgents.delete(sessionId)
     }
-    sessionManager.setRunning(sessionId, false)
-    broadcastForSession(sessionId, createSessionRunningMessage(false))
+    try {
+      sessionManager.setRunning(sessionId, false)
+      broadcastForSession(sessionId, createSessionRunningMessage(false))
+    } catch {
+      // Session may have been deleted or invalidated
+    }
     finalizeTurnCompletion(sessionId, sessionManager, broadcastForSession)
     throw error
   }


### PR DESCRIPTION
## Problem

The server crashed with an uncaught `SessionNotFoundError` when a session was deleted during an active compaction cycle.

### Error chain

1. Auto-compaction failed with `SQLITE_CONSTRAINT_FOREIGNKEY` during `consolidateSession()`
2. The error propagated through `runChatTurn()` → `QueueProcessor.runTurn().finally()`
3. In `finally()`, `setRunning()` called `requireSession()` which threw `SessionNotFoundError`
4. This uncaught exception crashed the server

### Original error
`
[ERROR] Auto-compaction failed, continuing without compaction {"sessionId":"...","error":"FOREIGN KEY constraint failed","currentTokens":225526,"maxTokens":262144} [ERROR] Chat turn error {"sessionId":"...","mode":"builder","error":{"code":"SQLITE_CONSTRAINT_FOREIGNKEY"}} [ERROR] QueueProcessor turn error {"sessionId":"...","error":{"code":"SQLITE_CONSTRAINT_FOREIGNKEY"}} SessionNotFoundError: Session not found: ... at SessionManager.requireSession at SessionManager.setRunning at processor.ts:198:34
`

### Root cause

This happened when deleting a session during an active compaction. The `consolidateSession()` method tries to insert a snapshot event into the events table, which has a foreign key reference to `sessions(id)`. If the session was deleted between the FK check and the insert, the constraint fails.

### Fix

- **`store.ts`**: FK errors during `consolidateSession()` now return `null` silently instead of throwing
- **`processor.ts`**: Cleanup in `finally()` wrapped in try/catch to handle deleted sessions gracefully
- **`chat-handler.ts`**: `setRunning()` in error handler wrapped in try/catch to handle deleted sessions gracefully