### PR TITLE
feat: @-mention file autocomplete in chat input

### DIFF
--- a/src/server/chat/prompts.ts
+++ b/src/server/chat/prompts.ts
@@ -49,6 +49,10 @@ Platform: ${process.platform} (${process.arch})${modelLine}
 - If the current runtime reminder says build mode, focus on implementation, verification, and completing approved criteria.
 - Respect tool and permission constraints enforced by the server even if the conversation suggests otherwise.
 
+## FILE REFERENCES
+- The user may reference files or directories with an @ prefix, e.g. @src/index.ts or @web/components/.
+- These are paths relative to the working directory above. Strip the leading @ and resolve against the working directory — never treat an @-reference as an absolute path.
+
 ## IMPORTANT GUARDRAILS
 - NEVER delete/git checkout an already modified file: that would result in a data loss.
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -31,6 +31,7 @@ import { createWorkflowRoutes } from './routes/workflows.js'
 import { createDevServerRoutes } from './routes/dev-server.js'
 import { createTerminalRoutes } from './routes/terminals.js'
 import { createDirectoryRoutes } from './routes/directories.js'
+import { createFileSearchRoutes } from './routes/file-search.js'
 import { createAutoUpdateRoutes } from './routes/auto-update.js'
 import { devServerManager } from './dev-server/manager.js'
 import { getGlobalConfigDir } from '../cli/paths.js'
@@ -1538,6 +1539,7 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
   })
 
   app.use('/api/directories', createDirectoryRoutes())
+  app.use('/api/files', createFileSearchRoutes())
 
   // Serve static web UI
   const webDir = resolve(__dirname, '../../web')

