### PR TITLE
fix: word-breaking for long text + logout redirect to home

### DIFF
--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -21,13 +21,13 @@ export function Header({ onMenuClick, onCriteriaToggle }: HeaderProps) {
   const [showSettings, setShowSettings] = useState(false)
   const [sessionDropdownOpen, setSessionDropdownOpen] = useState(false)
   const [isFullscreen, setIsFullscreen] = useState(!!document.fullscreenElement)
+  const [location, setLocation] = useLocation()
 
   useEffect(() => {
     const onChange = () => setIsFullscreen(!!document.fullscreenElement)
     document.addEventListener('fullscreenchange', onChange)
     return () => document.removeEventListener('fullscreenchange', onChange)
   }, [])
-  const [location] = useLocation()
   const isProjectPage = location.startsWith('/p/')
   const isSessionPage = /^\/p\/[^/]+\/s\/[^/]+$/.test(location)
   const session = useSessionStore((state) => state.currentSession)
@@ -155,7 +155,7 @@ export function Header({ onMenuClick, onCriteriaToggle }: HeaderProps) {
         <button
           onClick={() => {
             localStorage.removeItem('openfox_token')
-            window.location.reload()
+            setLocation('/')
           }}
           className="p-2.5 rounded hover:bg-bg-tertiary text-text-muted hover:text-text-primary transition-colors"
           title="Logout"

--- a/web/src/components/plan/AutoPromptCard.tsx
+++ b/web/src/components/plan/AutoPromptCard.tsx
@@ -57,10 +57,10 @@ export function AutoPromptCard({ message }: AutoPromptCardProps) {
       {showContentDirectly && (
         <div className="flex justify-center feed-item mb-4">
           <div
-            className="max-w-[75%] rounded p-3 bg-bg-tertiary/50 text-text-secondary text-sm"
+            className="max-w-[75%] rounded p-3 bg-bg-tertiary/50 text-text-secondary text-sm overflow-x-auto"
             style={{ borderLeft: `3px solid ${metaColor}` }}
           >
-            <pre className="whitespace-pre-wrap font-mono text-xs">{message.content}</pre>
+            <pre className="whitespace-pre-wrap break-words font-mono text-xs">{message.content}</pre>
           </div>
         </div>
       )}
@@ -74,7 +74,7 @@ export function AutoPromptCard({ message }: AutoPromptCardProps) {
           </div>
 
           <div className="h-full min-h-96">
-            <pre className="text-sm text-text-secondary whitespace-pre-wrap bg-bg-tertiary rounded p-4 h-full min-h-96 overflow-auto font-mono">
+            <pre className="text-sm text-text-secondary whitespace-pre-wrap break-words bg-bg-tertiary rounded p-4 h-full min-h-96 overflow-auto font-mono">
               {message.content}
             </pre>
           </div>

--- a/web/src/components/plan/ChatMessage.tsx
+++ b/web/src/components/plan/ChatMessage.tsx
@@ -54,7 +54,7 @@ function UserMessage({ message, messageId, sessionId }: UserMessageProps) {
           </span>
         )}
         <div
-          className={`whitespace-pre-wrap text-sm ${
+          className={`whitespace-pre-wrap break-words text-sm ${
             isSystemGenerated
               ? `${isCommand ? 'text-teal-200' : isAutoPrompt ? 'text-slate-200' : 'text-amber-200 italic'}`
               : ''
@@ -101,7 +101,7 @@ export const ChatMessage = memo(function ChatMessage({
     return (
       <div className="feed-item bg-bg-tertiary/30 border-l-2 border-accent-primary rounded-r p-2">
         <div className="text-accent-primary text-xs mb-0.5">Tool: {message.toolName}</div>
-        <pre className="text-text-secondary text-xs whitespace-pre-wrap overflow-x-auto max-h-32">
+        <pre className="text-text-secondary text-xs whitespace-pre-wrap break-words overflow-x-auto max-h-32">
           {message.content.slice(0, 500)}
           {message.content.length > 500 && '...'}
         </pre>
@@ -151,7 +151,7 @@ export const ChatMessage = memo(function ChatMessage({
       <div className="flex justify-end feed-item">
         <div className="max-w-[75%] rounded p-2 bg-amber-500/10 border border-amber-500/30">
           <span className="text-[10px] block mb-0.5 text-amber-400">System</span>
-          <div className="whitespace-pre-wrap text-sm text-amber-200 italic">{message.content}</div>
+          <div className="whitespace-pre-wrap break-words text-sm text-amber-200 italic">{message.content}</div>
         </div>
       </div>
     )

--- a/web/src/components/shared/Markdown.tsx
+++ b/web/src/components/shared/Markdown.tsx
@@ -92,7 +92,7 @@ function createMarkdownComponents(muted: boolean, showSyntaxHighlighting: boolea
 
     p({ children }: { children?: React.ReactNode }) {
       const color = muted ? 'text-text-muted' : 'text-text-primary'
-      return <p className={`${color} mb-1.5 last:mb-0 leading-tight`}>{children}</p>
+      return <p className={`${color} mb-1.5 last:mb-0 leading-tight break-words`}>{children}</p>
     },
 
     ul({ children }: { children?: React.ReactNode }) {

--- a/web/src/components/shared/ThinkingBlock.tsx
+++ b/web/src/components/shared/ThinkingBlock.tsx
@@ -11,7 +11,7 @@ export const ThinkingBlock = memo(function ThinkingBlock({ content, variant = 'd
     return (
       <div className="text-text-muted text-sm italic feed-item">
         <span className="text-purple-400">thinking:</span>
-        <div className="ml-1.5 mt-0.5">
+        <div className="ml-1.5 mt-0.5 overflow-x-auto">
           <Markdown content={content} />
         </div>
       </div>
@@ -19,7 +19,7 @@ export const ThinkingBlock = memo(function ThinkingBlock({ content, variant = 'd
   }
 
   return (
-    <div className="text-text-muted text-sm italic bg-secondary rounded p-1.5 feed-item">
+    <div className="text-text-muted text-sm italic bg-secondary rounded p-1.5 feed-item overflow-x-auto">
       <Markdown content={content} muted />
     </div>
   )

--- a/web/src/components/shared/ToolCallDisplay.tsx
+++ b/web/src/components/shared/ToolCallDisplay.tsx
@@ -212,7 +212,9 @@ export const ToolCallDisplay = memo(function ToolCallDisplay({
               <>
                 <div>
                   <div className="text-[10px] text-text-muted mb-0.5">Arguments:</div>
-                  <pre className="text-xs bg-bg-primary p-1.5 rounded overflow-x-auto">{formatToolArgsFull(args)}</pre>
+                  <pre className="text-xs bg-bg-primary p-1.5 rounded overflow-x-auto break-words">
+                    {formatToolArgsFull(args)}
+                  </pre>
                 </div>
 
                 {/* Show result for non-specialized operations */}
@@ -221,7 +223,7 @@ export const ToolCallDisplay = memo(function ToolCallDisplay({
                     <div className="text-[10px] text-text-muted mb-0.5">
                       Result{durationMs !== undefined && ` (${durationMs}ms)`}:
                     </div>
-                    <pre className="text-xs bg-bg-primary p-1.5 rounded overflow-x-auto max-h-32">
+                    <pre className="text-xs bg-bg-primary p-1.5 rounded overflow-x-auto max-h-32 break-words">
                       {result || 'No output'}
                     </pre>
                   </div>
@@ -252,7 +254,7 @@ export const ToolCallDisplay = memo(function ToolCallDisplay({
           {status === 'error' && error && tool !== 'run_command' && (
             <div>
               <div className="text-[10px] text-accent-error mb-0.5">Error:</div>
-              <pre className="text-xs bg-bg-primary p-1.5 rounded text-accent-error">{error}</pre>
+              <pre className="text-xs bg-bg-primary p-1.5 rounded text-accent-error break-words">{error}</pre>
             </div>
           )}
         </div>


### PR DESCRIPTION
- Added break-words to user messages, tool messages, correction messages
- Added overflow-x-auto to thinking blocks
- Added break-words to auto-prompt cards, tool call arguments/results/errors
- Added break-words to markdown paragraphs
- Fixed logout button to redirect to home page after clearing token