### PR TITLE
fix: do not override explicit model with auto-detected model on startup

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -103,16 +103,18 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
       logger.info('Using configured LLM backend', { backend: getBackendDisplayName(backend) })
     }
 
+    const hasExplicitModel = !!config.defaultModelSelection
     const detected = await detectModel(config.llm.baseUrl)
-    if (detected) {
+    if (detected && !hasExplicitModel) {
       llmClient.setModel(detected)
       if (!useMock) {
         logger.info('Auto-detected LLM model', { model: detected, backend: getBackendDisplayName(backend) })
       }
-    } else {
-      if (!useMock) {
-        logger.warn('Could not auto-detect model, using config', { model: config.llm.model })
-      }
+    } else if (!detected && !useMock) {
+      logger.warn('Could not auto-detect model, using config', { model: config.llm.model })
+    }
+    if (hasExplicitModel && !useMock) {
+      logger.info('Using explicit model from config', { model: config.llm.model, defaultModelSelection: config.defaultModelSelection })
     }
 
     // Refetch models with context windows on startup


### PR DESCRIPTION
Fixes #35

## Problem

When a user has configured an explicit model via `defaultModelSelection` (e.g. `deepseek-v4-flash`), the server startup `initLLM()` function unconditionally calls `llmClient.setModel(detected)` with the first model returned by the provider's `/v1/models` endpoint.

Since models are returned in alphabetical order, `minimax-m3` (first alphabetically) silently overrides the user's configured model whenever the user's model ID comes later in the sort order.

## Propagation chain

1. **Server startup**: `initLLM()` calls `detectModel()` which takes `data[0]` → `"minimax-m3"`. Then `llmClient.setModel("minimax-m3")` overrides the global LLM client.
2. **Sub-agents reuse the same client**: The workflow executor passes the same `llmClient` to sub-agents (verifier, code_reviewer). No separate client is created per agent type.
3. **User-visible symptom**: During the `verify` and `code_review` workflow steps, the model shown in the UI switches to `minimax-m3` instead of the configured `deepseek-v4-flash`.

## Fix

In `initLLM()` in `src/server/index.ts`:
- Always call `detectModel()` for connectivity status reporting (llmStatus)
- Only call `llmClient.setModel(detected)` when no explicit `config.defaultModelSelection` is configured
- Log a clear info message when using the explicit model from config

## Testing

Verified manually: with `defaultModelSelection` set to `deepseek-v4-flash`, `/api/config` now returns `model: "deepseek-v4-flash"` and `llmStatus: "connected"`.

The model no longer switches to `minimax-m3` during workflow sub-agent execution.