### PR TITLE
Allow image-only messages without text - sometimes a picture is worth a thousand tokens :)

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -701,11 +701,13 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
     }
 
     const { content, attachments, messageKind } = req.body
-    if (!content?.trim()) {
-      return res.status(400).json({ error: 'content is required' })
+    const hasContent = content?.trim()
+    const hasAttachments = Array.isArray(attachments) && attachments.length > 0
+    if (!hasContent && !hasAttachments) {
+      return res.status(400).json({ error: 'content or attachments is required' })
     }
 
-    sessionManager.queueMessage(sessionId, 'asap', content, attachments, messageKind)
+    sessionManager.queueMessage(sessionId, 'asap', content ?? '', attachments, messageKind)
 
     res.json({ success: true, queueState: sessionManager.getQueueState(sessionId) })
   })

--- a/web/src/components/plan/ChatMessage.tsx
+++ b/web/src/components/plan/ChatMessage.tsx
@@ -26,6 +26,8 @@ function UserMessage({ message, messageId, sessionId }: UserMessageProps) {
   const isAutoPrompt = message.messageKind === 'auto-prompt'
   const isCommand = message.messageKind === 'command'
   const isSystemGenerated = message.isSystemGenerated
+  const hasAttachments = message.attachments && message.attachments.length > 0
+  const hasContent = message.content.trim().length > 0
 
   return (
     <div className="flex justify-end items-start gap-1.5 feed-item">
@@ -62,6 +64,9 @@ function UserMessage({ message, messageId, sessionId }: UserMessageProps) {
         >
           {message.content}
         </div>
+        {hasAttachments && (
+          <div className="text-xs text-text-muted mt-1">{hasContent ? 'Image attached' : 'Image uploaded'}</div>
+        )}
         {message.attachments && message.attachments.length > 0 && (
           <MessageAttachments attachments={message.attachments} messageId={message.id} />
         )}

--- a/web/src/components/plan/MessageSearchModal.tsx
+++ b/web/src/components/plan/MessageSearchModal.tsx
@@ -125,8 +125,11 @@ export function getItemLabel(item: DisplayItem): string {
       if (msg.thinkingContent?.trim()) return msg.thinkingContent.slice(0, 200)
       return ''
     }
-    const preview = cleanContent.slice(0, 200)
-    return preview.length < cleanContent.length ? `${preview}...` : preview
+    const preview = cleanContent.slice(0, 180)
+    const hasAttachments = msg.attachments && msg.attachments.length > 0
+    const attachmentLabel = hasAttachments ? (cleanContent ? '[Image attached]' : '[Image uploaded]') : ''
+    const suffix = preview.length < cleanContent.length ? '...' : ''
+    return attachmentLabel ? `${preview}${suffix} ${attachmentLabel}` : `${preview}${suffix}`
   }
   if (item.type === 'subagent') return `Sub-agent: ${item.subAgentType}`
   return ''

--- a/web/src/stores/session/store.ts
+++ b/web/src/stores/session/store.ts
@@ -480,10 +480,23 @@ export const useSessionStore = create<SessionState>((set, get) => {
       if (!sessionId) return
 
       try {
+        const hasContent = content?.trim()
+        const hasAttachments = attachments && attachments.length > 0
+        const body: Record<string, unknown> = {}
+        if (hasContent) {
+          body.content = content
+        }
+        if (hasAttachments) {
+          body.attachments = attachments
+        }
+        if (opts?.messageKind) {
+          body.messageKind = opts.messageKind
+        }
+
         const res = await authFetch(`/api/sessions/${sessionId}/message`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ content, attachments, messageKind: opts?.messageKind }),
+          body: JSON.stringify(body),
         })
         const data = await res.json()
         if (data.queueState) {


### PR DESCRIPTION
## Changes
- Allow sending messages with only image attachments (no text required)
- Show 'Image uploaded' indicator for image-only messages
- Show 'Image attached' indicator for messages with both text and images
- Timeline search now displays attachment indicators

## Technical Details
- Server validates content OR attachments instead of requiring content
- Frontend sends only present fields in the request body
- ChatMessage component shows appropriate indicator based on content/attachments