### PR TITLE
Prevent backdrop click from closing ProviderModal and losing unsaved config

### DIFF
--- a/web/src/components/shared/ProviderModal.tsx
+++ b/web/src/components/shared/ProviderModal.tsx
@@ -606,12 +606,7 @@ export function ProviderModal({
   if (!isOpen) return null
 
   return (
-    <div
-      className="fixed inset-0 bg-black/60 flex items-center justify-center z-50"
-      onClick={(e) => {
-        if (e.target === e.currentTarget) onClose()
-      }}
-    >
+    <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50">
       <div className="bg-bg-secondary border border-border rounded-xl w-[640px] max-h-[85vh] overflow-y-auto shadow-2xl">
         {/* Header */}
         <div className="flex items-center justify-between px-6 py-4 border-b border-border">


### PR DESCRIPTION
Un clic sur l'overlay' (le fond noir en dehors de la fenêtre) fermait la modale et faisait perdre toute la configuration en cours de saisie.

Ce petit changement de confort retire le handler de clic sur le backdrop. On peut toujours fermer la modale via le bouton ×, le bouton Cancel ou la touche Escape.

**Changement** : 1 ligne supprimée (+1, -6), suppression du onClick sur la div overlay dans ProviderModal.tsx.