### PR TITLE
style: Add Firefox-compatible thin scrollbars

### DIFF
--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -32,6 +32,12 @@
   ::-webkit-scrollbar-thumb:hover {
     @apply bg-text-muted;
   }
+
+  /* Firefox scrollbars */
+  * {
+    scrollbar-width: thin;
+    scrollbar-color: rgba(100, 116, 139, 0.3) transparent;
+  }
 }
 
 @layer components {


### PR DESCRIPTION
## Changes
- Added Firefox scrollbar styling using standard CSS properties
- Used thin scrollbar width with subtle semi-transparent colors
- Scrollbars now match Chrome's appearance across both browsers
- Transparent track and 30% opacity thumb for minimal visual intrusion

## Testing
- Verified scrollbars appear consistent in both Chrome and Firefox