### PR TITLE
fix: keybinding + theme loading, clean: mobile UI

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -153,10 +153,15 @@ function App() {
     if (connectionStatus === 'connected' || hasToken) {
       fetchConfig().then(() => {
         setConfigFetched(true)
-        // Batch load all display settings in a single API call
+        // Batch load all display settings and keybindings in a single API call
         useSettingsStore
           .getState()
-          .getSettings([...DISPLAY_SETTINGS_KEYS, SETTINGS_KEYS.DISPLAY_THEME, SETTINGS_KEYS.DISPLAY_USER_PRESETS])
+          .getSettings([
+            ...DISPLAY_SETTINGS_KEYS,
+            SETTINGS_KEYS.DISPLAY_THEME,
+            SETTINGS_KEYS.DISPLAY_USER_PRESETS,
+            SETTINGS_KEYS.KEYBINDINGS,
+          ])
       })
     }
   }, [connectionStatus, hasToken, fetchConfig])
@@ -210,20 +215,20 @@ function App() {
         applyPreset('dark')
       }
     } else {
-      applyPreset('dark')
+      // Default to system theme if nothing saved
+      applyPreset('system')
     }
 
     if (serverFollowSystem !== undefined) {
-      setFollowSystemTheme(serverFollowSystem === 'true')
+      const currentFollowSystem = useThemeStore.getState().followSystemTheme
+      if (currentFollowSystem !== (serverFollowSystem === 'true')) {
+        setFollowSystemTheme(serverFollowSystem === 'true')
+      }
     }
 
     const cleanup = initSystemThemeListener()
     return () => cleanup()