--- a/src/server/routes/file-search.test.ts
+++ b/src/server/routes/file-search.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import express from 'express'
+import { mkdir, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { createFileSearchRoutes } from './file-search.js'
+
+describe('GET /api/files', () => {
+  let app: express.Express
+  let server: ReturnType<typeof app.listen>
+  let baseUrl: string
+  let testDir: string
+
+  beforeEach(async () => {
+    testDir = join(tmpdir(), `openfox-file-search-test-${Date.now()}`)
+    await mkdir(testDir, { recursive: true })
+    await mkdir(join(testDir, 'src'), { recursive: true })
+    await writeFile(join(testDir, 'README.md'), '# Test')
+    await writeFile(join(testDir, 'package.json'), '{}')
+    await writeFile(join(testDir, 'src', 'index.ts'), 'export {}')
+    await writeFile(join(testDir, 'src', 'utils.ts'), 'export {}')
+
+    app = express()
+    app.use('/api/files', createFileSearchRoutes())
+
+    return new Promise<void>((resolve) => {
+      server = app.listen(0, () => {
+        baseUrl = `http://localhost:${(server.address() as any).port}`
+        resolve()
+      })
+    })
+  })
+
+  afterEach(async () => {
+    server?.close()
+    await rm(testDir, { recursive: true, force: true })
+  })
+
+  it('returns files matching an exact filename', async () => {
+    const res = await fetch(`${baseUrl}/api/files?q=README.md&workdir=${encodeURIComponent(testDir)}`)
+    expect(res.status).toBe(200)
+    const results = (await res.json()) as Array<{ name: string; type: string; score: number }>
+    expect(results.length).toBeGreaterThan(0)
+    const first = results[0]!
+    expect(first.name).toBe('README.md')
+    expect(first.type).toBe('file')
+    expect(first.score).toBe(100)
+  })
+
+  it('returns files matching a partial name', async () => {
+    const res = await fetch(`${baseUrl}/api/files?q=package&workdir=${encodeURIComponent(testDir)}`)
+    expect(res.status).toBe(200)
+    const results = (await res.json()) as Array<{ name: string; score: number }>
+    expect(results.length).toBeGreaterThan(0)
+    const first = results[0]!
+    expect(first.name).toBe('package.json')
+    expect(first.score).toBeGreaterThanOrEqual(60)
+  })
+
+  it('returns directories with a higher score than files', async () => {
+    const res = await fetch(`${baseUrl}/api/files?q=src&workdir=${encodeURIComponent(testDir)}`)
+    expect(res.status).toBe(200)
+    const results = (await res.json()) as Array<{ name: string; type: string; score: number }>
+    expect(results.length).toBeGreaterThan(0)
+    const first = results[0]!
+    expect(first.name).toBe('src')
+    expect(first.type).toBe('directory')
+    expect(first.score).toBe(110)
+  })
+
+  it('returns empty array for non-matching query', async () => {
+    const res = await fetch(`${baseUrl}/api/files?q=nonexistent&workdir=${encodeURIComponent(testDir)}`)
+    expect(res.status).toBe(200)
+    const results = (await res.json()) as Array<unknown>
+    expect(results.length).toBe(0)
+  })
+
+  it('returns results for empty query so the user can navigate rather than type', async () => {
+    const res = await fetch(`${baseUrl}/api/files?q=&workdir=${encodeURIComponent(testDir)}`)
+    expect(res.status).toBe(200)
+    const results = (await res.json()) as Array<{ type: string; score: number }>
+    expect(results.length).toBeGreaterThan(0)
+  })
+
+  it('returns results sorted by score (highest first)', async () => {
+    const res = await fetch(`${baseUrl}/api/files?q=ts&workdir=${encodeURIComponent(testDir)}`)
+    expect(res.status).toBe(200)
+    const results = (await res.json()) as Array<{ score: number }>
+    expect(results.length).toBeGreaterThan(0)
+
+    for (let i = 1; i < results.length; i++) {
+      expect(results[i]!.score).toBeLessThanOrEqual(results[i - 1]!.score)
+    }
+  })
+
+  it('returns paths relative to workdir', async () => {
+    const res = await fetch(`${baseUrl}/api/files?q=index&workdir=${encodeURIComponent(testDir)}`)
+    expect(res.status).toBe(200)
+    const results = (await res.json()) as Array<{ path: string }>
+    expect(results.length).toBeGreaterThan(0)
+    const first = results[0]!
+    expect(first.path).toContain('src')
+    expect(first.path).toContain('index.ts')
+  })
+
+  it('ignores node_modules by default', async () => {
+    const nodeModulesDir = join(testDir, 'node_modules')
+    await mkdir(nodeModulesDir, { recursive: true })
+    await writeFile(join(nodeModulesDir, 'index.ts'), 'export {}')
+
+    const res = await fetch(`${baseUrl}/api/files?q=index&workdir=${encodeURIComponent(testDir)}`)
+    expect(res.status).toBe(200)
+    const results = (await res.json()) as Array<{ path: string }>
+
+    const nodeModulePaths = results.filter((r) => r.path.includes('node_modules'))
+    expect(nodeModulePaths.length).toBe(0)
+  })
+})

--- a/src/server/routes/file-search.ts
+++ b/src/server/routes/file-search.ts
@@ -1,0 +1,101 @@
+import { Router } from 'express'
+import fg from 'fast-glob'
+
+export function createFileSearchRoutes(): Router {
+  const router = Router()
+
+  router.get('/', async (req, res) => {
+    const query = (req.query['q'] as string) || ''
+    const workdir = (req.query['workdir'] as string) || process.cwd()
+
+    try {
+      const results = await searchFiles(query, workdir)
+      res.json(results)
+    } catch {
+      res.status(500).json({ error: 'File search failed' })
+    }
+  })
+
+  return router
+}
+
+interface FileSuggestion {
+  path: string
+  name: string
+  type: 'file' | 'directory'
+  score: number
+}
+
+async function searchFiles(query: string, workdir: string): Promise<FileSuggestion[]> {
+  const entries = await fg(['**/*'], {
+    cwd: workdir,
+    dot: true,
+    deep: 5,
+    onlyFiles: false,
+    ignore: [
+      '**/node_modules/**',
+      '**/.git/**',
+      '**/dist/**',
+      '**/.next/**',
+      '**/.cache/**',
+      '**/__pycache__/**',
+      '**/*.lock',
+      '**/.openfox/**',
+    ],
+    objectMode: true,
+  })
+
+  const scored: FileSuggestion[] = []
+
+  for (const entry of entries) {
+    const filePath = entry.path
+    let score = fuzzyScore(filePath, query)
+    if (score === 0) {
+      continue
+    }
+
+    const isDir = entry.dirent.isDirectory()
+    if (isDir) {
+      score += 10
+    }
+
+    scored.push({
+      path: filePath,
+      name: filePath.split('/').pop() || filePath,
+      type: isDir ? 'directory' : 'file',
+      score,
+    })
+  }
+
+  scored.sort((a, b) => b.score - a.score)
+
+  return scored.slice(0, 20)
+}
+
+function fuzzyScore(filePath: string, query: string): number {
+  if (!query) {
+    return 1
+  }
+  const fileName = filePath.split('/').pop() || filePath
+  const fileNameLower = fileName.toLowerCase()
+  const fullPathLower = filePath.toLowerCase()
+  const lowerQuery = query.toLowerCase()
+
+  if (fileNameLower === lowerQuery) {
+    return 100
+  }
+
+  if (fileNameLower.startsWith(lowerQuery)) {
+    return 80
+  }
+
+  if (fileNameLower.includes(lowerQuery)) {
+    return 60
+  }
+
+  if (fullPathLower.includes(lowerQuery)) {
+    return 40
+  }
+
+  return 0
+}

--- a/web/src/components/plan/ChatInput.tsx
+++ b/web/src/components/plan/ChatInput.tsx
@@ -15,6 +15,7 @@ import { QueuedMessages } from './QueuedMessages'
 import { AgentSelector } from './AgentSelector'
 import { DangerLevelSelector } from './DangerLevelSelector'
 import { ProviderSelector } from '../settings/ProviderSelector'
+import { AtMentionAutocomplete, type AtMentionAutocompleteHandle, type FileSuggestion } from '../shared/AtMentionAutocomplete'
 
 interface ChatInputProps {
   input: string
@@ -78,6 +79,8 @@ export function ChatInput({
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
   const prevLenRef = useRef(0)
+  const cursorPosRef = useRef(0)
+  const autocompleteRef = useRef<AtMentionAutocompleteHandle>(null)
 
   const isRunning = useIsRunning()
   const stopGeneration = useSessionStore((state) => state.stopGeneration)
@@ -85,6 +88,7 @@ export function ChatInput({
   const queuedMessages = useSessionStore((state) => state.queuedMessages)
   const restoredInput = useSessionStore((state) => state.restoredInput)
   const clearRestoredInput = useSessionStore((state) => state.clearRestoredInput)
+  const workdir = useSessionStore((state) => state.currentSession?.workdir)
 
   const { sendMessage } = useScrolledSend(setAutoScroll)
 
@@ -170,6 +174,9 @@ export function ChatInput({
   }
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (autocompleteRef.current?.handleKeyDown(e)) {
+      return
+    }
     if (showHistory) {
       switch (e.key) {
         case 'Enter': {
@@ -278,6 +285,38 @@ export function ChatInput({
     clearInput()
   }
 
+  const handleSelectFile = useCallback((suggestion: FileSuggestion, startIndex: number) => {
+    const isDirectory = suggestion.type === 'directory'
+    // Files get a trailing space (closes the popup); directories get a trailing
+    // slash so the query continues and the popup refetches the dir's contents.
+    const suffix = isDirectory ? '/' : ' '
+    const beforeCursor = input.slice(0, startIndex)
+    const afterCursor = input.slice(cursorPosRef.current)
+    const newText = `${beforeCursor}@${suggestion.path}${suffix}${afterCursor}`
+    setInput(newText)
+    const newCursorPos = startIndex + suggestion.path.length + 2
+    cursorPosRef.current = newCursorPos
+    if (textareaRef.current) {
+      textareaRef.current.selectionStart = newCursorPos
+      textareaRef.current.selectionEnd = newCursorPos
+      textareaRef.current.focus()
+    }
+  }, [input, setInput])
+
+  const handleInput = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setInput(e.target.value)
+    if (showHistory) closeHistory()
+    cursorPosRef.current = e.target.selectionStart
+  }, [setInput, showHistory, closeHistory])
+
+  const handleSelect = useCallback((e: React.MouseEvent<HTMLTextAreaElement>) => {
+    cursorPosRef.current = (e.target as HTMLTextAreaElement).selectionStart
+  }, [])
+
+  const handleKeyUp = useCallback((e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    cursorPosRef.current = e.currentTarget.selectionStart
+  }, [])
+
   return (
     <form onSubmit={handleSubmit} className="relative p-2 md:p-4 bg-secondary">
       {isRunning && (
@@ -352,21 +391,23 @@ export function ChatInput({
         onDragLeave={handleDragLeave}
         onDrop={handleDrop}
       >
-        <textarea
-          id={CHAT_TEXTAREA_ID}
-          ref={textareaRef}
-          value={input}
-          onChange={(e) => {
-            setInput(e.target.value)
-            if (showHistory) closeHistory()
-          }}
-          onKeyDown={handleKeyDown}
-          placeholder="What would you like to build?"
-          data-testid="chat-input-textarea"
-          className="flex-1 bg-transparent text-sm placeholder:text-text-muted resize-none overflow-y-auto focus:outline-none"
-          style={{ minHeight: '24px', maxHeight: '200px' }}
-          spellCheck={false}
-        />
+        <div className="relative flex-1 min-w-0">
+          <textarea
+            id={CHAT_TEXTAREA_ID}
+            ref={textareaRef}
+            value={input}
+            onChange={handleInput}
+            onKeyDown={handleKeyDown}
+            onSelect={handleSelect}
+            onKeyUp={handleKeyUp}
+            placeholder="What would you like to build?"
+            data-testid="chat-input-textarea"
+            className="w-full bg-transparent text-sm placeholder:text-text-muted resize-none overflow-y-auto focus:outline-none"
+            style={{ minHeight: '24px', maxHeight: '200px' }}
+            spellCheck={false}
+            />
+          <AtMentionAutocomplete ref={autocompleteRef} text={input} cursorPos={cursorPosRef.current} workdir={workdir} onSelect={handleSelectFile} />
+        </div>
         <div className="flex items-center self-center gap-1.5">
           {isRunning && (
             <button

--- a/web/src/components/shared/AtMentionAutocomplete.test.tsx
+++ b/web/src/components/shared/AtMentionAutocomplete.test.tsx
@@ -1,0 +1,243 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { createRoot } from 'react-dom/client'
+import { act, fireEvent, waitFor } from '@testing-library/react'
+import { AtMentionAutocomplete, type AtMentionAutocompleteHandle } from './AtMentionAutocomplete'
+import { authFetch } from '../../lib/api'
+
+vi.mock('../../lib/api', () => ({
+  authFetch: vi.fn(),
+}))
+
+const mockedAuthFetch = vi.mocked(authFetch)
+
+interface FileSuggestion {
+  path: string
+  name: string
+  type: 'file' | 'directory'
+  score: number
+}
+
+const SUGGESTIONS: FileSuggestion[] = [
+  { path: 'README.md', name: 'README.md', type: 'file', score: 1 },
+  { path: 'src/READMORE.ts', name: 'READMORE.ts', type: 'file', score: 0.8 },
+  { path: 'docs/READ', name: 'READ', type: 'directory', score: 0.5 },
+]
+
+function makeResponse(data: unknown): Response {
+  return { json: async () => data } as Response
+}
+
+function render(ui: React.ReactElement) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  act(() => {
+    root.render(ui)
+  })
+  return {
+    container,
+    rerender: (next: React.ReactElement) =>
+      act(() => {
+        root.render(next)
+      }),
+  }
+}
+
+function makeRef(): { current: AtMentionAutocompleteHandle | null } {
+  return { current: null }
+}
+
+function keyEvent(key: string): React.KeyboardEvent {
+  return { key, preventDefault: vi.fn() } as unknown as React.KeyboardEvent
+}
+
+async function waitForSuggestions(container: HTMLElement) {
+  await waitFor(() => {
+    expect(container.querySelector('li')).toBeTruthy()
+  })
+}
+
+describe('AtMentionAutocomplete', () => {
+  beforeEach(() => {
+    mockedAuthFetch.mockReset()
+    mockedAuthFetch.mockResolvedValue(makeResponse(SUGGESTIONS))
+    document.body.innerHTML = ''
+  })
+
+  it('renders nothing when there is no @ mention under the cursor', () => {
+    const { container } = render(
+      <AtMentionAutocomplete text="hello world" cursorPos={11} onSelect={vi.fn()} />,
+    )
+    expect(container.innerHTML).toBe('')
+    expect(mockedAuthFetch).not.toHaveBeenCalled()
+  })
+
+  it('renders nothing before the debounced fetch fires (suggestions empty, not loading)', () => {
+    const { container } = render(
+      <AtMentionAutocomplete text="@REA" cursorPos={4} onSelect={vi.fn()} />,
+    )
+    expect(container.querySelector('li')).toBeNull()
+  })
+
+  it('fetches suggestions for the query after the debounce and renders them', async () => {
+    const { container } = render(
+      <AtMentionAutocomplete text="@REA" cursorPos={4} onSelect={vi.fn()} />,
+    )
+    await waitForSuggestions(container)
+    expect(mockedAuthFetch).toHaveBeenCalledWith('/api/files?q=REA')
+    expect(container.textContent).toContain('README.md')
+    expect(container.textContent).toContain('src/READMORE.ts')
+    expect(container.textContent).toContain('docs/READ')
+  })
+
+  it('renders nothing when the fetch resolves with an empty list', async () => {
+    mockedAuthFetch.mockResolvedValue(makeResponse([]))
+    const { container } = render(
+      <AtMentionAutocomplete text="@REA" cursorPos={4} onSelect={vi.fn()} />,
+    )
+    await waitFor(() => {
+      expect(mockedAuthFetch).toHaveBeenCalledWith('/api/files?q=REA')
+    })
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(container.querySelector('li')).toBeNull()
+  })
+
+  it('calls onSelect with the suggestion and startIndex when a suggestion is clicked', async () => {
+    const onSelect = vi.fn()
+    const { container } = render(
+      <AtMentionAutocomplete text="@REA" cursorPos={4} onSelect={onSelect} />,
+    )
+    await waitForSuggestions(container)
+    const items = container.querySelectorAll('li')
+    fireEvent.click(items[1]!)
+    expect(onSelect).toHaveBeenCalledWith(SUGGESTIONS[1], 0)
+  })
+  it('passes the full directory suggestion when a directory is clicked', async () => {
+    const onSelect = vi.fn()
+    const { container } = render(
+      <AtMentionAutocomplete text="@REA" cursorPos={4} onSelect={onSelect} />,
+    )
+    await waitForSuggestions(container)
+    const items = container.querySelectorAll('li')
+    // docs/READ is a directory (index 2); the parent uses its type to navigate
+    fireEvent.click(items[2]!)
+    expect(onSelect).toHaveBeenCalledWith(SUGGESTIONS[2], 0)
+  })
+
+  it('keeps the popup open and refetches when the query is a directory path', async () => {
+    // After selecting the "src" directory, ChatInput inserts "@src/" with the cursor
+    // after the slash; the slash does not terminate the mention, so the popup must
+    // stay open and fetch the directory's contents.
+    mockedAuthFetch.mockResolvedValue(
+      makeResponse([
+        { path: 'src/index.ts', name: 'index.ts', type: 'file', score: 1 },
+        { path: 'src/components', name: 'components', type: 'directory', score: 1 },
+      ]),
+    )
+    const { container } = render(
+      <AtMentionAutocomplete text="@src/" cursorPos={5} onSelect={vi.fn()} />,
+    )
+    await waitForSuggestions(container)
+    expect(mockedAuthFetch).toHaveBeenCalledWith('/api/files?q=src%2F')
+    expect(container.textContent).toContain('src/index.ts')
+    expect(container.textContent).toContain('src/components')
+  })
+
+  it('clears suggestions on Escape via the imperative handle', async () => {
+    const ref = makeRef()
+    const { container } = render(
+      <AtMentionAutocomplete ref={ref} text="@REA" cursorPos={4} onSelect={vi.fn()} />,
+    )
+    await waitForSuggestions(container)
+    act(() => {
+      ref.current!.handleKeyDown(keyEvent('Escape'))
+    })
+    expect(container.querySelector('li')).toBeNull()
+  })
+
+  it('selects the highlighted (first) suggestion on Enter', async () => {
+    const ref = makeRef()
+    const onSelect = vi.fn()
+    render(
+      <AtMentionAutocomplete ref={ref} text="@REA" cursorPos={4} onSelect={onSelect} />,
+    )
+    await waitForSuggestions(document.body)
+    act(() => {
+      ref.current!.handleKeyDown(keyEvent('Enter'))
+    })
+    expect(onSelect).toHaveBeenCalledWith(SUGGESTIONS[0], 0)
+  })
+
+  it('moves selection down with ArrowDown and selects the second item on Enter', async () => {
+    const ref = makeRef()
+    const onSelect = vi.fn()
+    const { container } = render(
+      <AtMentionAutocomplete ref={ref} text="@REA" cursorPos={4} onSelect={onSelect} />,
+    )
+    await waitForSuggestions(container)
+    act(() => {
+      ref.current!.handleKeyDown(keyEvent('ArrowDown'))
+    })
+    // selectedIndexRef is synced via useEffect, so the ArrowDown must commit
+    // (re-render + effect flush) before Enter reads it — mirroring real ticks.
+    act(() => {
+      ref.current!.handleKeyDown(keyEvent('Enter'))
+    })
+    expect(onSelect).toHaveBeenCalledWith(SUGGESTIONS[1], 0)
+  })
+
+  it('clamps at the first item on ArrowUp (still selects the first on Enter)', async () => {
+    const ref = makeRef()
+    const onSelect = vi.fn()
+    const { container } = render(
+      <AtMentionAutocomplete ref={ref} text="@REA" cursorPos={4} onSelect={onSelect} />,
+    )
+    await waitForSuggestions(container)
+    act(() => {
+      ref.current!.handleKeyDown(keyEvent('ArrowUp'))
+      ref.current!.handleKeyDown(keyEvent('Enter'))
+    })
+    expect(onSelect).toHaveBeenCalledWith(SUGGESTIONS[0], 0)
+  })
+
+  it('does not call onSelect on Enter when there are no suggestions', async () => {
+    mockedAuthFetch.mockResolvedValue(makeResponse([]))
+    const ref = makeRef()
+    const onSelect = vi.fn()
+    render(
+      <AtMentionAutocomplete ref={ref} text="@REA" cursorPos={4} onSelect={onSelect} />,
+    )
+    await waitFor(() => expect(mockedAuthFetch).toHaveBeenCalled())
+    act(() => {
+      ref.current!.handleKeyDown(keyEvent('Enter'))
+    })
+    expect(onSelect).not.toHaveBeenCalled()
+  })
+
+  it('renders nothing and does not fetch when the cursor sits past a trailing space (post-selection state)', () => {
+    // Reproduces the contract that keeps the popup closed after ChatInput.handleSelectFile
+    // inserts "@README.md " and positions the cursor after the trailing space.
+    const { container } = render(
+      <AtMentionAutocomplete text="@README.md " cursorPos={11} onSelect={vi.fn()} />,
+    )
+    expect(container.querySelector('li')).toBeNull()
+    expect(mockedAuthFetch).not.toHaveBeenCalled()
+  })
+
+  it('refetches when the query grows on rerender', async () => {
+    const { container, rerender } = render(
+      <AtMentionAutocomplete text="@REA" cursorPos={4} onSelect={vi.fn()} />,
+    )
+    await waitForSuggestions(container)
+    mockedAuthFetch.mockResolvedValue(
+      makeResponse([{ path: 'README.md', name: 'README.md', type: 'file', score: 1 }]),
+    )
+    rerender(<AtMentionAutocomplete text="@READM" cursorPos={6} onSelect={vi.fn()} />)
+    await waitFor(() => {
+      expect(mockedAuthFetch).toHaveBeenCalledWith('/api/files?q=READM')
+    })
+  })
+})

--- a/web/src/components/shared/AtMentionAutocomplete.tsx
+++ b/web/src/components/shared/AtMentionAutocomplete.tsx
@@ -1,0 +1,188 @@
+import { useState, useRef, useEffect, useCallback, useImperativeHandle, forwardRef } from 'react'
+import { getAtMentionAtCursor } from '../../lib/atMention'
+import { authFetch } from '../../lib/api'
+import { Spinner } from '../shared/Spinner'
+import { FolderIcon } from '../shared/icons'
+
+interface FileSuggestion {
+  path: string
+  name: string
+  type: 'file' | 'directory'
+  score: number
+}
+
+interface AtMentionAutocompleteProps {
+  text: string
+  cursorPos: number
+  workdir?: string | null
+  onSelect: (suggestion: FileSuggestion, startIndex: number) => void
+}
+
+export interface AtMentionAutocompleteHandle {
+  handleKeyDown: (e: React.KeyboardEvent) => boolean
+}
+
+const AtMentionAutocomplete = forwardRef<AtMentionAutocompleteHandle, AtMentionAutocompleteProps>(
+  function AtMentionAutocomplete({ text, cursorPos, workdir, onSelect }, ref) {
+  const mention = getAtMentionAtCursor(text, cursorPos)
+  const [suggestions, setSuggestions] = useState<FileSuggestion[]>([])
+  const [loading, setLoading] = useState(false)
+  const [selectedIndex, setSelectedIndex] = useState(0)
+  const containerRef = useRef<HTMLDivElement>(null)
+  const itemsRef = useRef<(HTMLLIElement | null)[]>([])
+  const selectedIndexRef = useRef(0)
+  const suggestionsRef = useRef<FileSuggestion[]>([])
+
+  useEffect(() => {
+    selectedIndexRef.current = selectedIndex
+  }, [selectedIndex])
+
+  useEffect(() => {
+    suggestionsRef.current = suggestions
+  }, [suggestions])
+
+  useEffect(() => {
+    if (!mention) {
+      setSuggestions([])
+      return
+    }
+
+    const timeoutId = setTimeout(() => {
+      fetchSuggestions(mention.query)
+    }, 150)
+
+    return () => clearTimeout(timeoutId)
+  }, [mention?.query, workdir])
+
+  const fetchSuggestions = async (query: string) => {
+    setLoading(true)
+    try {
+      const params = new URLSearchParams({ q: query })
+      if (workdir) params.set('workdir', workdir)
+      const response = await authFetch(`/api/files?${params.toString()}`)
+      const data: FileSuggestion[] = await response.json()
+      setSuggestions(data)
+      setSelectedIndex(0)
+      selectedIndexRef.current = 0
+    } catch (err) {
+      console.error('File search failed:', err)
+      setSuggestions([])
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent): boolean => {
+      if (!mention) return false
+
+      switch (e.key) {
+        case 'ArrowDown':
+          e.preventDefault()
+          setSelectedIndex((i) => {
+            const next = Math.min(i + 1, suggestionsRef.current.length - 1)
+            if (itemsRef.current[next]) {
+              itemsRef.current[next]?.scrollIntoView({ block: 'nearest' })
+            }
+            return next
+          })
+          return true
+        case 'ArrowUp':
+          e.preventDefault()
+          setSelectedIndex((i) => {
+            const next = Math.max(i - 1, 0)
+            if (itemsRef.current[next]) {
+              itemsRef.current[next]?.scrollIntoView({ block: 'nearest' })
+            }
+            return next
+          })
+          return true
+        case 'Enter':
+        case 'Tab': {
+          const currentSuggestions = suggestionsRef.current
+          if (currentSuggestions[selectedIndexRef.current]) {
+            e.preventDefault()
+            onSelect(currentSuggestions[selectedIndexRef.current]!, mention.startIndex)
+            return true
+          }
+          return false
+        }
+        case 'Escape':
+          e.preventDefault()
+          setSuggestions([])
+          return true
+      }
+      return false
+    },
+    [mention, onSelect],
+  )
+
+  useImperativeHandle(ref, () => ({ handleKeyDown }), [handleKeyDown])
+
+  useEffect(() => {
+    if (!mention) return
+
+    const handleClick = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setSuggestions([])
+      }
+    }
+
+    document.addEventListener('mousedown', handleClick)
+    return () => document.removeEventListener('mousedown', handleClick)
+  }, [mention])
+
+  if (!mention) return null
+
+  if (loading) {
+    return (
+      <div className="absolute bottom-full left-0 right-0 mb-2 z-50">
+        <div className="bg-bg-secondary border border-border rounded-lg shadow-lg">
+          <div className="p-4 text-center">
+            <Spinner size="sm" />
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  if (suggestions.length === 0) return null
+
+  return (
+    <div ref={containerRef} className="absolute bottom-full left-0 right-0 mb-2 z-50">
+      <div className="bg-bg-secondary border border-border rounded-lg shadow-lg max-h-64 overflow-y-auto">
+        <ul className="py-1">
+          {suggestions.map((item, index) => (
+            <li
+              ref={(el) => {
+                itemsRef.current[index] = el
+              }}
+              key={item.path}
+              className={`px-3 py-2 cursor-pointer flex items-center gap-2 text-sm ${
+                index === selectedIndex
+                  ? 'bg-accent-primary/20 text-text-primary'
+                  : 'text-text-muted hover:bg-bg-tertiary'
+              }`}
+              onClick={() => {
+                if (mention) {
+                  onSelect(item, mention.startIndex)
+                }
+              }}
+            >
+              {item.type === 'directory' ? (
+                <FolderIcon className="w-4 h-4 shrink-0" />
+              ) : (
+                <span className="w-4 h-4 shrink-0" />
+              )}
+              <span className="truncate">{item.path}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  )
+  },
+)
+
+export { AtMentionAutocomplete }
+export type { FileSuggestion }

--- a/web/src/lib/atMention.test.ts
+++ b/web/src/lib/atMention.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest'
+import { getAtMentionAtCursor } from '../lib/atMention'
+
+describe('getAtMentionAtCursor', () => {
+  it('returns null when there is no @ in the text', () => {
+    expect(getAtMentionAtCursor('hello world', 11)).toBeNull()
+  })
+
+  it('returns null when @ is at the start but cursor is before it', () => {
+    expect(getAtMentionAtCursor('@file.ts', 0)).toBeNull()
+  })
+
+  it('returns query and startIndex for @ at the start of text', () => {
+    const result = getAtMentionAtCursor('@file.ts', 8)
+    expect(result).toEqual({ query: 'file.ts', startIndex: 0 })
+  })
+
+  it('returns query and startIndex for @ in the middle of text', () => {
+    const result = getAtMentionAtCursor('Read @file.ts', 13)
+    expect(result).toEqual({ query: 'file.ts', startIndex: 5 })
+  })
+
+  it('returns query and startIndex for @ on a new line', () => {
+    const result = getAtMentionAtCursor('Hello\n@file.ts', 14)
+    expect(result).toEqual({ query: 'file.ts', startIndex: 6 })
+  })
+
+  it('returns null when there is a space after @', () => {
+    const result = getAtMentionAtCursor('@ file.ts', 10)
+    expect(result).toBeNull()
+  })
+
+  it('returns null when there is a newline after @', () => {
+    const result = getAtMentionAtCursor('@\nfile.ts', 10)
+    expect(result).toBeNull()
+  })
+
+  it('returns null when there is a tab after @', () => {
+    const result = getAtMentionAtCursor('@\tfile.ts', 10)
+    expect(result).toBeNull()
+  })
+
+  it('returns query for just @', () => {
+    const result = getAtMentionAtCursor('@', 1)
+    expect(result).toEqual({ query: '', startIndex: 0 })
+  })
+
+  it('returns query for partial filename', () => {
+    const result = getAtMentionAtCursor('Read @src/index', 16)
+    expect(result).toEqual({ query: 'src/index', startIndex: 5 })
+  })
+
+  it('returns null when @ is after a newline but cursor is before it', () => {
+    const result = getAtMentionAtCursor('Hello\n@file.ts', 6)
+    expect(result).toBeNull()
+  })
+  it('returns null when the query has a trailing space (post-selection state)', () => {
+    // After selecting a file the input becomes "@README.md " with the cursor
+    // past the trailing space; the space in the query must close the popup.
+    const result = getAtMentionAtCursor('@README.md ', 11)
+    expect(result).toBeNull()
+  })
+
+  it('keeps a valid query when it contains a slash (directory navigation)', () => {
+    // After selecting a directory the input becomes "@src/" with the cursor after
+    // the slash; the slash must NOT terminate the mention, so the popup stays open.
+    const result = getAtMentionAtCursor('@src/', 5)
+    expect(result).toEqual({ query: 'src/', startIndex: 0 })
+  })
+
+  it('uses the last @ when multiple @ are present', () => {
+    const result = getAtMentionAtCursor('see @foo and @bar', 18)
+    expect(result).toEqual({ query: 'bar', startIndex: 13 })
+  })
+})

--- a/web/src/lib/atMention.ts
+++ b/web/src/lib/atMention.ts
@@ -1,0 +1,16 @@
+export function getAtMentionAtCursor(text: string, cursorPos: number): { query: string; startIndex: number } | null {
+  const beforeCursor = text.slice(0, cursorPos)
+  const lastAt = beforeCursor.lastIndexOf('@')
+
+  if (lastAt === -1) {
+    return null
+  }
+
+  const query = beforeCursor.slice(lastAt + 1)
+
+  if (query.includes(' ') || query.includes('\n') || query.includes('\t')) {
+    return null
+  }
+
+  return { query, startIndex: lastAt }
+}


### PR DESCRIPTION
Type `@` in the chat input to fuzzy-search project files and directories and insert their paths.

- Backend: GET /api/files (fast-glob + fuzzy scoring, scoped to the session workdir, recursive ignores for node_modules/dist/etc.)
- Frontend: autocomplete popup with keyboard nav, @-token parsing, and directory continuation (trailing slash).
- Prompt: a FILE REFERENCES section tells the model that @-references are paths relative to the working directory, so it stops resolving them as absolute paths.