### PR TITLE
Enhance toolbar button readability with background color

### DIFF
--- a/web/src/components/plan/ChatInput.tsx
+++ b/web/src/components/plan/ChatInput.tsx
@@ -283,7 +283,7 @@ export function ChatInput({
           <RunningIndicator />
         </div>
       )}
-      <div className="absolute -top-8 right-2 md:right-4 z-10 flex items-center gap-2">
+      <div className="absolute -top-8 right-2 md:right-4 z-10 flex items-center gap-2 px-3 py-1.5 rounded-lg bg-secondary/95 backdrop-blur-sm">
         <AutoScrollToggle
           isActive={isAutoScrollActive}
           onToggle={setAutoScroll}


### PR DESCRIPTION
The toolbar containing "Browse history" and "live"/"scroll to bottom"
buttons is positioned absolutely above the chat input. Without a
background, scrolling content passes behind it, making the text
unreadable.

Changes:
  - Add padding (px-3 py-1.5) and rounded corners (rounded-lg)
  - Add semi-transparent background (bg-secondary/95)
  - Add backdrop blur (backdrop-blur-sm) for a frosted-glass effect

This ensures the buttons remain legible regardless of what content
scrolls behind them.