-  }, [
-    displaySettings[SETTINGS_KEYS.DISPLAY_THEME],
-    displaySettings[SETTINGS_KEYS.DISPLAY_USER_PRESETS],
-    displaySettings[SETTINGS_KEYS.DISPLAY_FOLLOW_SYSTEM_THEME],
-  ])
+  }, [displaySettings[SETTINGS_KEYS.DISPLAY_THEME], displaySettings[SETTINGS_KEYS.DISPLAY_USER_PRESETS]])
 
   const getInitialLeftSidebar = () => {
     const saved = localStorage.getItem('openfox:leftSidebar')

--- a/web/src/components/plan/MessageOptionsMenu.tsx
+++ b/web/src/components/plan/MessageOptionsMenu.tsx
@@ -13,8 +13,31 @@ interface MessageOptionsMenuProps {
 export function MessageOptionsMenu({ content, align = 'right', messageIndex, sessionId }: MessageOptionsMenuProps) {
   const [showMenu, setShowMenu] = useState(false)
   const [copied, setCopied] = useState(false)
+  const [menuPosition, setMenuPosition] = useState<'left' | 'right'>('left')
   const menuRef = useRef<HTMLDivElement>(null)
+  const buttonRef = useRef<HTMLButtonElement>(null)
   const loadSession = useSessionStore((s) => s.loadSession)
+
+  const isRightAligned = align === 'right'
+
+  const calculatePosition = (): 'left' | 'right' => {
+    if (!buttonRef.current) return 'left'
+    const buttonRect = buttonRef.current.getBoundingClientRect()
+    const spaceOnRight = window.innerWidth - buttonRect.right
+    const spaceOnLeft = buttonRect.left
+
+    // Get actual menu width from computed styles (min-w-36 = 144px, but can be wider based on content)
+    const menuElement = menuRef.current?.querySelector('[class*="absolute"]') as HTMLElement
+    const menuWidth = menuElement ? Math.max(menuElement.getBoundingClientRect().width, 144) : 144
+
+    const canFitOnRight = spaceOnRight >= menuWidth
+    const canFitOnLeft = spaceOnLeft >= menuWidth
+
+    if (canFitOnLeft && canFitOnRight) return 'left'
+    if (canFitOnLeft) return 'left'
+    if (canFitOnRight) return 'right'
+    return spaceOnLeft >= spaceOnRight ? 'left' : 'right'
+  }
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -60,8 +83,6 @@ export function MessageOptionsMenu({ content, align = 'right', messageIndex, ses
     loadSession(sessionId)
   }
 
-  const isRightAligned = align === 'right'
-
   return (
     <>
       <div className={`flex items-start gap-1.5 ${isRightAligned ? '' : 'order-first'}`}>
@@ -69,7 +90,13 @@ export function MessageOptionsMenu({ content, align = 'right', messageIndex, ses
 
         <div ref={menuRef} className="relative">
           <button
-            onClick={() => setShowMenu(!showMenu)}
+            ref={buttonRef}
+            onClick={() => {
+              if (!showMenu) {
+                setMenuPosition(calculatePosition())
+              }
+              setShowMenu(!showMenu)
+            }}
             className="p-1 rounded hover:bg-bg-tertiary text-text-muted hover:text-text-primary"
             title="Message options"
           >
@@ -78,7 +105,7 @@ export function MessageOptionsMenu({ content, align = 'right', messageIndex, ses
 
           {showMenu && (
             <div
-              className={`absolute top-full mt-1 bg-bg-secondary border border-border rounded shadow-xl z-50 py-1 min-w-36 ${isRightAligned ? 'right-0' : 'left-0'}`}
+              className={`absolute top-full mt-1 bg-bg-secondary border border-border rounded shadow-xl z-50 py-1 min-w-36 ${menuPosition === 'right' ? 'left-0' : 'right-0'}`}
             >
               <button
                 onClick={handleCopy}

--- a/web/src/components/plan/MoreMenu.tsx
+++ b/web/src/components/plan/MoreMenu.tsx
@@ -164,7 +164,7 @@ export function MoreMenu({
       </button>
 
       {isOpen && (
-        <div className="absolute bottom-full right-0 mb-1 w-80 bg-bg-secondary border border-border rounded-lg shadow-xl z-50">
+        <div className="absolute bottom-full right-0 mb-1 w-80 max-w-[calc(100vw-2rem)] bg-bg-secondary border border-border rounded-lg shadow-xl z-50 overflow-hidden">
           <div className="flex border-b border-border">
             <button
               type="button"

--- a/web/src/components/settings/GlobalSettingsModal.tsx
+++ b/web/src/components/settings/GlobalSettingsModal.tsx
@@ -4,9 +4,8 @@ import { NotificationSettings } from './NotificationSettings'
 import { SkillsContent } from './SkillsModal'
 import { InstructionsTab } from './tabs/InstructionsTab'
 import { DisplayTab } from './tabs/DisplayTab'
-import { KeybindingsTab } from './tabs/KeybindingsTab'
 import { AdvancedTab } from './tabs/AdvancedTab'
-import { wsClient } from '../../lib/ws'
+import { KeybindingsTab } from './tabs/KeybindingsTab'
 
 interface GlobalSettingsModalProps {
   isOpen: boolean
@@ -15,37 +14,14 @@ interface GlobalSettingsModalProps {
 
 type Tab = 'instructions' | 'skills' | 'notifications' | 'display' | 'keybindings' | 'advanced'
 
-function TabButton({ label, active, onClick }: { label: string; active: boolean; onClick: () => void }) {
-  return (
-    <button
-      onClick={onClick}
-      className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
-        active
-          ? 'border-accent-primary text-accent-primary'
-          : 'border-transparent text-text-muted hover:text-text-secondary hover:border-border'
-      }`}
-    >
-      {label}
-    </button>
-  )
-}
-
 export function GlobalSettingsModal({ isOpen, onClose }: GlobalSettingsModalProps) {
   const [activeTab, setActiveTab] = useState<Tab>('instructions')
 
-  const handleClose = () => {
-    try {
-      wsClient.send('context.checkDynamic', {})
-    } catch {
-      // WS might not be connected
-    }
-    onClose()
-  }
-
   return (
-    <Modal isOpen={isOpen} onClose={handleClose} title="Settings" size="xl" minHeight="500px">
+    <Modal isOpen={isOpen} onClose={onClose} title="Settings" size="xl" minHeight="500px">
       <div className="flex flex-col h-full">
-        <div className="flex border-b border-border mb-4 -mt-1">
+        {/* Tab bar - horizontally scrollable on mobile */}
+        <div className="flex border-b border-border mb-4 -mt-1 overflow-x-auto scrollbar-hide">
           <TabButton
             label="Instructions"
             active={activeTab === 'instructions'}
@@ -59,13 +35,14 @@ export function GlobalSettingsModal({ isOpen, onClose }: GlobalSettingsModalProp
           />
           <TabButton label="Display" active={activeTab === 'display'} onClick={() => setActiveTab('display')} />
           <TabButton
-            label="Shortcuts"
+            label="Keybindings"
             active={activeTab === 'keybindings'}
             onClick={() => setActiveTab('keybindings')}
           />
           <TabButton label="Advanced" active={activeTab === 'advanced'} onClick={() => setActiveTab('advanced')} />
         </div>
 
+        {/* Tab content */}
         {activeTab === 'instructions' && <InstructionsTab isOpen={isOpen} />}
         {activeTab === 'skills' && <SkillsContent isOpen={isOpen} />}
         {activeTab === 'notifications' && (
@@ -78,5 +55,20 @@ export function GlobalSettingsModal({ isOpen, onClose }: GlobalSettingsModalProp
         {activeTab === 'advanced' && <AdvancedTab onClose={onClose} />}
       </div>
     </Modal>
+  )
+}
+
+function TabButton({ label, active, onClick }: { label: string; active: boolean; onClick: () => void }) {
+  return (
+    <button
+      onClick={onClick}
+      className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors whitespace-nowrap ${
+        active
+          ? 'border-accent-primary text-accent-primary'
+          : 'border-transparent text-text-muted hover:text-text-secondary hover:border-border'
+      }`}
+    >
+      {label}
+    </button>
   )
 }

--- a/web/src/components/settings/NotificationSettings.tsx
+++ b/web/src/components/settings/NotificationSettings.tsx
@@ -211,8 +211,12 @@ function Toggle({
   onChange: (v: boolean) => void
 }) {
   return (
-    <label className="flex items-start gap-3 cursor-pointer group">
-      <div className="pt-0.5">
+    <label className="flex items-start justify-between gap-3 cursor-pointer group">
+      <div className="flex-1 min-w-0">
+        <div className="text-sm text-text-primary group-hover:text-accent-primary transition-colors">{label}</div>
+        <div className="text-xs text-text-muted mt-0.5">{description}</div>
+      </div>
+      <div className="flex-shrink-0 pt-0.5">
         <div
           className={`relative w-9 h-5 rounded-full transition-colors ${
             checked ? 'bg-accent-primary' : 'bg-bg-tertiary border border-border'
@@ -228,10 +232,6 @@ function Toggle({
             }`}
           />
         </div>
-      </div>
-      <div>
-        <div className="text-sm text-text-primary group-hover:text-accent-primary transition-colors">{label}</div>
-        <div className="text-xs text-text-muted">{description}</div>
       </div>
     </label>
   )

--- a/web/src/components/settings/ThemeEditor.tsx
+++ b/web/src/components/settings/ThemeEditor.tsx
@@ -125,7 +125,7 @@ function ThemeEditorModal({
         {Object.entries(groupedTokens).map(([category, tokens]) => (
           <div key={category} className="space-y-3">
             <h4 className="text-xs font-medium text-text-muted uppercase">{categoryLabels[category] ?? category}</h4>
-            <div className="grid grid-cols-2 gap-3">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
               {tokens.map((token) => (
                 <div key={token.key} className="flex flex-col gap-1">
                   <label htmlFor={token.key} className="text-xs text-text-muted">
@@ -137,13 +137,13 @@ function ThemeEditorModal({
                       id={token.key}
                       value={rgbToHex(localTokens[token.key] ?? token.defaultValue)}
                       onChange={(e) => handleTokenChange(token.key, e.target.value)}
-                      className="w-8 h-8 rounded cursor-pointer border border-border bg-transparent"
+                      className="w-8 h-8 rounded cursor-pointer border border-border bg-transparent flex-shrink-0"
                     />
                     <input
                       type="text"
                       value={localTokens[token.key] ?? token.defaultValue}
                       onChange={(e) => handleTokenChange(token.key, e.target.value)}
-                      className="flex-1 px-2 py-1 bg-bg-tertiary border border-border rounded text-xs text-text-primary font-mono focus:outline-none focus:ring-1 focus:ring-accent-primary"
+                      className="flex-1 min-w-0 px-2 py-1 bg-bg-tertiary border border-border rounded text-xs text-text-primary font-mono focus:outline-none focus:ring-1 focus:ring-accent-primary"
                     />
                   </div>
                 </div>
@@ -170,17 +170,22 @@ export function ThemeEditor() {
   const currentPreset = useThemeStore((state) => state.currentPreset)
   const isCustom = useThemeStore((state) => state.isCustom)
   const basePreset = useThemeStore((state) => state.basePreset)
-  const userPresets = useThemeStore((state) => state.userPresets)
   const applyPreset = useThemeStore((state) => state.applyPreset)
   const applyUserPreset = useThemeStore((state) => state.applyUserPreset)
   const deleteUserPreset = useThemeStore((state) => state.deleteUserPreset)
   const saveTheme = useThemeStore((state) => state.saveTheme)
-  const followSystemTheme = useThemeStore((state) => state.followSystemTheme)
-  const setFollowSystemTheme = useThemeStore((state) => state.setFollowSystemTheme)
+  const userPresets = useThemeStore((state) => state.userPresets)
 
   const handlePresetSelect = (presetId: string) => {
-    applyPreset(presetId)
-    saveTheme(JSON.stringify({ preset: presetId })).catch(() => {})
+    if (presetId === 'system') {
+      // System is a virtual theme - save it as "system" but apply the actual preset
+      applyPreset(presetId)
+      saveTheme(JSON.stringify({ preset: 'system' })).catch(() => {})
+    } else {
+      // For non-system themes, clear the system theme state
+      saveTheme(JSON.stringify({ preset: presetId })).catch(() => {})
+      applyPreset(presetId)
+    }
   }
 
   const handleUserPresetSelect = (index: number) => {
@@ -253,70 +258,68 @@ export function ThemeEditor() {
     deleteUserPreset(index)
   }
 
-  const activePresetId = isCustom ? basePreset : currentPreset
+  // Show System as active when basePreset is 'system', otherwise use currentPreset
+  const activePresetId = basePreset === 'system' ? 'system' : isCustom ? basePreset : currentPreset
 
   return (
     <div className="space-y-4">
       <h3 className="text-sm font-medium text-text-primary">Theme</h3>
 
-      <label className="flex items-center gap-3 cursor-pointer">
-        <button
-          type="button"
-          role="switch"
-          aria-checked={followSystemTheme}
-          onClick={() => setFollowSystemTheme(!followSystemTheme)}
-          className={`relative w-10 h-5 rounded-full transition-colors ${
-            followSystemTheme ? 'bg-accent-primary' : 'bg-bg-tertiary border border-border'
-          }`}
-        >
-          <span
-            className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-white transition-transform ${
-              followSystemTheme ? 'translate-x-5' : 'translate-x-0'
-            }`}
-          />
-        </button>
-        <span className="text-sm text-text-secondary">Follow system theme</span>
-      </label>
-
-      <div className="grid grid-cols-5 gap-2">
-        {THEME_PRESETS.map((preset) => (
-          <div key={preset.id} className="relative group">
-            <button
-              type="button"
-              onClick={() => handlePresetSelect(preset.id)}
-              className={`w-full flex flex-col items-center gap-2 px-3 py-3 rounded-lg border transition-colors ${
-                activePresetId === preset.id && !isCustom
-                  ? 'border-accent-primary bg-bg-tertiary text-text-primary'
-                  : 'border-border bg-bg-secondary text-text-muted hover:border-text-muted'
-              }`}
-            >
-              <div
-                className="w-8 h-8 rounded border flex items-center justify-center"
-                style={{
-                  backgroundColor: rgbToHex(preset.tokens['color-bg-primary'] ?? '#000'),
-                  borderColor: rgbToHex(preset.tokens['color-border'] ?? '#000'),
-                }}
+      <div className="flex flex-wrap gap-2 pb-2">
+        {THEME_PRESETS.map((preset) => {
+          // Only one theme can be active at a time
+          const isActive = preset.id === activePresetId && !isCustom
+          return (
+            <div key={preset.id} className="relative group">
+              <button
+                type="button"
+                onClick={() => handlePresetSelect(preset.id)}
+                className={`flex flex-col items-center gap-2 px-3 py-3 rounded-lg border transition-colors min-w-[80px] ${
+                  isActive
+                    ? 'border-accent-primary bg-bg-tertiary text-text-primary'
+                    : 'border-border bg-bg-secondary text-text-muted hover:border-text-muted'
+                }`}
               >
                 <div
-                  className="w-3 h-3 rounded-full"
-                  style={{ backgroundColor: rgbToHex(preset.tokens['color-text-primary'] ?? '#fff') }}
-                />
-              </div>
-              <span className="text-xs">{preset.name}</span>
-            </button>
-            <button
-              type="button"
-              onClick={(e) => {
-                e.stopPropagation()
-                handleNewFromPreset(preset.id)
-              }}
-              className="absolute top-1 right-1 w-6 h-6 rounded bg-bg-tertiary border border-border flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity z-10 hover:border-text-muted"
-              title="Create custom theme based on this"
-            >
-              <span className="text-xs">✎</span>
-            </button>
-          </div>
-        ))}
+                  className="w-8 h-8 rounded border flex items-center justify-center"
+                  style={{
+                    backgroundColor:
+                      preset.id === 'system' ? 'transparent' : rgbToHex(preset.tokens['color-bg-primary'] ?? '#000'),
+                    borderColor: rgbToHex(preset.tokens['color-border'] ?? '#000'),
+                  }}
+                >
+                  {preset.id === 'system' ? (
+                    <div
+                      className="w-4 h-4 rounded-full"
+                      style={{
+                        background: 'linear-gradient(135deg, #000 50%, #fff 50%)',
+                      }}
+                    />
+                  ) : (
+                    <div
+                      className="w-3 h-3 rounded-full"
+                      style={{ backgroundColor: rgbToHex(preset.tokens['color-text-primary'] ?? '#fff') }}
+                    />
+                  )}
+                </div>
+                <span className="text-xs">{preset.name}</span>
+              </button>
+              {preset.id !== 'system' && (
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    handleNewFromPreset(preset.id)
+                  }}
+                  className="absolute top-1 right-1 w-6 h-6 rounded bg-bg-tertiary border border-border flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity z-10 hover:border-text-muted"
+                  title="Create custom theme based on this"
+                >
+                  <span className="text-xs">✎</span>
+                </button>
+              )}
+            </div>
+          )
+        })}
       </div>
 
       {userPresets.length > 0 && (

--- a/web/src/components/settings/tabs/AdvancedTab.tsx
+++ b/web/src/components/settings/tabs/AdvancedTab.tsx
@@ -72,15 +72,17 @@ export function AdvancedTab({ onClose }: { onClose: () => void }) {
   return (
     <div className="space-y-6">
       <div>
-        <label className="flex items-center justify-between cursor-pointer">
-          <div className="flex-1 min-w-0 mr-3">
+        <label className="flex items-start justify-between gap-3 cursor-pointer">
+          <div className="flex-1 min-w-0">
             <div className="text-sm font-medium text-text-primary">Dynamic System Prompt</div>
             <div className="text-xs text-text-muted mt-0.5">
               Rebuild the system prompt on every turn. When disabled, changes are applied on demand via the context
               header for better cache performance.
             </div>
           </div>
-          <Toggle enabled={localToggles.dynamicPrompt} onClick={handleToggleDynamicSystemPrompt} />
+          <div className="flex-shrink-0">
+            <Toggle enabled={localToggles.dynamicPrompt} onClick={handleToggleDynamicSystemPrompt} />
+          </div>
         </label>
       </div>
       <hr className="border-border" />
@@ -95,14 +97,16 @@ export function AdvancedTab({ onClose }: { onClose: () => void }) {
       <hr className="border-border" />
       <div>
         <h3 className="text-sm font-medium text-text-primary mb-3">Integrations</h3>
-        <label className="flex items-center justify-between cursor-pointer">
-          <div>
+        <label className="flex items-start justify-between gap-3 cursor-pointer">
+          <div className="flex-1 min-w-0">
             <div className="text-sm text-text-primary">Show "Open in VSCode" links</div>
             <div className="text-xs text-text-muted mt-0.5">
               Display a link on file reads to open the file directly in VS Code.
             </div>
           </div>
-          <Toggle enabled={localToggles.openInEditor} onClick={handleToggleOpenInEditor} />
+          <div className="flex-shrink-0">
+            <Toggle enabled={localToggles.openInEditor} onClick={handleToggleOpenInEditor} />
+          </div>
         </label>
       </div>
       <hr className="border-border" />

--- a/web/src/components/settings/tabs/DisplayTab.tsx
+++ b/web/src/components/settings/tabs/DisplayTab.tsx
@@ -77,15 +77,15 @@ export function DisplayTab() {
         <h3 className="text-sm font-medium text-text-primary mb-4">Feed Display</h3>
         <div className="space-y-4">
           {toggles.map(({ key, label, description }) => (
-            <label key={key} className="flex items-center justify-between cursor-pointer">
-              <div>
-                <div className="text-sm text-text-primary">{label}</div>
-                <div className="text-xs text-text-muted">{description}</div>
+            <label key={key} className="flex items-start justify-between gap-3 cursor-pointer">
+              <div className="flex-1 min-w-0">
+                <div className="text-sm text-text-primary font-medium">{label}</div>
+                <div className="text-xs text-text-muted mt-0.5">{description}</div>
               </div>
               <button
                 type="button"
                 onClick={() => handleToggle(key)}
-                className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
+                className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors ${
                   local[key] ? 'bg-accent-primary' : 'bg-bg-tertiary'
                 }`}
               >

--- a/web/src/components/settings/tabs/KeybindingsTab.tsx
+++ b/web/src/components/settings/tabs/KeybindingsTab.tsx
@@ -114,15 +114,11 @@ function KeybindingRow({
 }
 
 export function KeybindingsTab() {
-  const { settings, loading, getSetting, setSetting } = useSettingsStoreState()
+  const { settings, loading, setSetting } = useSettingsStoreState()
   const raw = settings[SETTINGS_KEYS.KEYBINDINGS]
   const isLoading = loading[SETTINGS_KEYS.KEYBINDINGS] ?? false
   const config = parseKeybindings(raw)
   const [recording, setRecording] = useState<string | null>(null)
-
-  useEffect(() => {
-    getSetting(SETTINGS_KEYS.KEYBINDINGS)
-  }, [getSetting])
 
   const actions: Array<{ id: string; label: string; binding: KeyBinding }> = [
     { id: 'terminalToggle', label: 'Toggle Terminal', binding: config.terminalToggle },

--- a/web/src/stores/theme.ts
+++ b/web/src/stores/theme.ts
@@ -32,6 +32,13 @@ export interface ThemePreset {
 
 export const THEME_PRESETS: ThemePreset[] = [
   {
+    id: 'system',
+    name: 'System',
+    // System theme is virtual - it dynamically follows the OS preference
+    // and doesn't have its own tokens
+    tokens: {},
+  },
+  {
     id: 'dark',
     name: 'Dark',
     tokens: {
@@ -213,8 +220,24 @@ export const useThemeStore = create<ThemeState>((set, get) => ({
   applyPreset: (presetId: string) => {
     const preset = THEME_PRESETS.find((p) => p.id === presetId)
     if (preset) {
-      set({ currentPreset: presetId, basePreset: '', customTokens: {}, isCustom: false, isCustomizing: false })
-      get().applyTheme()
+      // System theme is virtual - set basePreset to 'system' to keep it selected in UI
+      // but apply the actual dark/light theme tokens
+      if (presetId === 'system') {
+        const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
+        const actualPreset = mediaQuery.matches ? 'dark' : 'light'
+        // Keep basePreset as 'system' for UI selection, use currentPreset for actual theme application
+        set({
+          basePreset: 'system',
+          currentPreset: actualPreset,
+          customTokens: {},
+          isCustom: false,
+          isCustomizing: false,
+        })
+        get().applyTheme()
+      } else {
+        set({ currentPreset: presetId, basePreset: '', customTokens: {}, isCustom: false, isCustomizing: false })
+        get().applyTheme()
+      }
     }
   },
 
@@ -323,8 +346,6 @@ export const useThemeStore = create<ThemeState>((set, get) => ({
       get().applyPreset(isDark ? 'dark' : 'light')
       get().saveTheme(JSON.stringify({ preset: isDark ? 'dark' : 'light' }))
     }
-
-    applySystemTheme(mediaQuery.matches)
 
     const handler = (e: MediaQueryListEvent) => applySystemTheme(e.matches)
     mediaQuery.addEventListener('change', handler)


### PR DESCRIPTION
**Fixes**
* Load the key bindings during page load (they were only loaded after opening Settings > Keybindings)
* Prevent system theme listener from overriding saved theme on page load (this essentially broke theme save-ability)

**UI improvements**
* Replace the system theme toggle/checkbox with a dedicated "System" theme
* Make the settings dialog and theme editor mobile friendly
  * Header nav side-scrollable
  * Fix checkboxes falling apart when viewport too narrow
  * Fix "Message options" popup disappearing out to the left when there's no room
* Unify all toggles/checkboxes to be on the right side of their labels 

  * Your variant had briefly flashing themes when the toggle was on but another theme was clicked which seemed rather confusing
* Fix System theme selection to not also select Dark/Light simultaneously
* Allow theme selectors to wrap into multiple lines
* Remove duplicate calls to /api/settings/display.followSystemTheme when switching themes

**Before**
<img width="250" alt="display 1 before" src="https://github.com/user-attachments/assets/b5aaf202-da74-4dc5-bfbd-263a8764e51b" /><img width="250" alt="display 2 before" src="https://github.com/user-attachments/assets/bf92b211-dc54-4719-8434-bee6039e99b6" />
<img width="250" alt="theme before" src="https://github.com/user-attachments/assets/1f285421-9de9-4f9d-aca9-4626582fb5f2" /> <img width="350" alt="menu before" src="https://github.com/user-attachments/assets/1ee9490a-c617-496e-be99-ce80716a80ef" />

**After**
<img width="250" alt="display after" src="https://github.com/user-attachments/assets/edf8ee6e-e57a-4d78-a052-1f0b77002ba7" /><img width="250" alt="theme after" src="https://github.com/user-attachments/assets/5d300b34-d50d-4ea9-9d38-7f1f4eae7e0f" />
<img width="350" alt="menu after" src="https://github.com/user-attachments/assets/6ab7a2d6-1a73-4f49-b56f-31d44df2a6bd" />
