### PR TITLE
feat: add conversation history to the sidebar

### DIFF
--- a/web/src/components/layout/SessionLayout.tsx
+++ b/web/src/components/layout/SessionLayout.tsx
@@ -2,12 +2,16 @@ import type { ReactNode } from 'react'
 import { useSessionStore } from '../../stores/session'
 import { SummaryDisplay } from '../plan/SummaryDisplay'
 import type { Message } from '@shared/types.js'
+import type { DisplayItem } from '../plan/groupMessages'
 
 interface SessionLayoutProps {
   children: ReactNode
   criteriaSidebarOpen?: boolean
   onCriteriaSidebarToggle?: () => void
   messages: Message[]
+  displayItems?: DisplayItem[]
+  activeIndex?: number
+  onNavigate?: (index: number) => void
 }
 
 export function SessionLayout({
@@ -15,6 +19,9 @@ export function SessionLayout({
   criteriaSidebarOpen = true,
   onCriteriaSidebarToggle,
   messages,
+  displayItems,
+  activeIndex,
+  onNavigate,
 }: SessionLayoutProps) {
   const session = useSessionStore((state) => state.currentSession)
 
@@ -32,7 +39,14 @@ export function SessionLayout({
         {/* Summary Sidebar - mobile: fixed overlay, desktop: flex item */}
         {criteriaSidebarOpen ? (
           <aside className="hidden md:block w-[320px] shrink-0 border-l border-border p-4 overflow-y-auto bg-secondary">
-            <SummaryDisplay summary={session?.summary ?? null} messages={messages} workdir={session?.workdir} />
+            <SummaryDisplay
+              summary={session?.summary ?? null}
+              messages={messages}
+              workdir={session?.workdir}
+              displayItems={displayItems}
+              activeIndex={activeIndex}
+              onNavigate={onNavigate}
+            />
           </aside>
         ) : (
           <aside className="hidden md:block w-0 shrink-0 overflow-hidden border-l-0" />
@@ -48,7 +62,14 @@ export function SessionLayout({
             ${criteriaSidebarOpen ? 'w-[320px] translate-x-0 border-l border-border' : 'w-[320px] translate-x-full'}
           `}
         >
-          <SummaryDisplay summary={session?.summary ?? null} messages={messages} workdir={session?.workdir} />
+          <SummaryDisplay
+            summary={session?.summary ?? null}
+            messages={messages}
+            workdir={session?.workdir}
+            displayItems={displayItems}
+            activeIndex={activeIndex}
+            onNavigate={onNavigate}
+          />
         </aside>
       </div>
     </div>

--- a/web/src/components/plan/ConversationIndex.tsx
+++ b/web/src/components/plan/ConversationIndex.tsx
@@ -63,11 +63,6 @@ export function ConversationIndex({ displayItems, activeIndex, onNavigate }: Con
 
         // Skip if element or container has no valid dimensions
         if (elementRect.height === 0 || containerRect.height === 0) {
-          console.log('[ConversationIndex] Skipping scroll - invalid dimensions:', {
-            index,
-            elementHeight: elementRect.height,
-            containerHeight: containerRect.height,
-          })
           return
         }
 
@@ -84,16 +79,6 @@ export function ConversationIndex({ displayItems, activeIndex, onNavigate }: Con
         const maxScroll = container.scrollHeight - containerHeight
         const clampedScrollTop = Math.max(0, Math.min(targetScrollTop, maxScroll))
 
-        console.log('[ConversationIndex] scrollToIndex:', {
-          index,
-          behavior,
-          elementTopInContainer,
-          elementHeight,
-          containerHeight,
-          targetScrollTop,
-          maxScroll,
-          clampedScrollTop,
-        })
         container.scrollTo({ top: clampedScrollTop, behavior })
       }
     },

--- a/web/src/components/plan/ConversationIndex.tsx
+++ b/web/src/components/plan/ConversationIndex.tsx
@@ -1,0 +1,544 @@
+import { memo, useRef, useCallback, useEffect } from 'react'
+import type { DisplayItem } from './groupMessages'
+
+interface ConversationIndexProps {
+  displayItems: DisplayItem[]
+  activeIndex?: number
+  onNavigate?: (index: number) => void
+}
+
+// Format timestamp to relative time string
+function formatTime(timestamp: string): string {
+  const now = Date.now()
+  const then = new Date(timestamp).getTime()
+  const diffMs = now - then
+  const diffHours = diffMs / (1000 * 60 * 60)
+  const diffDays = diffHours / 24
+
+  if (diffHours < 24) {
+    // Less than 24 hours: show time
+    const date = new Date(timestamp)
+    return date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit', hour12: false })
+  } else if (diffDays < 5) {
+    // 1-5 days: show hours/days ago
+    if (diffHours < 48) {
+      return `${Math.floor(diffHours)}h ago`
+    }
+    return `${Math.floor(diffDays)}d ago`
+  } else {
+    // 5+ days: show date
+    const date = new Date(timestamp)
+    return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+  }
+}
+
+export function ConversationIndex({ displayItems, activeIndex, onNavigate }: ConversationIndexProps) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const itemRefs = useRef<Map<number, HTMLDivElement>>(new Map())
+
+  // Track if user is interacting with the index to prevent auto-scroll conflicts
+  const isUserInteractingRef = useRef(false)
+
+  const scrollToIndex = useCallback(
+    (index: number, behavior: 'smooth' | 'auto' = 'auto') => {
+      // Skip if user is actively interacting
+      if (isUserInteractingRef.current) return
+
+      let element = itemRefs.current.get(index)
+      const container = containerRef.current
+
+      // If element not found (skipped item), try to find the next rendered item
+      if (!element && container) {
+        for (let i = index + 1; i < displayItems.length; i++) {
+          element = itemRefs.current.get(i)
+          if (element) break
+        }
+      }
+
+      if (element && container) {
+        // Calculate element position relative to the container
+        // Use getBoundingClientRect for accurate viewport positions
+        const elementRect = element.getBoundingClientRect()
+        const containerRect = container.getBoundingClientRect()
+
+        // Skip if element or container has no valid dimensions
+        if (elementRect.height === 0 || containerRect.height === 0) {
+          console.log('[ConversationIndex] Skipping scroll - invalid dimensions:', {
+            index,
+            elementHeight: elementRect.height,
+            containerHeight: containerRect.height,
+          })
+          return
+        }
+
+        // Element position within the container (accounting for current scroll)
+        const elementTopInContainer = elementRect.top - containerRect.top + container.scrollTop
+
+        const elementHeight = element.clientHeight
+        const containerHeight = container.clientHeight
+
+        // Calculate target scroll position to center the element
+        const targetScrollTop = elementTopInContainer - containerHeight / 2 + elementHeight / 2
+
+        // Clamp to valid range [0, maxScroll]
+        const maxScroll = container.scrollHeight - containerHeight
+        const clampedScrollTop = Math.max(0, Math.min(targetScrollTop, maxScroll))
+
+        console.log('[ConversationIndex] scrollToIndex:', {
+          index,
+          behavior,
+          elementTopInContainer,
+          elementHeight,
+          containerHeight,
+          targetScrollTop,
+          maxScroll,
+          clampedScrollTop,
+        })
+        container.scrollTo({ top: clampedScrollTop, behavior })
+      }
+    },
+    [displayItems.length],
+  )
+
+  const handleScrollToIndex = useCallback(
+    (index: number) => {
+      if (index >= 0 && index < displayItems.length) {
+        // Set lock to prevent auto-scroll feedback
+        isUserInteractingRef.current = true
+
+        // Notify parent to scroll the main chat to this item
+        onNavigate?.(index)
+
+        // After scroll animation completes, re-trigger activeIndex to ensure correct highlight
+        // This fixes mobile where the highlight may be off by 1-2 items during/after scroll
+        setTimeout(() => {
+          isUserInteractingRef.current = false
+          // Force a re-evaluation of the active index by triggering a scroll event
+          // This allows the chat's scroll handler to recalculate the closest item
+          const container = document.querySelector('[data-scroll-container]') as HTMLElement
+          if (container) {
+            container.dispatchEvent(new Event('scroll'))
+          }
+        }, 600)
+      }
+    },
+    [onNavigate],
+  )
+
+  // Auto-scroll conversation index when user clicks an item (not when chat scrolls)
+  const prevActiveIndexRef = useRef<number | undefined>(undefined)
+  const lastScrollTimeRef = useRef<number>(0)
+  const scrollDebounceMs = 150 // Debounce scroll updates for smoother mobile experience
+  const isScrollingRef = useRef(false) // Track if a scroll animation is in progress
+
+  useEffect(() => {
+    if (activeIndex === undefined || activeIndex < 0 || activeIndex >= displayItems.length) {
+      return
+    }
+
+    // Only auto-scroll if this is a new click interaction (not from chat scrolling)
+    // If the index was already scrolled by user, don't force it back
+    if (isUserInteractingRef.current) {
+      // User is actively interacting - let them scroll freely
+      return
+    }
+
+    // Skip if a scroll animation is already in progress
+    if (isScrollingRef.current) {
+      return
+    }
+
+    const element = itemRefs.current.get(activeIndex)
+    const container = containerRef.current
+
+    if (element && container) {
+      const containerHeight = container.clientHeight
+      const containerTop = container.getBoundingClientRect().top
+
+      // Calculate element's position relative to the viewport
+      const elementTop = element.getBoundingClientRect().top
+      const elementBottom = elementTop + element.clientHeight
+
+      // Check if element is already visible within the container
+      const containerTopInViewport = containerTop
+      const containerBottomInViewport = containerTop + containerHeight
+
+      // Element is visible if it's within the container bounds (with buffer)
+      const isVisible = elementTop >= containerTopInViewport - 50 && elementBottom <= containerBottomInViewport + 50
+
+      // Check if element is getting close to the container edges (within 30px)
+      // This triggers scroll BEFORE the element leaves the container
+      const distanceFromTop = elementTop - containerTopInViewport
+      const distanceFromBottom = containerBottomInViewport - elementBottom
+      const isNearEdge = distanceFromTop < 30 || distanceFromBottom < 30
+
+      // Only scroll if element is getting near the edge AND this is a new item (not just chat scrolling)
+      const isNewItem = prevActiveIndexRef.current !== activeIndex
+
+      // Debounce scroll updates to prevent rapid-fire scrolling on mobile
+      const now = Date.now()
+      const shouldDebounce = now - lastScrollTimeRef.current < scrollDebounceMs
+
+      // Scroll when element is near edge or not visible, and it's a new item
+      const shouldScroll = (isNearEdge || !isVisible) && isNewItem && !shouldDebounce
+
+      if (shouldScroll) {
+        // Use smooth scrolling to match the chat behavior
+        isScrollingRef.current = true
+        scrollToIndex(activeIndex, 'smooth')
+        lastScrollTimeRef.current = now
+
+        // Release scroll lock after animation completes (200ms for smooth scroll)
+        setTimeout(() => {
+          isScrollingRef.current = false
+        }, 200)
+      }
+
+      // Update previous index
+      prevActiveIndexRef.current = activeIndex
+    }
+  }, [activeIndex, displayItems.length, scrollToIndex])
+
+  const isItemActive = (index: number): boolean => {
+    return activeIndex === index
+  }
+
+  const getItemLabel = (item: DisplayItem, index: number): string => {
+    if (item.type === 'message') {
+      const msg = item.message
+      // Strip all HTML tags and normalize whitespace for all messages
+      const rawContent = msg.content || ''
+      const cleanContent = rawContent
+        .replace(/<[^>]+>/g, '')
+        .replace(/\s+/g, ' ')
+        .trim()
+      const lowerContent = cleanContent.toLowerCase()
+
+      // Check for specific patterns first (before role-based handling)
+      if (lowerContent.startsWith('# build mode') || lowerContent.startsWith('build mode')) {
+        return 'Builder'
+      }
+      if (lowerContent.startsWith('# plan mode') || lowerContent.startsWith('plan mode')) {
+        return 'Planner'
+      }
+      if (
+        lowerContent.includes('compaction') ||
+        lowerContent.includes('compacted') ||
+        lowerContent.includes('context window')
+      ) {
+        return 'Compaction'
+      }
+
+      // Check for special message kinds BEFORE role-based handling
+      if (msg.messageKind) {
+        if (msg.messageKind === 'workflow-started') {
+          try {
+            const data = JSON.parse(msg.content) as { workflowName: string }
+            return `Workflow: ${data.workflowName}`
+          } catch {
+            return 'Workflow started'
+          }
+        }
+        if (msg.messageKind === 'task-completed') {
+          return 'Task completed'
+        }
+        if (msg.messageKind === 'auto-prompt') {
+          return 'Auto-prompt'
+        }
+        if (msg.messageKind === 'correction') {
+          return 'Correction'
+        }
+        if (msg.messageKind === 'context-reset') {
+          return 'Context reset'
+        }
+        if (msg.messageKind === 'command') {
+          return 'Command executed'
+        }
+      }
+
+      if (msg.role === 'user') {
+        const preview = cleanContent.slice(0, 200)
+        return preview.length < cleanContent.length ? `${preview}...` : preview
+      }
+      if (msg.role === 'assistant') {
+        // Show regular content if available, otherwise show thinking content
+        if (cleanContent) {
+          // Check if content is JSON (workflow/task data)
+          if (cleanContent.trim().startsWith('{')) {
+            try {
+              const data = JSON.parse(cleanContent) as { workflowName?: string; summary?: string }
+              if (data.workflowName) {
+                return `Workflow: ${data.workflowName}`
+              }
+              if (data.summary !== undefined) {
+                return 'Task completed'
+              }
+            } catch {
+              // Not valid JSON, continue with normal text
+            }
+          }
+          const text = cleanContent.slice(0, 200)
+          return text.length < cleanContent.length ? `${text}...` : text
+        }
+        // Fall back to thinking content if no regular content
+        if (msg.thinkingContent?.trim()) {
+          const preview = msg.thinkingContent.slice(0, 200)
+          return preview.length < msg.thinkingContent.length ? `${preview}...` : preview
+        }
+        return ''
+      }
+      return `Message ${index + 1}`
+    }
+    if (item.type === 'context-divider') {
+      return `Earlier context (${item.windowSequence})`
+    }
+    if (item.type === 'subagent') {
+      return `Sub-agent: ${item.subAgentType}`
+    }
+    if (item.type === 'criteria-batch') {
+      return 'Acceptance Criteria'
+    }
+    return `Item ${index + 1}`
+  }
+
+  return (
+    <div ref={containerRef} className="h-full overflow-y-auto">
+      {displayItems.map((item, index) => {
+        const isActive = isItemActive(index)
+        const isCriteria = item.type === 'criteria-batch'
+        const isAssistant = item.type === 'message' && item.message.role === 'assistant'
+        const hasThinking = isAssistant && item.message.thinkingContent?.trim()
+        const hasContent = isAssistant && item.message.content?.trim()
+        // Thinking messages: have thinking content but NO regular content
+        const isThinking = isAssistant && hasThinking && !hasContent
+        const isSystemReminder = item.type === 'message' && item.message.content?.includes('<system-reminder>')
+        const isBuildMode = isSystemReminder && item.message.content?.includes('# Build Mode')
+        const isPlanMode = isSystemReminder && item.message.content?.includes('# Plan Mode')
+        const isCompaction =
+          item.type === 'message' &&
+          (item.message.content?.toLowerCase().includes('compacted') ||
+            item.message.content?.toLowerCase().includes('compaction') ||
+            item.message.content?.toLowerCase().includes('context window'))
+        const isEmptyAssistant = isAssistant && !hasContent && !hasThinking
+        // Check for special message kinds
+        const isWorkflowStarted =
+          item.type === 'message' &&
+          (item.message.messageKind === 'workflow-started' ||
+            (item.message.content?.trim().startsWith('{') && item.message.content?.includes('"workflowName"')))
+        const isTaskCompleted =
+          item.type === 'message' &&
+          (item.message.messageKind === 'task-completed' ||
+            (item.message.content?.trim().startsWith('{') && item.message.content?.includes('"summary"')))
+        const isAutoPrompt = item.type === 'message' && item.message.messageKind === 'auto-prompt'
+        const isCorrection = item.type === 'message' && item.message.messageKind === 'correction'
+        const isContextReset = item.type === 'message' && item.message.messageKind === 'context-reset'
+        const isCommand = item.type === 'message' && item.message.messageKind === 'command'
+
+        // Skip rendering empty assistant messages and context dividers
+        if (isEmptyAssistant || item.type === 'context-divider') {
+          return null
+        }
+
+        // Get timestamp for datetime display
+        let timestamp: string | undefined
+        if (item.type === 'message') {
+          timestamp = item.message.timestamp
+        } else if (item.type === 'subagent') {
+          // Use the first message's timestamp for subagent groups
+          timestamp = item.messages[0]?.timestamp
+        } else if (item.type === 'criteria-batch') {
+          // Use the timestamp from the criteria batch
+          timestamp = item.timestamp
+        }
+
+        // Determine text color based on item type - using distinctly different colors
+        let textColorClass = 'text-text-muted'
+        if (isCompaction) {
+          textColorClass = 'text-gray-400'
+        } else if (item.type === 'message' && item.message.role === 'user' && !isSystemReminder) {
+          textColorClass = 'text-orange-400'
+        } else if (isThinking) {
+          textColorClass = 'text-cyan-300'
+        } else if (
+          isAssistant &&
+          !isSystemReminder &&
+          !isWorkflowStarted &&
+          !isTaskCompleted &&
+          !isAutoPrompt &&
+          !isCorrection &&
+          !isContextReset &&
+          !isCommand
+        ) {
+          textColorClass = 'text-lime-300'
+        } else if (isBuildMode) {
+          textColorClass = 'text-sky-400'
+        } else if (isPlanMode) {
+          textColorClass = 'text-violet-400'
+        } else if (isSystemReminder) {
+          textColorClass = 'text-yellow-400'
+        } else if (isWorkflowStarted) {
+          textColorClass = 'text-sky-400'
+        } else if (isTaskCompleted) {
+          textColorClass = 'text-green-400'
+        } else if (isAutoPrompt) {
+          textColorClass = 'text-violet-400'
+        } else if (isCorrection) {
+          textColorClass = 'text-yellow-400'
+        } else if (isContextReset) {
+          textColorClass = 'text-gray-400'
+        } else if (isCommand) {
+          textColorClass = 'text-lime-400'
+        } else if (item.type === 'subagent') {
+          textColorClass = 'text-amber-500'
+        } else if (isCriteria) {
+          textColorClass = 'text-green-400'
+        }
+
+        return (
+          <div
+            key={index}
+            ref={(el) => {
+              if (el) {
+                itemRefs.current.set(index, el)
+              }
+            }}
+            data-item-index={index}
+            onClick={() => handleScrollToIndex(index)}
+            className={`
+              px-1 py-1 rounded-lg cursor-pointer text-xs transition-all duration-200 hover:bg-bg-tertiary mb-0.5
+              ${
+                isActive
+                  ? 'bg-gradient-to-r from-accent-primary/15 to-accent-primary/0 border-l-2 border-accent-primary/50'
+                  : 'bg-gradient-to-r from-bg-tertiary/30 to-bg-tertiary/0 border-l-2 border-border/30'
+              }
+              ${isCompaction ? 'text-gray-400' : textColorClass}
+            `}
+            title={getItemLabel(item, index)}
+          >
+            <div className="flex items-center gap-1">
+              <div className="flex items-center gap-1 min-w-0 flex-1">
+                {/* Only show ONE emoji based on strict priority order */}
+                {!isWorkflowStarted &&
+                  !isTaskCompleted &&
+                  !isAutoPrompt &&
+                  !isCorrection &&
+                  !isContextReset &&
+                  !isCommand &&
+                  isBuildMode && <span className="text-sky-400 w-4 text-center flex-shrink-0">🔨</span>}
+                {!isWorkflowStarted &&
+                  !isTaskCompleted &&
+                  !isAutoPrompt &&
+                  !isCorrection &&
+                  !isContextReset &&
+                  !isCommand &&
+                  !isBuildMode &&
+                  isPlanMode && <span className="text-violet-400 w-4 text-center flex-shrink-0">📋</span>}
+                {!isWorkflowStarted &&
+                  !isTaskCompleted &&
+                  !isAutoPrompt &&
+                  !isCorrection &&
+                  !isContextReset &&
+                  !isCommand &&
+                  !isBuildMode &&
+                  !isPlanMode &&
+                  isCompaction && <span className="text-orange-500 w-4 text-center flex-shrink-0">🗜️</span>}
+                {!isWorkflowStarted &&
+                  !isTaskCompleted &&
+                  !isAutoPrompt &&
+                  !isCorrection &&
+                  !isContextReset &&
+                  !isCommand &&
+                  !isBuildMode &&
+                  !isPlanMode &&
+                  !isCompaction &&
+                  isSystemReminder && <span className="text-yellow-400 w-4 text-center flex-shrink-0">⚙️</span>}
+                {!isWorkflowStarted &&
+                  !isTaskCompleted &&
+                  !isAutoPrompt &&
+                  !isCorrection &&
+                  !isContextReset &&
+                  !isCommand &&
+                  !isBuildMode &&
+                  !isPlanMode &&
+                  !isCompaction &&
+                  !isSystemReminder &&
+                  isThinking && <span className="text-cyan-300 w-4 text-center flex-shrink-0">🧠</span>}
+                {!isWorkflowStarted &&
+                  !isTaskCompleted &&
+                  !isAutoPrompt &&
+                  !isCorrection &&
+                  !isContextReset &&
+                  !isCommand &&
+                  !isBuildMode &&
+                  !isPlanMode &&
+                  !isCompaction &&
+                  !isSystemReminder &&
+                  !isThinking &&
+                  item.type === 'message' &&
+                  item.message.role === 'user' &&
+                  !isCompaction && <span className="text-orange-400 w-4 text-center flex-shrink-0">🤔</span>}
+                {!isWorkflowStarted &&
+                  !isTaskCompleted &&
+                  !isAutoPrompt &&
+                  !isCorrection &&
+                  !isContextReset &&
+                  !isCommand &&
+                  !isBuildMode &&
+                  !isPlanMode &&
+                  !isCompaction &&
+                  !isSystemReminder &&
+                  !isThinking &&
+                  item.type === 'message' &&
+                  item.message.role === 'assistant' && (
+                    <span className="text-lime-300 w-4 text-center flex-shrink-0">🤖</span>
+                  )}
+                {!isWorkflowStarted &&
+                  !isTaskCompleted &&
+                  !isAutoPrompt &&
+                  !isCorrection &&
+                  !isContextReset &&
+                  !isCommand &&
+                  !isBuildMode &&
+                  !isPlanMode &&
+                  !isCompaction &&
+                  !isSystemReminder &&
+                  !isThinking &&
+                  item.type === 'subagent' && <span className="text-amber-500 w-4 text-center flex-shrink-0">◈</span>}
+                {!isWorkflowStarted &&
+                  !isTaskCompleted &&
+                  !isAutoPrompt &&
+                  !isCorrection &&
+                  !isContextReset &&
+                  !isCommand &&
+                  !isBuildMode &&
+                  !isPlanMode &&
+                  !isCompaction &&
+                  !isSystemReminder &&
+                  !isThinking &&
+                  item.type === 'criteria-batch' && (
+                    <span className="text-green-400 w-4 text-center flex-shrink-0">✅</span>
+                  )}
+                {isWorkflowStarted && <span className="text-sky-400 w-4 text-center flex-shrink-0">⚡</span>}
+                {isTaskCompleted && <span className="text-green-400 w-4 text-center flex-shrink-0">✓</span>}
+                {isAutoPrompt && <span className="text-violet-400 w-4 text-center flex-shrink-0">📝</span>}
+                {isCorrection && <span className="text-yellow-400 w-4 text-center flex-shrink-0">⚠️</span>}
+                {isContextReset && <span className="text-gray-400 w-4 text-center flex-shrink-0">⟳</span>}
+                {isCommand && <span className="text-lime-400 w-4 text-center flex-shrink-0">📜</span>}
+                <span className={`flex-1 ${textColorClass} line-clamp-2`}>{getItemLabel(item, index)}</span>
+              </div>
+              {timestamp && (
+                <span
+                  className={`text-[9px] flex-shrink-0 font-medium px-1 ${isActive ? 'text-accent-primary' : 'text-text-muted'}`}
+                >
+                  {formatTime(timestamp)}
+                </span>
+              )}
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+export const MemoizedConversationIndex = memo(ConversationIndex)

--- a/web/src/components/plan/DevServerFooter.tsx
+++ b/web/src/components/plan/DevServerFooter.tsx
@@ -182,7 +182,7 @@ export const DevServerFooter = memo(function DevServerFooter({ workdir }: DevSer
   }
 
   return (
-    <div className="mt-2 pt-3 border-t border-border space-y-3">
+    <div>
       {/* Header row: [dot] Dev Server ... [settings] */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
@@ -210,85 +210,80 @@ export const DevServerFooter = memo(function DevServerFooter({ workdir }: DevSer
 
       {hasConfig ? (
         <>
-          {state === 'running' || state === 'warning' ? (
-            /* Stop + Open side by side */
-            <div className="flex gap-2">
+          <div className="mt-2">
+            {state === 'running' || state === 'warning' ? (
+              /* Stop + Open side by side */
+              <div className="flex gap-2">
+                <button
+                  onClick={handleAction}
+                  className="flex-1 flex items-center justify-center gap-1.5 rounded font-medium text-sm px-3 py-1.5 bg-bg-tertiary text-text-primary hover:bg-border transition-colors"
+                >
+                  <StopIcon />
+                  Stop
+                </button>
+                {status?.url && (
+                  <button
+                    onClick={() => openInspectWindow()}
+                    className="flex-1 flex items-center justify-center gap-1.5 rounded font-medium text-sm px-3 py-1.5 bg-accent-primary/25 text-text-primary hover:bg-accent-primary/40 transition-colors"
+                    title={status.url}
+                  >
+                    <OpenExternalIcon />
+                    Open
+                  </button>
+                )}
+              </div>
+            ) : (
+              /* Start button — full width */
               <button
                 onClick={handleAction}
-                className="flex-1 flex items-center justify-center gap-1.5 rounded font-medium text-sm px-3 py-1.5 bg-bg-tertiary text-text-primary hover:bg-border transition-colors"
+                className="w-full rounded font-medium text-sm px-3 py-1.5 bg-accent-primary/25 text-text-primary hover:bg-accent-primary/40 transition-colors"
               >
-                <StopIcon />
-                Stop
+                Start
               </button>
-              {status?.url && (
-                <button
-                  onClick={() => openInspectWindow()}
-                  className="flex-1 flex items-center justify-center gap-1.5 rounded font-medium text-sm px-3 py-1.5 bg-accent-primary/25 text-text-primary hover:bg-accent-primary/40 transition-colors"
-                  title={status.url}
-                >
-                  <OpenExternalIcon />
-                  Open
-                </button>
-              )}
-            </div>
-          ) : (
-            /* Start button — full width */
-            <button
-              onClick={handleAction}
-              className="w-full rounded font-medium text-sm px-3 py-1.5 bg-accent-primary/25 text-text-primary hover:bg-accent-primary/40 transition-colors"
-            >
-              Start
-            </button>
-          )}
+            )}
 
-          {/* Log panel — always visible when running */}
-          {isAlive && (
-            <div
-              ref={logContainerRef}
-              className="relative"
-              onMouseEnter={() => {
-                if (hideTimeoutRef.current) clearTimeout(hideTimeoutRef.current)
-                showTimeoutRef.current = setTimeout(() => {
-                  setIsHoveringLogs(true)
-                  setIsHidingLogs(false)
-                }, 500)
-              }}
-              onMouseLeave={() => {
-                if (showTimeoutRef.current) clearTimeout(showTimeoutRef.current)
-                setIsHidingLogs(true)
-                hideTimeoutRef.current = setTimeout(() => setIsHoveringLogs(false), 150)
-              }}
-            >
-              <LogRenderer
-                logs={logs}
-                preRef={logRef}
-                preClassName="text-sm bg-bg-primary p-2 rounded overflow-auto max-h-[200px] border border-border"
-              />
+            {/* Log panel — always visible when running */}
+            {isAlive && (
+              <div
+                ref={logContainerRef}
+                className="relative mt-2"
+                onMouseEnter={() => {
+                  if (hideTimeoutRef.current) clearTimeout(hideTimeoutRef.current)
+                  showTimeoutRef.current = setTimeout(() => {
+                    setIsHoveringLogs(true)
+                    setIsHidingLogs(false)
+                  }, 500)
+                }}
+                onMouseLeave={() => {
+                  if (showTimeoutRef.current) clearTimeout(showTimeoutRef.current)
+                  setIsHidingLogs(true)
+                  hideTimeoutRef.current = setTimeout(() => setIsHoveringLogs(false), 150)
+                }}
+              >
+                <LogRenderer
+                  logs={logs}
+                  preRef={logRef}
+                  preClassName="text-sm bg-bg-primary p-2 rounded overflow-auto max-h-[200px] border border-border"
+                />
 
-              {/* Hover expansion portal */}
-              {(isHoveringLogs || isHidingLogs) &&
-                logContainerRef.current &&
-                createPortal(
-                  <LogHoverExpand
-                    logs={logs}
-                    anchorRef={logContainerRef}
-                    isHiding={isHidingLogs}
-                    onExpand={() => setShowExpandModal(true)}
-                    onClose={() => setIsHoveringLogs(false)}
-                  />,
-                  document.body,
-                )}
-            </div>
-          )}
+                {/* Hover expansion portal */}
+                {(isHoveringLogs || isHidingLogs) &&
+                  logContainerRef.current &&
+                  createPortal(
+                    <LogHoverExpand
+                      logs={logs}
+                      anchorRef={logContainerRef}
+                      isHiding={isHidingLogs}
+                      onExpand={() => setShowExpandModal(true)}
+                      onClose={() => setIsHoveringLogs(false)}
+                    />,
+                    document.body,
+                  )}
+              </div>
+            )}
+          </div>
         </>
-      ) : (
-        <button
-          onClick={() => setShowConfigModal(true)}
-          className="w-full rounded font-medium text-sm px-3 py-1.5 bg-bg-tertiary text-text-muted hover:bg-border transition-colors"
-        >
-          Configure
-        </button>
-      )}
+      ) : null}
 
       <DevServerConfigModal isOpen={showConfigModal} onClose={() => setShowConfigModal(false)} />
 

--- a/web/src/components/plan/MessageList.tsx
+++ b/web/src/components/plan/MessageList.tsx
@@ -55,7 +55,7 @@ export const MessageList = memo(function MessageList({
         {displayItems.map((item, index) => {
           if (item.type === 'context-divider') {
             return (
-              <div key={index} className="flex items-center gap-2 feed-item px-2 md:px-4">
+              <div key={index} data-item-index={index} className="flex items-center gap-2 feed-item px-2 md:px-4">
                 <div className="flex-1 border-t border-border" />
                 <span className="text-[10px] text-text-muted font-medium px-2">Earlier context summarized</span>
                 <div className="flex-1 border-t border-border" />
@@ -66,7 +66,7 @@ export const MessageList = memo(function MessageList({
           if (item.type === 'subagent') {
             const groupIsStreaming = item.messages.some((m) => m.isStreaming)
             return (
-              <div key={index} className="px-2 md:px-4">
+              <div key={index} data-item-index={index} className="px-2 md:px-4">
                 <SubAgentContainer
                   messages={item.messages}
                   subAgentType={item.subAgentType}
@@ -79,7 +79,7 @@ export const MessageList = memo(function MessageList({
 
           if (item.type === 'criteria-batch') {
             return (
-              <div key={index} className="feed-item px-2 md:px-4">
+              <div key={index} data-item-index={index} className="feed-item px-2 md:px-4">
                 <CriteriaGroupDisplay toolCalls={item.toolCalls} criteria={criteria} />
               </div>
             )
@@ -88,7 +88,7 @@ export const MessageList = memo(function MessageList({
           const message = item.message
           if (message.role === 'assistant') {
             return (
-              <div key={index} className="px-2 md:px-4">
+              <div key={index} data-item-index={index} className="px-2 md:px-4">
                 <AssistantMessage
                   message={message}
                   showStats={showStats}
@@ -108,7 +108,7 @@ export const MessageList = memo(function MessageList({
           }
 
           return (
-            <div key={index} className="px-2 md:px-4">
+            <div key={index} data-item-index={index} className="px-2 md:px-4">
               <div
                 data-message-id={message.id}
                 className={highlightedMessageId === message.id ? 'rounded animate-highlight-fade' : undefined}

--- a/web/src/components/plan/PlanPanel.tsx
+++ b/web/src/components/plan/PlanPanel.tsx
@@ -239,18 +239,6 @@ export function PlanPanel({
       const maxScroll = container.scrollHeight - container.clientHeight
       const isAtBottom = container.scrollTop >= maxScroll - 10
 
-      // Debug logging
-      console.log('[PlanPanel] handleScroll:', {
-        scrollTop: container.scrollTop,
-        scrollHeight: container.scrollHeight,
-        clientHeight: container.clientHeight,
-        isAtBottom,
-        closestIndex,
-        closestDistance,
-        lastRenderedIndex,
-        activeIndex,
-      })
-
       if (isAtBottom && lastRenderedIndex !== -1) {
         setActiveIndex(lastRenderedIndex)
         lastActiveIndexUpdateRef.current = now

--- a/web/src/components/plan/PlanPanel.tsx
+++ b/web/src/components/plan/PlanPanel.tsx
@@ -134,6 +134,139 @@ export function PlanPanel({
 
   const { force_scroll_to_bottom, isAutoScrollActive, setAutoScroll } = useAutoScroll(scrollContainerRef, session)
 
+  // Track topmost visible display item for conversation index highlighting
+  const [activeIndex, setActiveIndex] = useState<number | undefined>(undefined)
+  const displayItemsRef = useRef(displayItems)
+  displayItemsRef.current = displayItems
+
+  // Scroll the main chat to a specific display item index
+  const scrollToIndex = useCallback(
+    (index: number) => {
+      if (index < 0 || index >= displayItems.length) return
+
+      const element = document.querySelector(`[data-item-index="${index}"]`)
+      if (!element) return
+
+      const container = scrollContainerRef.current
+      if (!container) return
+
+      setAutoScroll(false)
+
+      const elementTop = element.getBoundingClientRect().top + container.scrollTop
+      const targetPosition = elementTop - 80
+
+      // Record scroll position before scrolling
+      const startScrollTop = container.scrollTop
+
+      // Smooth scroll animation
+      container.scrollTo({
+        top: targetPosition,
+        behavior: 'smooth',
+      })
+
+      // Check after 100ms if scroll actually moved
+      setTimeout(() => {
+        const currentScrollTop = container.scrollTop
+        // If scroll didn't move (< 1px), item was unreachable - set highlight manually
+        if (Math.abs(currentScrollTop - startScrollTop) < 1) {
+          setActiveIndex(index)
+        }
+        // If scroll moved, let scroll handler update activeIndex naturally
+      }, 100)
+    },
+    [displayItems.length, scrollContainerRef, setAutoScroll],
+  )
+
+  // Debounce activeIndex updates to prevent rapid-fire updates during scroll
+  const lastActiveIndexUpdateRef = useRef<number>(0)
+  const activeIndexDebounceMs = 50 // Minimum time between activeIndex updates
+
+  useEffect(() => {
+    const container = scrollContainerRef.current
+    if (!container || displayItems.length === 0) return
+
+    const handleScroll = () => {
+      const now = Date.now()
+      // Skip if we just updated activeIndex
+      if (now - lastActiveIndexUpdateRef.current < activeIndexDebounceMs) {
+        return
+      }
+
+      const containerTop = container.scrollTop
+      const viewportTop = containerTop
+      const viewportBottom = containerTop + container.clientHeight
+
+      let closestIndex = -1
+      let closestDistance = Infinity
+      let lastRenderedIndex = -1
+
+      displayItemsRef.current.forEach((_, index) => {
+        const item = displayItemsRef.current[index]
+        if (!item) return
+
+        if (item.type === 'message' && item.message.role === 'assistant') {
+          if (!item.message.content?.trim() && !item.message.thinkingContent?.trim()) {
+            return
+          }
+        }
+
+        lastRenderedIndex = index
+
+        const element = document.querySelector(`[data-item-index="${index}"]`)
+        if (element) {
+          const rect = element.getBoundingClientRect()
+          const elementTop = rect.top + container.scrollTop - container.getBoundingClientRect().top
+          const elementHeight = element.clientHeight
+          const elementCenter = elementTop + elementHeight / 2
+
+          // Only consider elements that have their center at or slightly below viewport top (with 5px offset)
+          // Pick the first one that's visible (closest to viewport top from below)
+          if (elementCenter >= viewportTop - 5 && elementTop < viewportBottom) {
+            const distance = elementCenter - viewportTop
+            if (distance < closestDistance) {
+              closestDistance = distance
+              closestIndex = index
+            }
+          }
+        }
+      })
+
+      // Fallback: if no element found at or below viewport top, use last rendered
+      if (closestIndex === -1 && lastRenderedIndex !== -1) {
+        closestIndex = lastRenderedIndex
+      }
+
+      const maxScroll = container.scrollHeight - container.clientHeight
+      const isAtBottom = container.scrollTop >= maxScroll - 10
+
+      // Debug logging
+      console.log('[PlanPanel] handleScroll:', {
+        scrollTop: container.scrollTop,
+        scrollHeight: container.scrollHeight,
+        clientHeight: container.clientHeight,
+        isAtBottom,
+        closestIndex,
+        closestDistance,
+        lastRenderedIndex,
+        activeIndex,
+      })
+
+      if (isAtBottom && lastRenderedIndex !== -1) {
+        setActiveIndex(lastRenderedIndex)
+        lastActiveIndexUpdateRef.current = now
+      } else if (closestIndex !== -1) {
+        setActiveIndex(closestIndex)
+        lastActiveIndexUpdateRef.current = now
+      }
+    }
+
+    container.addEventListener('scroll', handleScroll, { passive: true })
+
+    return () => {
+      container.removeEventListener('scroll', handleScroll)
+    }
+  }, [displayItems.length])
+
   const prevLenRef = useRef(0)
 
   const resizeTextarea = useCallback(() => {
@@ -407,6 +540,9 @@ export function PlanPanel({
         criteriaSidebarOpen={criteriaSidebarOpen}
         onCriteriaSidebarToggle={onCriteriaSidebarToggle}
         messages={messages}
+        displayItems={displayItems}
+        activeIndex={activeIndex}
+        onNavigate={scrollToIndex}
       >
         {pendingQuestion && <AskUserDialog question={pendingQuestion} />}
         <SessionHeader />

--- a/web/src/components/plan/SummaryDisplay.tsx
+++ b/web/src/components/plan/SummaryDisplay.tsx
@@ -10,15 +10,27 @@ import { DevServerFooter } from './DevServerFooter'
 import { BackgroundProcesses } from './BackgroundProcesses'
 import { BranchIcon } from '../shared/icons'
 import { DiffViewer } from './DiffViewer'
+import { ConversationIndex } from './ConversationIndex'
 import type { Message } from '@shared/types.js'
+import type { DisplayItem } from './groupMessages'
 
 interface SummaryDisplayProps {
   summary: string | null
   messages: Message[]
   workdir?: string
+  displayItems?: DisplayItem[]
+  activeIndex?: number
+  onNavigate?: (index: number) => void
 }
 
-export function SummaryDisplay({ summary, messages, workdir }: SummaryDisplayProps) {
+export function SummaryDisplay({
+  summary,
+  messages,
+  workdir,
+  displayItems,
+  activeIndex,
+  onNavigate,
+}: SummaryDisplayProps) {
   const [showStatsModal, setShowStatsModal] = useState(false)
   const stats = useSessionStats(messages)
   const { branch } = useGitStatus()
@@ -68,6 +80,18 @@ export function SummaryDisplay({ summary, messages, workdir }: SummaryDisplayPro
           <h3 className="text-sm font-semibold text-text-primary mb-2">Progress</h3>
           <CriteriaProgressSummary criteria={session?.criteria ?? []} />
         </div>
+
+        {/* Red square - fills available space with scrollable content */}
+        {displayItems && (
+          <div className="min-h-[100px] min-h-0 mt-4 flex-1 flex flex-col">
+            <div className="pb-2 flex-shrink-0">
+              <h3 className="text-sm font-semibold text-text-primary">History</h3>
+            </div>
+            <div className="flex-1 overflow-y-auto bg-transparent rounded">
+              <ConversationIndex displayItems={displayItems} activeIndex={activeIndex} onNavigate={onNavigate} />
+            </div>
+          </div>
+        )}
       </div>
 
       {/* Git branch — above separator */}

--- a/web/src/components/plan/SummaryDisplay.tsx
+++ b/web/src/components/plan/SummaryDisplay.tsx
@@ -81,7 +81,7 @@ export function SummaryDisplay({
           <CriteriaProgressSummary criteria={session?.criteria ?? []} />
         </div>
 
-        {/* Red square - fills available space with scrollable content */}
+        {/* History sidebar */}
         {displayItems && (
           <div className="min-h-[100px] min-h-0 mt-4 flex-1 flex flex-col">
             <div className="pb-2 flex-shrink-0">

--- a/web/src/components/plan/groupMessages.ts
+++ b/web/src/components/plan/groupMessages.ts
@@ -6,7 +6,7 @@ export type { Message, ToolCall }
 export type DisplayItem =
   | { type: 'message'; message: Message }
   | { type: 'subagent'; subAgentId: string; subAgentType: string; messages: Message[] }
-  | { type: 'criteria-batch'; toolCalls: ToolCall[] }
+  | { type: 'criteria-batch'; toolCalls: ToolCall[]; timestamp: string }
   | { type: 'context-divider'; windowSequence: number }
 
 // Check if a message contains only criterion tool calls (no text content)
@@ -54,6 +54,7 @@ export function groupMessages(messages: Message[], previousItems: DisplayItem[] 
   }
 
   let criteriaBatchIndex = 0
+  let lastCriteriaMessageTimestamp: string | undefined
 
   const flushCriteriaBuffer = () => {
     if (criteriaBuffer.length > 0) {
@@ -68,7 +69,11 @@ export function groupMessages(messages: Message[], previousItems: DisplayItem[] 
       if (toolCallsMatch) {
         items.push(previousBatch)
       } else {
-        items.push({ type: 'criteria-batch', toolCalls: [...criteriaBuffer] })
+        items.push({
+          type: 'criteria-batch',
+          toolCalls: [...criteriaBuffer],
+          timestamp: lastCriteriaMessageTimestamp || new Date().toISOString(),
+        })
       }
       criteriaBatchIndex++
       criteriaBuffer = []
@@ -129,6 +134,8 @@ export function groupMessages(messages: Message[], previousItems: DisplayItem[] 
       for (const tc of msg.toolCalls!) {
         criteriaBuffer.push(tc)
       }
+      // Capture the message timestamp for the criteria batch
+      lastCriteriaMessageTimestamp = msg.timestamp
       continue
     }
 


### PR DESCRIPTION
- Add conversation history sidebar with bi-directional scroll synchronization
- Display conversation timeline with icons for different message types
- Prioritize regular content over thinking content (for items containing both)
- Show workflow and task completion status with proper formatting
- Emoji priority order for the sidebar (from highest to lowest priority):

⚡ — Workflow Started (messageKind === 'workflow-started')
✅ — Task Completed (messageKind === 'task-completed' or summary in JSON)
📝 — Auto-Prompt (messageKind === 'auto-prompt')
🔧 — Correction (messageKind === 'correction')
🔄 — Context Reset (messageKind === 'context-reset')
⚡ — Command Executed (messageKind === 'command')
🔨 — Build Mode (System reminder with # Build Mode)
📋 — Plan Mode (System reminder with # Plan Mode)
🗜️ — Compaction (Content includes "compacted", "compaction", or "context window")
⚙️ — System Reminder (Generic system message)
🧠 — Thinking (Assistant message with thinking content but NO regular content)
🤔 — User Message (Regular user message)
🤖 — Assistant Message (Regular assistant message with content)

<img width="963" height="854" alt="image" src="https://github.com/user-attachments/assets/774d5eac-3789-4639-8c74-43eee49a87d3" />


I have smooth scrolling disabled in my Chrome, so I've captured Firefox here.

https://github.com/user-attachments/assets/93fb4281-addb-4d5b-bfa0-f15ae9c67d72

Starting from ConversationIndex.tsx:405 this is particularly "ugly" - if you want to call "explicit verbosity" that way, but it gets the job done. Sorry this has turned into a particularly big PR, but this feature definitely helps me get back on track quickly when hopping 42 projects at once ;)

I will handle Firefox's ugly scrollbars soon-ish too...