### PR TITLE
feat: add "Show syntax highlighting" setting

### DIFF
--- a/src/server/db/settings.ts
+++ b/src/server/db/settings.ts
@@ -12,6 +12,7 @@ export const SETTINGS_KEYS = {
   DISPLAY_SHOW_STATS: 'display.showStats',
   DISPLAY_SHOW_AGENT_DEFINITIONS: 'display.showAgentDefinitions',
   DISPLAY_SHOW_WORKFLOW_BARS: 'display.showWorkflowBars',
+  DISPLAY_SHOW_SYNTAX_HIGHLIGHTING: 'display.showSyntaxHighlighting',
   DISPLAY_THEME: 'display.theme',
   DISPLAY_USER_PRESETS: 'display.userPresets',
 } as const
@@ -22,6 +23,7 @@ export const SETTINGS_DEFAULTS: Record<string, string> = {
   [SETTINGS_KEYS.DISPLAY_SHOW_STATS]: 'true',
   [SETTINGS_KEYS.DISPLAY_SHOW_AGENT_DEFINITIONS]: 'true',
   [SETTINGS_KEYS.DISPLAY_SHOW_WORKFLOW_BARS]: 'true',
+  [SETTINGS_KEYS.DISPLAY_SHOW_SYNTAX_HIGHLIGHTING]: 'true',
   [SETTINGS_KEYS.DISPLAY_THEME]: JSON.stringify({ preset: 'dark' }),
 }
 

--- a/web/src/components/settings/GlobalSettingsModal.tsx
+++ b/web/src/components/settings/GlobalSettingsModal.tsx
@@ -111,6 +111,11 @@ function DisplayTab() {
       label: 'Show workflow bars',
       description: 'Display workflow start and end markers',
     },
+    {
+      key: SETTINGS_KEYS.DISPLAY_SHOW_SYNTAX_HIGHLIGHTING,
+      label: 'Show syntax highlighting',
+      description: 'Nicer formatting, but very slow - does not affect red/green diff coloring',
+    },
   ] as const
 
   const localValues = Object.fromEntries(toggles.map((t) => [t.key, settings[t.key] ?? 'true'])) as Record<

--- a/web/src/components/shared/CodeHighlight.tsx
+++ b/web/src/components/shared/CodeHighlight.tsx
@@ -1,5 +1,6 @@
 import { memo } from 'react'
 import { SyntaxHighlighter, oneDark } from '../../lib/syntax-highlighter'
