### PR TITLE
[Needs testing] feat: optimize session loading, fix e2e tests, some minor fixes

### DIFF
--- a/e2e/reconnection.test.ts
+++ b/e2e/reconnection.test.ts
@@ -85,17 +85,16 @@ describe('Session Reconnection', () => {
       const client2 = await createTestClient({ url: server.wsUrl })
 
       try {
-        // Load the session
-        const response = await client2.send('session.load', { sessionId })
-
-        expect(response.type).toBe('session.state')
+        // Load the session (triggers REST fetch internally)
+        await client2.send('session.load', { sessionId })
 
         const session = client2.getSession()!
         expect(session.id).toBe(sessionId)
         expect(session.projectId).toBe(projectId)
 
-        // Should receive messages from previous interaction
-        const payload = response.payload as { session: SessionType; messages: MessageType[] }
+        // Wait for session.state event (triggered by REST fetch)
+        const stateEvent = await client2.waitFor('session.state', undefined, 5000)
+        const payload = stateEvent.payload as { session: SessionType; messages: MessageType[] }
         expect(payload.messages.length).toBeGreaterThan(0)
 
         // Should include the user message we sent
@@ -238,9 +237,12 @@ describe('Session Reconnection', () => {
       const client2 = await createTestClient({ url: server.wsUrl })
 
       try {
-        const response = await client2.send('session.load', { sessionId })
+        // Load session (triggers REST fetch internally)
+        await client2.send('session.load', { sessionId })
 
-        const payload = response.payload as { messages: MessageType[] }
+        // Wait for session.state event
+        const stateEvent = await client2.waitFor('session.state', undefined, 5000)
+        const payload = stateEvent.payload as { messages: MessageType[] }
 
         // Find assistant message with tool calls
         const assistantMessage = payload.messages.find(

--- a/e2e/session-name.test.ts
+++ b/e2e/session-name.test.ts
@@ -88,8 +88,10 @@ describe('Auto Session Name', () => {
       await client.waitFor('session.name_generated', undefined, 3_000)
 
       // Reload session to verify DB update
-      const reloaded = await client.send('session.load', { sessionId: session.id })
-      expect(reloaded.type).toBe('session.state')
+      await client.send('session.load', { sessionId: session.id })
+
+      // Wait for session.state event (triggered by REST fetch)
+      await client.waitFor('session.state', undefined, 5000)
 
       const updatedSession = client.getSession()!
       // Title should have been updated (either generated name or still default if generation failed)
@@ -111,21 +113,15 @@ describe('Auto Session Name', () => {
 
       await client.waitForChatDone(3_000)
 
-      await client2.waitFor(
-        'session.state',
-        (payload: unknown) => {
-          const sessionPayload = payload as { session: { metadata: { title?: string | null } } }
-          return Boolean(sessionPayload.session.metadata.title && sessionPayload.session.metadata.title !== 'Session 1')
-        },
-        3_000,
-      )
+      // Wait for session.name_generated event (which indicates title was updated)
+      await client2.waitFor('session.name_generated', undefined, 3_000)
 
-      // Verify session.state was broadcast with updated title
+      // Verify session.name_generated was broadcast
       const allEvents = client2.allEvents()
-      const sessionStateUpdates = allEvents.filter((msg) => msg.type === 'session.state')
+      const nameGeneratedEvents = allEvents.filter((msg) => msg.type === 'session.name_generated')
 
-      // At least one session.state should have been sent
-      expect(sessionStateUpdates.length).toBeGreaterThan(0)
+      // At least one session.name_generated should have been sent
+      expect(nameGeneratedEvents.length).toBeGreaterThan(0)
 
       await client2.close()
     })

--- a/e2e/utils/ws-client.ts
+++ b/e2e/utils/ws-client.ts
@@ -412,6 +412,74 @@ export async function createTestClient(options: TestClientOptions = {}): Promise
         }).then(() => ({ type: 'ack', id: crypto.randomUUID(), payload: {} }) as ServerMessage)
       }
 
+      // Handle session.load by setting active session and fetching from REST
+      if (type === 'session.load') {
+        return (async () => {
+          const { sessionId } = payload as { sessionId: string }
+          const httpUrl = url.replace('/ws', '').replace('ws://', 'http://')
+
+          // First, send the session.load message to the server (this triggers context.state)
+          const wsResponse = await new Promise<ServerMessage>((resolve, reject) => {
+            const id = crypto.randomUUID()
+            const message: ClientMessage = { id, type, payload }
+
+            const timeout = setTimeout(() => {
+              pendingRequests.delete(id)
+              reject(new Error(`Timeout waiting for response to session.load`))
+            }, 5000)
+
+            pendingRequests.set(id, {
+              resolve: (msg) => {
+                clearTimeout(timeout)
+                resolve(msg)
+              },
+              reject: (err) => {
+                clearTimeout(timeout)
+                reject(err)
+              },
+            })
+
+            ws.send(JSON.stringify(message))
+          })
+
+          // Then fetch session data from REST API
+          const res = await fetch(`${httpUrl}/api/sessions/${sessionId}`, {
+            method: 'GET',
+          })
+          const data = await res.json()
+
+          // Handle error response from REST API
+          if (!res.ok || data.error) {
+            return wsResponse // Return the error from WS
+          }
+
+          if (data.session) {
+            currentSession = data.session
+            // Trigger session.state event for tests that wait for it
+            const sessionStateMsg: ServerMessage = {
+              id: crypto.randomUUID(),
+              type: 'session.state',
+              payload: {
+                session: data.session,
+                messages: data.messages || [],
+                pendingConfirmations: data.pendingConfirmations || [],
+              },
+            }
+            events.push(sessionStateMsg)
+            // Resolve any waiters waiting for session.state
+            for (let i = eventWaiters.length - 1; i >= 0; i--) {
+              const waiter = eventWaiters[i]!
+              if (waiter.type === 'session.state') {
+                eventWaiters.splice(i, 1)
+                waiter.resolve(sessionStateMsg)
+              }
+            }
+          }
+
+          return wsResponse
+        })()
+      }
+
       return new Promise((resolve, reject) => {
         const id = crypto.randomUUID()
         const message: ClientMessage<T> = { id, type, payload }

--- a/package-lock.json
+++ b/package-lock.json
@@ -84,7 +84,8 @@
         "typescript": "^5.7.3",
         "typescript-eslint": "^8.57.2",
         "vite-plugin-pwa": "^1.2.0",
-        "vitest": "^4.1.2"
+        "vitest": "^4.1.2",
+        "vitest-localstorage-mock": "^0.1.2"
       },
       "engines": {
         "node": ">=24.0.0"
@@ -1218,9 +1219,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.0.tgz",
-      "integrity": "sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==",
+      "version": "7.29.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.4.tgz",
+      "integrity": "sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5551,9 +5552,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -7932,9 +7933,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -18611,6 +18612,16 @@
         }
       }
     },
+    "node_modules/vitest-localstorage-mock": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/vitest-localstorage-mock/-/vitest-localstorage-mock-0.1.2.tgz",
+      "integrity": "sha512-1oee6iDWhhquzVogssbpwQi6a2F3L+nCKF2+qqyCs5tH0sOYRyTqnsfj2dtmEQiL4xtJkHLn42hEjHGESlsJHw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "vitest": "*"
+      }
+    },
     "node_modules/vitest/node_modules/@vitest/expect": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
@@ -19812,9 +19823,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -129,7 +129,8 @@
     "typescript": "^5.7.3",
     "typescript-eslint": "^8.57.2",
     "vite-plugin-pwa": "^1.2.0",
-    "vitest": "^4.1.2"
+    "vitest": "^4.1.2",
+    "vitest-localstorage-mock": "^0.1.2"
   },
   "lint-staged": {
     "src/**/*.ts": [

--- a/src/server/db/sessions.ts
+++ b/src/server/db/sessions.ts
@@ -7,8 +7,6 @@
 
 import type { Session, SessionSummary, SessionMode, SessionPhase } from '../../shared/types.js'
 import { getDatabase } from './index.js'
-import { getEventStore } from '../events/store.js'
-
 export type DangerLevel = 'normal' | 'dangerous'
 
 function getProjectDangerLevel(projectId: string): DangerLevel {

--- a/src/server/db/sessions.ts
+++ b/src/server/db/sessions.ts
@@ -7,6 +7,7 @@
 
 import type { Session, SessionSummary, SessionMode, SessionPhase } from '../../shared/types.js'
 import { getDatabase } from './index.js'
+import { getEventStore } from '../events/store.js'
 
 export type DangerLevel = 'normal' | 'dangerous'
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -690,6 +690,28 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
   })
 
   // Settings endpoints (REST)
+  // Batch endpoint: GET /api/settings?keys=key1,key2,key3
+  app.get('/api/settings', async (req, res) => {
+    const { getSetting, SETTINGS_DEFAULTS } = await import('./db/settings.js')
+    const keysParam = req.query['keys'] as string
+    if (!keysParam) {
+      return res.status(400).json({ error: 'keys query parameter is required' })
+    }
+    const keys = keysParam.split(',').map((k) => k.trim())
+    const result: Record<string, string> = {}
+    for (const key of keys) {
+      result[key] = getSetting(key) ?? SETTINGS_DEFAULTS[key] ?? ''
+    }
+    res.json(result)
+  })
+
+  app.get('/api/settings/:key', async (req, res) => {
+    const { getSetting, SETTINGS_DEFAULTS } = await import('./db/settings.js')
+    const key = req.params.key
+    const value = getSetting(key) ?? SETTINGS_DEFAULTS[key] ?? null
+    res.json({ key, value })
+  })
+
   app.get('/api/settings/:key', async (req, res) => {
     const { getSetting, SETTINGS_DEFAULTS } = await import('./db/settings.js')
     const key = req.params.key

--- a/src/server/session/manager.test.ts
+++ b/src/server/session/manager.test.ts
@@ -16,6 +16,7 @@ vi.mock('../lsp/index.js', () => ({
 import { loadConfig } from '../config.js'
 import { closeDatabase, getDatabase, initDatabase } from '../db/index.js'
 import { createProject } from '../db/projects.js'
+import { getSession } from '../db/sessions.js'
 import { initEventStore } from '../events/index.js'
 import { SessionManager } from './manager.js'
 
@@ -115,6 +116,43 @@ describe('SessionManager', () => {
     expect(allEvents.filter((type) => type === 'session_updated').length).toBeGreaterThanOrEqual(2)
     expect(sessionEvents).toContain('mode_changed')
     expect(sessionEvents).toContain('phase_changed')
+  })
+
+  it('uses database is_running as source of truth for session state', () => {
+    const session = manager.createSession(projectId)
+
+    // Set running to true via manager
+    manager.setRunning(session.id, true)
+    let loadedSession = manager.getSession(session.id)
+    expect(loadedSession?.isRunning).toBe(true)
+
+    // Set running to false via manager
+    manager.setRunning(session.id, false)
+    loadedSession = manager.getSession(session.id)
+    expect(loadedSession?.isRunning).toBe(false)
+
+    // Verify database was actually updated
+    const dbSession = getSession(session.id)
+    expect(dbSession?.isRunning).toBe(false)
+  })
+
+  it('returns correct isRunning even when EventStore has stale data', () => {
+    const session = manager.createSession(projectId)
+
+    // Set running to true
+    manager.setRunning(session.id, true)
+    expect(manager.getSession(session.id)?.isRunning).toBe(true)
+
+    // Set running to false - this updates both DB and emits event
+    manager.setRunning(session.id, false)
+
+    // Verify DB has the correct value
+    const dbSession = getSession(session.id)
+    expect(dbSession?.isRunning).toBe(false)
+
+    // When loading session, should use DB value (false)
+    const loadedSession = manager.getSession(session.id)
+    expect(loadedSession?.isRunning).toBe(false)
   })
 
   it('adds messages and manages context windows during compaction', () => {

--- a/src/server/session/manager.ts
+++ b/src/server/session/manager.ts
@@ -977,12 +977,12 @@ export class SessionManager {
     const eventState = getSessionState(dbSession.id, maxTokens)
 
     if (!eventState) {
-      // No events yet - return defaults
+      // No events yet - return defaults from DB
       return {
         ...dbSession,
         mode: 'planner',
         phase: 'plan',
-        isRunning: false,
+        isRunning: dbSession.isRunning,
         messages: [],
         criteria: [],
         contextWindows: [],
@@ -1014,11 +1014,14 @@ export class SessionManager {
       return msg
     })
 
+    // Use database is_running as source of truth (more reliable than EventStore which may have missing events)
+    const isRunning = dbSession.isRunning
+
     return {
       ...dbSession,
       mode: eventState.mode,
       phase: eventState.phase,
-      isRunning: eventState.isRunning,
+      isRunning,
       messages,
       criteria: eventState.criteria,
       contextWindows: [], // Derived from events, not stored separately

--- a/src/server/ws/protocol.test.ts
+++ b/src/server/ws/protocol.test.ts
@@ -607,7 +607,7 @@ describe('ws/protocol', () => {
       })
       expect(converted[10]).toEqual({ type: 'session.running', payload: { isRunning: true } })
       expect(converted[11]).toEqual({ type: 'criteria.updated', payload: { criteria: [] } })
-      expect(converted[12]).toBeNull()
+      expect(converted[12]).toBeNull() // criterion.updated returns null
       expect(converted[13]).toEqual({
         type: 'context.state',
         payload: {

--- a/src/server/ws/protocol.ts
+++ b/src/server/ws/protocol.ts
@@ -473,29 +473,9 @@ export function storedEventToServerMessage(event: StoredEvent): ServerMessage | 
     }
 
     case 'session.initialized': {
-      const data = event.data as Extract<TurnEvent, { type: 'session.initialized' }>['data']
-      // Build minimal session object from initialization data
-      const session: Session = {
-        id: (event as StoredEvent).sessionId,
-        projectId: data.projectId,
-        workdir: data.workdir,
-        mode: 'planner',
-        phase: 'plan',
-        isRunning: false,
-        criteria: [],
-        summary: data.title || 'Untitled Session',
-        metadata: {
-          totalTokensUsed: 0,
-          totalToolCalls: 0,
-          iterationCount: 0,
-        },
-        createdAt: new Date(event.timestamp).toISOString(),
-        updatedAt: new Date(event.timestamp).toISOString(),
-        messages: [],
-        contextWindows: [],
-        executionState: null,
-      }
-      return createSessionStateMessage(session, [], [])
+      // Skip - session data should be loaded via REST API, not broadcast via WebSocket
+      // This prevents duplicate potentially multi-MB session.state messages on connection
+      return null
     }
 
     case 'mode.changed': {
@@ -520,8 +500,8 @@ export function storedEventToServerMessage(event: StoredEvent): ServerMessage | 
     }
 
     case 'context.state': {
-      const data = event.data as ContextState & { subAgentId?: string }
-      return createContextStateMessage(data, data.subAgentId)
+      const data = event.data as Extract<TurnEvent, { type: 'context.state' }>['data']
+      return createContextStateMessage(data)
     }
 
     case 'session.name_generated': {

--- a/src/server/ws/server.test.ts
+++ b/src/server/ws/server.test.ts
@@ -685,21 +685,17 @@ describe('createWebSocketServer', () => {
 
     harness.send({ id: 'sl-ok', type: 'session.load', payload: { sessionId: 'session-1' } })
     expect(await harness.nextMessage((message) => message.id === 'sl-ok')).toMatchObject({
-      type: 'session.state',
-      payload: { messages: [{ id: 'assistant-1', role: 'assistant', content: 'Hello' }] },
-    })
-    expect(await harness.nextMessage((message) => message.type === 'context.state')).toMatchObject({
-      type: 'context.state',
+      type: 'ack',
+      payload: { sessionId: 'session-1' },
     })
 
     // With pure event-sourcing, empty events = empty messages (no DB fallback)
     eventStore.getEvents.mockReturnValueOnce([])
     harness.send({ id: 'sl-db', type: 'session.load', payload: { sessionId: 'session-1' } })
     expect(await harness.nextMessage((message) => message.id === 'sl-db')).toMatchObject({
-      type: 'session.state',
-      payload: { messages: [] },
+      type: 'ack',
+      payload: { sessionId: 'session-1' },
     })
-    await harness.nextMessage((message) => message.type === 'context.state')
 
     harness.send({ id: 'slist-deprecated', type: 'session.list', payload: {} })
     expect(await harness.nextMessage((message) => message.id === 'slist-deprecated')).toMatchObject({
@@ -770,7 +766,6 @@ describe('createWebSocketServer', () => {
 
     harness.send({ id: 'sl-ok', type: 'session.load', payload: { sessionId: 'session-1' } })
     await harness.nextMessage((message) => message.id === 'sl-ok')
-    await harness.nextMessage((message) => message.type === 'context.state')
 
     harness.send({ id: 'chat-bad', type: 'chat.send', payload: {} })
     expect(await harness.nextMessage((message) => message.id === 'chat-bad')).toMatchObject({
@@ -861,7 +856,6 @@ describe('createWebSocketServer', () => {
 
     harness.send({ id: 'sl-ok', type: 'session.load', payload: { sessionId: 'session-1' } })
     await harness.nextMessage((message) => message.id === 'sl-ok')
-    await harness.nextMessage((message) => message.type === 'context.state')
 
     harness.send({ id: 'chat-ok', type: 'chat.send', payload: { content: 'Please continue' } })
     expect(await harness.nextMessage((message) => message.id === 'chat-ok')).toMatchObject({
@@ -1338,20 +1332,11 @@ describe('createWebSocketServer', () => {
 
     harness.send({ id: 'load-session-1', type: 'session.load', payload: { sessionId: 'session-1' } })
     await harness.nextMessage((message) => message.id === 'load-session-1')
-    await harness.nextMessage((message) => message.type === 'context.state' && message.sessionId === 'session-1')
 
     harness.send({ id: 'load-session-2', type: 'session.load', payload: { sessionId: 'session-2' } })
     expect(await harness.nextMessage((message) => message.id === 'load-session-2')).toMatchObject({
-      type: 'session.state',
-      sessionId: 'session-2',
-      payload: { session: { id: 'session-2' } },
-    })
-    expect(
-      await harness.nextMessage((message) => message.type === 'context.state' && message.sessionId === 'session-2'),
-    ).toMatchObject({
-      type: 'context.state',
-      sessionId: 'session-2',
-      payload: { context: { currentTokens: 22 } },
+      type: 'ack',
+      payload: { sessionId: 'session-2' },
     })
 
     harness.eventStore.append('session-1', {

--- a/src/server/ws/server.ts
+++ b/src/server/ws/server.ts
@@ -1,7 +1,8 @@
 import { WebSocketServer, WebSocket } from 'ws'
 import { spawn } from 'node:child_process'
 import type { Server } from 'node:http'
-import type { ServerMessage, GitDiffFile } from '../../shared/protocol.js'
+import type { ServerMessage } from '../../shared/protocol.js'
+import type { GitDiffFile } from '../../shared/protocol.js'
 import { createServerMessage } from '../../shared/protocol.js'
 import { handleTerminalMessage, unsubscribeAllFromTerminal } from './terminal.js'
 import type { Config } from '../config.js'
@@ -792,9 +793,10 @@ async function handleClientMessage(
       return
 
     // =========================================================================
-    // Session Load - Required for WS subscription mechanism
-    // Note: This is kept ONLY to set activeSessionId for event routing.
-    // For actual data loading, use REST API: GET /api/sessions/:id
+    // Session Load - Sets active session for event routing
+    // Note: Data loading is done via REST API: GET /api/sessions/:id
+    // This WebSocket message is ONLY to tell the server which session is active
+    // so it can route real-time events correctly.
     // =========================================================================
     case 'session.load': {
       if (!isSessionLoadPayload(message.payload)) {
@@ -808,40 +810,28 @@ async function handleClientMessage(
         return
       }
 
-      // Tab model: set active session and subscribe if not already subscribed
+      // Tab model: set active session for event routing
       client.activeSessionId = session.id
       client.activeWorkdir = session.workdir
-      if (session.workdir) moduleStartGitPolling(session.workdir)
-      ensureEventStoreSubscription(session.id)
 
-      // Fetch messages from EventStore
-      const eventStore = getEventStore()
-      const events = eventStore.getEvents(session.id)
-      const messages = buildMessagesFromStoredEvents(events)
-      const pendingConfirmations = foldPendingConfirmations(events)
-      logger.debug('Loaded messages from EventStore', {
-        sessionId: session.id,
-        eventCount: events.length,
-        messageCount: messages.length,
-        pendingConfirmationsCount: pendingConfirmations.length,
-      })
-
-      const initialGitStatus = (async () => {
-        if (!session.workdir) return undefined
+      // Send initial git status immediately
+      if (session.workdir) {
         const branch = await moduleGitBranch(session.workdir)
         const { files } = await moduleGitDiff(session.workdir)
-        return { branch, diff: { files } }
-      })()
-      const gitStatusPayload = await initialGitStatus
+        const msg = createGitStatusMessage(branch, files)
+        send(msg)
+        if (branch) moduleStartGitPolling(session.workdir)
+      }
 
-      sendForSession(
-        session.id,
-        createSessionStateMessage(session, messages, pendingConfirmations, gitStatusPayload, message.id),
-      )
+      ensureEventStoreSubscription(session.id)
 
-      // Send context state
+      // Send context.state immediately after session.load
       const contextState = sessionManager.getContextState(session.id)
-      sendForSession(session.id, createContextStateMessage(contextState))
+      send(createContextStateMessage(contextState))
+
+      // Acknowledge without sending full session data
+      // Frontend should use REST API to fetch session data
+      send({ type: 'ack', payload: { sessionId: session.id }, id: message.id })
       break
     }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -45,6 +45,7 @@ export interface Session {
   executionState: ExecutionState | null
   metadata: SessionMetadata
   dangerLevel?: DangerLevel // Controls path confirmation bypass
+  messageCount?: number // Cached message count for efficient sidebar display (optional, populated on load)
 }
 
 // ============================================================================

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
   test: {
     include: ['src/**/*.test.ts', 'web/src/**/*.test.ts', 'web/src/**/*.test.tsx'],
     exclude: ['e2e/**', 'node_modules/**'],
+    setupFiles: ['vitest-localstorage-mock'],
     env: {
       NODE_OPTIONS: '--localstorage-file=/tmp/openfox-test-localstorage.json',
     },

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -46,7 +46,6 @@ function ProjectView({ sidebarOpen, onSidebarToggle }: { sidebarOpen: boolean; o
 
   const connectionStatus = useSessionStore((state) => state.connectionStatus)
   const clearSession = useSessionStore((state) => state.clearSession)
-
   const currentProject = useProjectStore((state) => state.currentProject)
 
   const hasToken = hasStoredToken()
@@ -94,39 +93,24 @@ function ProjectSessionView({
 
   const connectionStatus = useSessionStore((state) => state.connectionStatus)
   const session = useSessionStore((state) => state.currentSession)
-  const loadSession = useSessionStore((state) => state.loadSession)
-  const listSessions = useSessionStore((state) => state.listSessions)
-  const pendingSessionCreate = useSessionStore((state) => state.pendingSessionCreate)
   const error = useSessionStore((state) => state.error)
   const clearError = useSessionStore((state) => state.clearError)
-
   const currentProject = useProjectStore((state) => state.currentProject)
-  const loadProject = useProjectStore((state) => state.loadProject)
 
   const hasToken = hasStoredToken()
   const canLoad = connectionStatus === 'connected' || hasToken
 
   useEffect(() => {
     if (canLoad && projectId && currentProject?.id !== projectId) {
-      loadProject(projectId)
+      useProjectStore.getState().loadProject(projectId)
     }
     if (canLoad && sessionId && session?.id !== sessionId) {
-      loadSession(sessionId)
+      useSessionStore.getState().loadSession(sessionId)
     }
     if (canLoad && projectId) {
-      listSessions(projectId)
+      useSessionStore.getState().listSessions(projectId)
     }
-  }, [
-    canLoad,
-    projectId,
-    currentProject?.id,
-    loadProject,
-    sessionId,
-    session?.id,
-    loadSession,
-    listSessions,
-    pendingSessionCreate,
-  ])
+  }, [canLoad, projectId, currentProject?.id, sessionId, session?.id])
 
   useEffect(() => {
     if (error?.code === 'NOT_FOUND' && projectId) {
@@ -168,7 +152,6 @@ function App() {
   const { connectionStatus } = useWebSocket()
   const fetchConfig = useConfigStore((state) => state.fetchConfig)
   const refreshProviderModels = useConfigStore((state) => state.refreshProviderModels)
-  const loadDisplaySettings = useSettingsStore((state) => state.getSetting)
   const providers = useConfigStore((state) => state.providers)
   const activeProviderId = useConfigStore((state) => state.activeProviderId)
   const [, navigate] = useLocation()
@@ -181,14 +164,13 @@ function App() {
     if (connectionStatus === 'connected' || hasToken) {
       fetchConfig().then(() => {
         setConfigFetched(true)
-        for (const key of DISPLAY_SETTINGS_KEYS) {
-          loadDisplaySettings(key)
-        }
-        loadDisplaySettings(SETTINGS_KEYS.DISPLAY_THEME)
-        loadDisplaySettings(SETTINGS_KEYS.DISPLAY_USER_PRESETS)
+        // Batch load all display settings in a single API call
+        useSettingsStore
+          .getState()
+          .getSettings([...DISPLAY_SETTINGS_KEYS, SETTINGS_KEYS.DISPLAY_THEME, SETTINGS_KEYS.DISPLAY_USER_PRESETS])
       })
     }
-  }, [connectionStatus, hasToken, fetchConfig, loadDisplaySettings])
+  }, [connectionStatus, hasToken, fetchConfig])
 
   useEffect(() => {
     if (configFetched && activeProviderId) {

--- a/web/src/lib/ws.ts
+++ b/web/src/lib/ws.ts
@@ -62,6 +62,14 @@ class WebSocketClient {
       return this.connectingPromise
     }
 
+    this.lastCloseCode = 0
+    this.isReconnecting = false
+
+    if (this.connectingPromise && this.ws?.readyState === WebSocket.CONNECTING) {
+      console.warn('[WS CLIENT] Connection already in progress, returning existing promise')
+      return this.connectingPromise
+    }
+
     this.connectingPromise = new Promise((resolve, reject) => {
       try {
         const url = this.getUrl()

--- a/web/src/stores/session.ts
+++ b/web/src/stores/session.ts
@@ -54,6 +54,12 @@ let wsUnsubscribe: (() => void) | null = null
 // Track which messageIds have already triggered the new_message sound
 const triggeredNewMessageSound = new Set<string>()
 
+// Track which sessions are currently being loaded to prevent duplicate API calls
+const loadingSessionIds = new Set<string>()
+
+// Track which projects are currently being listed to prevent duplicate API calls
+const listingSessionsForProject = new Map<string, Promise<void>>()
+
 // --- Streaming update batching ---
 // Buffer high-frequency streaming events and flush once per animation frame
 // to reduce renders from 50+/sec to ~16/sec during fast streaming.
@@ -115,6 +121,8 @@ function removeUnreadSessionId(unreadSessionIds: string[], sessionId: string): s
 
 function mergeSessionIntoSummary(sessions: SessionSummary[], session: Session): SessionSummary[] {
   const existingSession = sessions.find((candidate) => candidate.id === session.id)
+  // Use messageCount from session if available (corrected from EventStore), otherwise calculate from messages
+  const messageCount = session.messageCount ?? session.messages.length
   const nextSummary: SessionSummary = existingSession
     ? {
         ...existingSession,
@@ -123,7 +131,7 @@ function mergeSessionIntoSummary(sessions: SessionSummary[], session: Session): 
         mode: session.mode,
         phase: session.phase,
         isRunning: session.isRunning && existingSession.isRunning !== false,
-        messageCount: session.messages.length,
+        messageCount,
         criteriaCount: session.criteria.length,
         criteriaCompleted: session.criteria.filter((criterion) => criterion.status.type === 'passed').length,
       }
@@ -138,7 +146,7 @@ function mergeSessionIntoSummary(sessions: SessionSummary[], session: Session): 
         updatedAt: '',
         criteriaCount: session.criteria.length,
         criteriaCompleted: session.criteria.filter((criterion) => criterion.status.type === 'passed').length,
-        messageCount: session.messages.length,
+        messageCount,
       }
 
   return existingSession
@@ -634,6 +642,13 @@ export const useSessionStore = create<SessionState>((set, get) => {
     },
 
     loadSession: async (sessionId) => {
+      // Prevent duplicate loads for the same session
+      if (loadingSessionIds.has(sessionId)) {
+        return
+      }
+
+      loadingSessionIds.add(sessionId)
+
       try {
         const currentSession = get().currentSession
 
@@ -665,12 +680,12 @@ export const useSessionStore = create<SessionState>((set, get) => {
         const data = await res.json()
         set({
           currentSession: data.session,
-          messages: data.messages ?? [],
+          messages: (data.messages as Message[] | undefined) ?? [],
           contextState: data.contextState,
-          queuedMessages: data.queueState ?? [],
+          queuedMessages: (data.queueState as QueuedMessage[] | undefined) ?? [],
         })
 
-        // Tell WS server which session is active (required for chat.send routing)
+        // Tell WS server which session is active for event routing (no data returned)
         wsClient.send('session.load', { sessionId })
 
         // Fetch background processes for this session
@@ -685,26 +700,43 @@ export const useSessionStore = create<SessionState>((set, get) => {
         }
       } catch {
         // ignore
+      } finally {
+        loadingSessionIds.delete(sessionId)
       }
     },
 
     listSessions: async (projectId?: string, limit = 20) => {
-      try {
-        const params = new URLSearchParams()
-        params.set('limit', String(limit))
-        if (projectId) {
-          params.set('projectId', projectId)
-        }
-        const res = await authFetch(`/api/sessions?${params.toString()}`)
-        const data = await res.json()
-        const incoming = (data.sessions ?? []) as SessionSummary[]
-        set((state) => ({
-          sessions: mergeSessionList(incoming, state.sessions, state.currentSession),
-          sessionsHasMore: projectId ? (data.hasMore ?? false) : true,
-        }))
-      } catch {
-        // ignore
+      const cacheKey = projectId ?? 'global'
+
+      // Prevent duplicate list calls for the same project
+      if (listingSessionsForProject.has(cacheKey)) {
+        console.warn('[STORE] listSessions skipped (already listing):', cacheKey)
+        return listingSessionsForProject.get(cacheKey)
       }
+
+      const listPromise = (async () => {
+        try {
+          const params = new URLSearchParams()
+          params.set('limit', String(limit))
+          if (projectId) {
+            params.set('projectId', projectId)
+          }
+          const res = await authFetch(`/api/sessions?${params.toString()}`)
+          const data = await res.json()
+          const incoming = (data.sessions ?? []) as SessionSummary[]
+          set((state) => ({
+            sessions: mergeSessionList(incoming, state.sessions, state.currentSession),
+            sessionsHasMore: projectId ? (data.hasMore ?? false) : true,
+          }))
+        } catch {
+          // ignore
+        } finally {
+          listingSessionsForProject.delete(cacheKey)
+        }
+      })()
+
+      listingSessionsForProject.set(cacheKey, listPromise)
+      return listPromise
     },
 
     loadMoreSessions: async (projectId) => {
@@ -1188,7 +1220,7 @@ export const useSessionStore = create<SessionState>((set, get) => {
           const activeSessionId = get().currentSession?.id
           const isBackgroundSession = eventSessionId && eventSessionId !== activeSessionId
 
-          // Always update sidebar running status
+          // Always update sidebar running status (for background sessions too)
           set((state) => ({
             sessions: state.sessions.map((s) => (s.id === eventSessionId ? { ...s, isRunning: payload.isRunning } : s)),
           }))
@@ -1218,8 +1250,24 @@ export const useSessionStore = create<SessionState>((set, get) => {
             if (state.messages.some((m) => m.id === payload.message.id)) {
               return state
             }
+
+            // Only count user messages
+            const isUserMessage = payload.message.role === 'user'
+
+            console.warn('[Message Count] chat.message received:', {
+              messageId: payload.message.id,
+              role: payload.message.role,
+              isUserMessage,
+              willCount: isUserMessage,
+              currentCount: state.sessions.find((s) => s.id === message.sessionId)?.messageCount,
+            })
+
             return {
               messages: [...state.messages, payload.message],
+              // Update session message count in sidebar (only for user messages)
+              sessions: state.sessions.map((s) =>
+                s.id === message.sessionId && isUserMessage ? { ...s, messageCount: s.messageCount + 1 } : s,
+              ),
               // Track streaming message if it's marked as streaming
               streamingMessageId: payload.message.isStreaming ? payload.message.id : state.streamingMessageId,
               // Initialize separate streaming message for independent updates

--- a/web/src/stores/settings.ts
+++ b/web/src/stores/settings.ts
@@ -22,6 +22,7 @@ interface SettingsState {
 
   // Actions
   getSetting: (key: string) => Promise<string | null>
+  getSettings: (keys: string[]) => Promise<void>
   setSetting: (key: string, value: string) => Promise<void>
 }
 
@@ -71,6 +72,23 @@ export const useSettingsStore = create<SettingsState>((set) => ({
     } catch {
       set(setLoading(key, false))
       return null
+    }
+  },
+
+  getSettings: async (keys: string[]) => {
+    if (keys.length === 0) return
+    try {
+      const res = await authFetch(`/api/settings?keys=${encodeURIComponent(keys.join(','))}`)
+      const data = await res.json()
+      // Update all settings at once
+      set({
+        settings: data,
+        loading: Object.fromEntries(keys.map((k) => [k, false])),
+      })
+    } catch {
+      set({
+        loading: Object.fromEntries(keys.map((k) => [k, false])),
+      })
     }
   },
 

--- a/web/src/stores/theme.test.ts
+++ b/web/src/stores/theme.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { THEME_TOKENS, THEME_PRESETS, migrateLegacyThemeSetting, getPresetFromJson, useThemeStore } from './theme'
 
+beforeEach(() => {
+  localStorage.clear()
+})
+
 describe('Theme System', () => {
   describe('THEME_TOKENS', () => {
     it('has all required categories', () => {


### PR DESCRIPTION
- Eliminate double (and triple) session loading
  - down from 2x REST + 2x Websocket at session change and 3x at page reload → 1x REST + 1x tiny ACK via Websocket
- WebSocket session.load now sends only a single ACK (instead of 2 or 3 multi-MB responses with the full session data)
- Show git status immediately on session load (eliminate 10s delay)
- Fix message count accuracy in the left sidebar (count increasing when session selected was a side-effect of loading everything 2 or 3 times)
- Add batch settings API endpoint (7 individual network calls → 1 batched call)
- Fix spinner randomly spinning after page refresh (use database is_running, not EventStore)
- Update e2e tests to fetch session via REST API after session.load
- Add context.state emission on session.load for e2e tests
- Add vitest-localstorage-mock to fix "theme"-test related issues
- Fix 4 npm vulnerabilities (2 moderate, 2 high) via npm audit fix

All 1421 unit tests and 220 e2e tests pass, but this PR has became rather crowded again because it was all somewhat related. I wouldn't be surprised if this broke some obscure corner-cases so that's why WIP + needs testing.