+import { useDisplaySettings } from '../../stores/settings'
 
 // Custom oneDark theme with transparent backgrounds and word wrapping
 export const oneDarkTransparent: { [key: string]: React.CSSProperties } = {
@@ -122,8 +123,20 @@ interface CodeHighlightProps {
 }
 
 export const CodeHighlight = memo(function CodeHighlight({ code, language, variant }: CodeHighlightProps) {
+  const { showSyntaxHighlighting } = useDisplaySettings()
   const preTag = variant === 'inline' ? 'span' : variant === 'block-nowrap' ? 'div' : 'pre'
   const style = variant === 'inline' ? inlineCodeStyle : variant === 'block-nowrap' ? codeStyle : wrappedCodeStyle
+
+  if (!showSyntaxHighlighting) {
+    const Tag = preTag
+    return (
+      <Tag style={style} className="language-">
+        <code style={style} className="language-">
+          {code}
+        </code>
+      </Tag>
+    )
+  }
 
   return (
     <SyntaxHighlighter style={oneDarkTransparent} language={language} PreTag={preTag} customStyle={style}>

--- a/web/src/components/shared/Markdown.tsx
+++ b/web/src/components/shared/Markdown.tsx
@@ -2,6 +2,7 @@ import { memo, useMemo } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { SyntaxHighlighter, oneDark } from '../../lib/syntax-highlighter'
+import { useDisplaySettings } from '../../stores/settings'
 import { useCopyToClipboard } from '../../hooks/useCopyToClipboard'
 import { CheckIcon, CopyIcon } from './icons'
 
@@ -11,7 +12,7 @@ interface MarkdownProps {
   muted?: boolean
 }
 
-function createMarkdownComponents(muted: boolean) {
+function createMarkdownComponents(muted: boolean, showSyntaxHighlighting: boolean) {
   const headingColor = muted ? 'text-text-muted' : 'text-sky-400'
   const strongColor = muted ? 'text-text-secondary' : 'text-amber-400'
 
@@ -32,6 +33,33 @@ function createMarkdownComponents(muted: boolean) {
       const language = match?.[1] || 'text'
       const codeString = String(children).replace(/\n$/, '')
       const { copied, copy } = useCopyToClipboard()
+
+      if (!showSyntaxHighlighting) {
+        return (
+          <div className="relative group my-1.5 rounded overflow-hidden">
+            <div className="absolute bottom-0 right-0 flex items-center gap-2 px-2 py-1 text-xs text-text-muted/70 bg-bg-tertiary/60 rounded-tl rounded-tr z-10">
+              <span>{language}</span>
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.preventDefault()
+                  e.stopPropagation()
+                  copy(codeString)
+                }}
+                className="opacity-0 group-hover:opacity-100 transition-opacity hover:text-text-primary p-0.5"
+                title="Copy code"
+              >
+                {copied ? <CheckIcon /> : <CopyIcon />}
+              </button>
+            </div>
+            <div className="overflow-x-auto">
+              <pre className="my-0 px-4 py-3 overflow-x-auto font-mono text-sm whitespace-pre-wrap break-word">
+                <code className="language-{language}">{codeString}</code>
+              </pre>
+            </div>
+          </div>
+        )
+      }
 
       return (
         <div className="relative group my-1.5 rounded overflow-hidden">
@@ -169,6 +197,8 @@ function createMarkdownComponents(muted: boolean) {
 
 // Memoize to prevent re-renders during streaming from causing flicker
 export const Markdown = memo(function Markdown({ content, className = '', muted = false }: MarkdownProps) {
+  const { showSyntaxHighlighting } = useDisplaySettings()
+
   // Preprocess markdown to fix common LLM formatting quirks
   const processedContent = useMemo(() => {
     let processed = preprocessMarkdown(content)
@@ -176,7 +206,10 @@ export const Markdown = memo(function Markdown({ content, className = '', muted 
     return processed
   }, [content])
 
-  const components = useMemo(() => createMarkdownComponents(muted), [muted])
+  const components = useMemo(
+    () => createMarkdownComponents(muted, showSyntaxHighlighting),
+    [muted, showSyntaxHighlighting],
+  )
 
   return (
     <div className={`markdown-content [&_li>p]:inline ${className}`}>

--- a/web/src/stores/settings.ts
+++ b/web/src/stores/settings.ts
@@ -10,6 +10,7 @@ export const SETTINGS_KEYS = {
   DISPLAY_SHOW_STATS: 'display.showStats',
   DISPLAY_SHOW_AGENT_DEFINITIONS: 'display.showAgentDefinitions',
   DISPLAY_SHOW_WORKFLOW_BARS: 'display.showWorkflowBars',
+  DISPLAY_SHOW_SYNTAX_HIGHLIGHTING: 'display.showSyntaxHighlighting',
   DISPLAY_THEME: 'display.theme',
   DISPLAY_USER_PRESETS: 'display.userPresets',
 } as const
@@ -41,6 +42,7 @@ export const DISPLAY_SETTINGS_KEYS = [
   SETTINGS_KEYS.DISPLAY_SHOW_STATS,
   SETTINGS_KEYS.DISPLAY_SHOW_AGENT_DEFINITIONS,
   SETTINGS_KEYS.DISPLAY_SHOW_WORKFLOW_BARS,
+  SETTINGS_KEYS.DISPLAY_SHOW_SYNTAX_HIGHLIGHTING,
 ] as const
 
 export function useDisplaySettings() {
@@ -53,6 +55,8 @@ export function useDisplaySettings() {
       useSettingsStore((state) => state.settings[SETTINGS_KEYS.DISPLAY_SHOW_AGENT_DEFINITIONS] ?? 'true') === 'true',
     showWorkflowBars:
       useSettingsStore((state) => state.settings[SETTINGS_KEYS.DISPLAY_SHOW_WORKFLOW_BARS] ?? 'true') === 'true',
+    showSyntaxHighlighting:
+      useSettingsStore((state) => state.settings[SETTINGS_KEYS.DISPLAY_SHOW_SYNTAX_HIGHLIGHTING] ?? 'true') === 'true',
   }
 }
 


### PR DESCRIPTION
- Add DISPLAY_SHOW_SYNTAX_HIGHLIGHTING setting key to server and client
- Default to enabled for backward compatibility
- Add toggle in Settings > Display below 'Show workflow bars'
- When disabled, render code blocks with basic monospace styling
- Affects both CodeHighlight component and Markdown code blocks

SyntaxHighlighter3 is **!!!RIDICULOUSLY!!! inefficient**!
Switching to a session with 47 messages and 8 code blocks and syntax highlighting enabled takes a whopping **3.65s**

<img width="1030" height="732" alt="Highlighter enabled: 3.65s" src="https://github.com/user-attachments/assets/1f5a2ae9-bbf1-456b-b804-a0a10654a670" />

The same session in a fresh, uncached browser, without syntax highlighting: **0.42s** or about **800% faster**!

<img width="1028" height="709" alt="Highlighter disabled: 0.42s" src="https://github.com/user-attachments/assets/8632f4da-507f-4dda-81ec-802d393d93e5" />

I also tried to lazy-load the SyntaxHighlighter onScroll, but that makes the experience even more terrible. Instead of waiting an eternity post-load you get half a second of stuttering and erratic re-rendering in the middle of an otherwise smooth scroll - so I only went for an On/Off toggle without any "lazy" in-between option.

Yeah, it looks a bit duller, but at least we're not losing the line numbers and it does not affect the diff coloring either:
<img width="885" height="50" alt="image" src="https://github.com/user-attachments/assets/d3083d9f-015b-4d1c-a947-7147d4165f28" />
<img height="200" alt="image" src="https://github.com/user-attachments/assets/30d8c74b-4ca3-4d42-be0e-b97e0f2c2dfa" /> <img height="200" alt="image" src="https://github.com/user-attachments/assets/9407b961-5405-48d3-897a-6eebdb125a52" />
