### PR TITLE
feat: add session search bar on homepage

### DIFF
--- a/web/src/components/HomePage.test.tsx
+++ b/web/src/components/HomePage.test.tsx
@@ -158,7 +158,7 @@ describe('HomePage', () => {
       expect(screen.getByText('1 match')).toBeInTheDocument()
     })
 
-    expect(screen.getByRole('link', { name: /Session a l/ })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /Session alpha/ })).toBeInTheDocument()
     expect(screen.queryByRole('link', { name: /Session b/ })).not.toBeInTheDocument()
   })
 
@@ -266,5 +266,173 @@ describe('HomePage', () => {
     await vi.waitFor(() => {
       expect(screen.getByText('My session')).toBeInTheDocument()
     })
+  })
+
+  it('filters by project name', async () => {
+    sessionStore.sessions = [
+      { id: 's1', projectId: 'p1', title: 'Setup docs', updatedAt: '2024-06-15T10:00:00Z', messageCount: 1, createdAt: '2024-06-15T09:00:00Z' },
+      { id: 's2', projectId: 'p2', title: 'Analysis', updatedAt: '2024-06-16T10:00:00Z', messageCount: 1, createdAt: '2024-06-16T09:00:00Z' },
+    ]
+    const { HomePage } = await import('./HomePage')
+    render(<HomePage />)
+    const input = screen.getByPlaceholderText('Search sessions by title or keyword...')
+    await userEvent.type(input, 'beta')
+    await vi.waitFor(() => expect(screen.getByText('1 match')).toBeInTheDocument())
+    expect(screen.getByText('Project Beta')).toBeInTheDocument()
+    expect(screen.queryByText('Setup docs')).not.toBeInTheDocument()
+  })
+
+  it('filters by case-insensitive matching', async () => {
+    sessionStore.sessions = [
+      { id: 's1', projectId: 'p1', title: 'Deploy Pipeline', updatedAt: '2024-06-15T10:00:00Z', messageCount: 1, createdAt: '2024-06-15T09:00:00Z' },
+      { id: 's2', projectId: 'p1', title: 'Database migration', updatedAt: '2024-06-16T10:00:00Z', messageCount: 1, createdAt: '2024-06-16T09:00:00Z' },
+    ]
+    const { HomePage } = await import('./HomePage')
+    render(<HomePage />)
+    const input = screen.getByPlaceholderText('Search sessions by title or keyword...')
+    await userEvent.type(input, 'DEPLOY')
+    await vi.waitFor(() => expect(screen.getByText('1 match')).toBeInTheDocument())
+    expect(screen.getByRole('link', { name: /Deploy Pipeline/ })).toBeInTheDocument()
+  })
+
+  it('requires all space-separated query words to match', async () => {
+    sessionStore.sessions = [
+      { id: 's1', projectId: 'p1', title: 'Fix bug open frontend', updatedAt: '2024-06-15T10:00:00Z', messageCount: 1, createdAt: '2024-06-15T09:00:00Z' },
+      { id: 's2', projectId: 'p1', title: 'Open source bug tracker', updatedAt: '2024-06-16T10:00:00Z', messageCount: 1, createdAt: '2024-06-16T09:00:00Z' },
+    ]
+    const { HomePage } = await import('./HomePage')
+    render(<HomePage />)
+    const input = screen.getByPlaceholderText('Search sessions by title or keyword...')
+    await userEvent.type(input, 'bug open')
+    await vi.waitFor(() => expect(screen.getByText('2 matches')).toBeInTheDocument())
+    expect(screen.getByRole('link', { name: /Fix bug open/ })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /Open source bug/ })).toBeInTheDocument()
+  })
+
+  it('shows only projects with matching sessions', async () => {
+    sessionStore.sessions = [
+      { id: 's1', projectId: 'p1', title: 'Database setup', updatedAt: '2024-06-15T10:00:00Z', messageCount: 1, createdAt: '2024-06-15T09:00:00Z' },
+      { id: 's2', projectId: 'p2', title: 'Frontend', updatedAt: '2024-06-16T10:00:00Z', messageCount: 1, createdAt: '2024-06-16T09:00:00Z' },
+    ]
+    const { HomePage } = await import('./HomePage')
+    render(<HomePage />)
+    const input = screen.getByPlaceholderText('Search sessions by title or keyword...')
+    await userEvent.type(input, 'database')
+    await vi.waitFor(() => expect(screen.getByText('1 match')).toBeInTheDocument())
+    expect(screen.getByText('Project Alpha')).toBeInTheDocument()
+    expect(screen.queryByText('Project Beta')).not.toBeInTheDocument()
+  })
+
+  it('limits to 5 sessions per project when not searching', async () => {
+    const sessions = Array.from({ length: 7 }, (_, i) => ({
+      id: `s${i}`, projectId: 'p1', title: `Session ${i}`,
+      updatedAt: `2024-06-${String(15 - i).padStart(2, '0')}T10:00:00Z`,
+      messageCount: 1, createdAt: '2024-06-01',
+    }))
+    sessionStore.sessions = sessions
+    const { HomePage } = await import('./HomePage')
+    render(<HomePage />)
+    const visible = screen.getAllByRole('link').filter((l) => (l as HTMLAnchorElement).href?.includes('/s/'))
+    expect(visible.length).toBe(5)
+  })
+
+  it('shows all matching sessions when searching (no 5-session limit)', async () => {
+    const sessions = Array.from({ length: 7 }, (_, i) => ({
+      id: `s${i}`, projectId: 'p1', title: `Fix bug ${i}`,
+      updatedAt: `2024-06-${String(15 - i).padStart(2, '0')}T10:00:00Z`,
+      messageCount: 1, createdAt: '2024-06-01',
+    }))
+    sessionStore.sessions = sessions
+    const { HomePage } = await import('./HomePage')
+    render(<HomePage />)
+    const input = screen.getByPlaceholderText('Search sessions by title or keyword...')
+    await userEvent.type(input, 'fix')
+    await vi.waitFor(() => expect(screen.getByText('7 matches')).toBeInTheDocument())
+    const visible = screen.getAllByRole('link').filter((l) => (l as HTMLAnchorElement).href?.includes('/s/'))
+    expect(visible.length).toBe(7)
+  })
+
+  it('shows prompts badge when session matches by prompts only', async () => {
+    sessionStore.sessions = [{
+      id: 's1', projectId: 'p1', title: 'Session alpha',
+      recentUserPrompts: [{ id: 'p1', content: 'Please review the PR', timestamp: '2024-06-15T10:00:00Z' }],
+      updatedAt: '2024-06-15T10:00:00Z', messageCount: 1, createdAt: '2024-06-15T09:00:00Z',
+    }]
+    const { HomePage } = await import('./HomePage')
+    render(<HomePage />)
+    const input = screen.getByPlaceholderText('Search sessions by title or keyword...')
+    await userEvent.type(input, 'review')
+    await vi.waitFor(() => expect(screen.getByText('1 match')).toBeInTheDocument())
+    expect(screen.getByText('prompts')).toBeInTheDocument()
+  })
+
+  it('does not show prompts badge when session matches by title', async () => {
+    sessionStore.sessions = [{
+      id: 's1', projectId: 'p1', title: 'Review PR 123',
+      recentUserPrompts: [{ id: 'p1', content: 'Please check this', timestamp: '2024-06-15T10:00:00Z' }],
+      updatedAt: '2024-06-15T10:00:00Z', messageCount: 1, createdAt: '2024-06-15T09:00:00Z',
+    }]
+    const { HomePage } = await import('./HomePage')
+    render(<HomePage />)
+    const input = screen.getByPlaceholderText('Search sessions by title or keyword...')
+    await userEvent.type(input, 'review')
+    await vi.waitFor(() => expect(screen.getByText('1 match')).toBeInTheDocument())
+    expect(screen.queryByText('prompts')).not.toBeInTheDocument()
+  })
+
+  it('shows snippet with highlighted keyword in prompts match', async () => {
+    sessionStore.sessions = [{
+      id: 's1', projectId: 'p1', title: 'QA workflow',
+      recentUserPrompts: [{ id: 'p1', content: 'Run full code review on the project', timestamp: '2024-06-15T10:00:00Z' }],
+      updatedAt: '2024-06-15T10:00:00Z', messageCount: 1, createdAt: '2024-06-15T09:00:00Z',
+    }]
+    const { HomePage } = await import('./HomePage')
+    render(<HomePage />)
+    const input = screen.getByPlaceholderText('Search sessions by title or keyword...')
+    await userEvent.type(input, 'review')
+    await vi.waitFor(() => expect(screen.getByText('prompts')).toBeInTheDocument())
+    expect(screen.getByText(/Run full code/)).toBeInTheDocument()
+  })
+
+  it('ranks title matches above prompt matches', async () => {
+    sessionStore.sessions = [
+      {
+        id: 's1', projectId: 'p1', title: 'Error in checkout flow',
+        recentUserPrompts: [{ id: 'p1', content: 'Check error handling', timestamp: '2024-06-14T10:00:00Z' }],
+        updatedAt: '2024-06-14T10:00:00Z', messageCount: 1, createdAt: '2024-06-14T09:00:00Z',
+      },
+      {
+        id: 's2', projectId: 'p1', title: 'UI improvements',
+        recentUserPrompts: [{ id: 'p2', content: 'Fix the error in modal', timestamp: '2024-06-15T10:00:00Z' }],
+        updatedAt: '2024-06-15T10:00:00Z', messageCount: 1, createdAt: '2024-06-15T09:00:00Z',
+      },
+    ]
+    const { HomePage } = await import('./HomePage')
+    render(<HomePage />)
+    const input = screen.getByPlaceholderText('Search sessions by title or keyword...')
+    await userEvent.type(input, 'error')
+    await vi.waitFor(() => expect(screen.getByText('2 matches')).toBeInTheDocument())
+    const links = screen.getAllByRole('link').filter((l) => (l as HTMLAnchorElement).href?.includes('/s/'))
+    expect(links[0]?.textContent).toContain('Error in checkout')
+    expect(links[1]?.textContent).toContain('UI improvements')
+  })
+
+  it('clears search on Escape key', async () => {
+    sessionStore.sessions = [{ id: 's1', projectId: 'p1', title: 'My session', updatedAt: '2024-06-15T10:00:00Z', messageCount: 1, createdAt: '2024-06-15T09:00:00Z' }]
+    const { HomePage } = await import('./HomePage')
+    render(<HomePage />)
+    const input = screen.getByPlaceholderText('Search sessions by title or keyword...')
+    await userEvent.type(input, 'zzzzz')
+    await vi.waitFor(() => expect(screen.getByText(/No sessions matching/)).toBeInTheDocument())
+    await userEvent.keyboard('{Escape}')
+    expect(input).toHaveValue('')
+    expect(screen.getByText('My session')).toBeInTheDocument()
+  })
+
+  it('handles session without a title by falling back to id slice', async () => {
+    sessionStore.sessions = [{ id: 'abcdef123456', projectId: 'p1', updatedAt: '2024-06-15T10:00:00Z', messageCount: 1, createdAt: '2024-06-15T09:00:00Z' }]
+    const { HomePage } = await import('./HomePage')
+    render(<HomePage />)
+    expect(screen.getByText('abcdef12')).toBeInTheDocument()
   })
 })

--- a/web/src/components/HomePage.test.tsx
+++ b/web/src/components/HomePage.test.tsx
@@ -1,5 +1,8 @@
 // @vitest-environment happy-dom
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import '@testing-library/jest-dom/vitest'
 
 vi.mock('../lib/ws', () => ({
   wsClient: {
@@ -16,29 +19,252 @@ vi.mock('wouter', () => ({
   useLocation: () => [undefined, vi.fn()],
 }))
 
+const sessionStore = { sessions: [] as any[] }
 vi.mock('../stores/session', () => ({
-  useSessionStore: () => ({
-    sessions: [],
-    listSessions: vi.fn(),
-    connectionStatus: 'connected',
-  }),
+  useSessionStore: (selector?: any) => {
+    const state = {
+      sessions: sessionStore.sessions,
+      listSessions: vi.fn(),
+      connectionStatus: 'connected',
+    }
+    return selector ? selector(state) : state
+  },
 }))
 
 vi.mock('../stores/project', () => ({
-  useProjectStore: () => ({
-    projects: [
-      { id: 'p1', name: 'Project Alpha', workdir: '/tmp/alpha', createdAt: '2024-01-01', updatedAt: '2024-01-01' },
-      { id: 'p2', name: 'Project Beta', workdir: '/tmp/beta', createdAt: '2024-01-02', updatedAt: '2024-01-02' },
-    ],
-    loading: false,
-    listProjects: vi.fn(),
-    deleteProject: vi.fn(),
-  }),
+  useProjectStore: (selector?: any) => {
+    const state = {
+      projects: [
+        {
+          id: 'p1',
+          name: 'Project Alpha',
+          workdir: '/tmp/alpha',
+          createdAt: '2024-01-01',
+          updatedAt: '2024-01-01',
+        },
+        {
+          id: 'p2',
+          name: 'Project Beta',
+          workdir: '/tmp/beta',
+          createdAt: '2024-01-02',
+          updatedAt: '2024-01-02',
+        },
+      ],
+      loading: false,
+      listProjects: vi.fn(),
+      deleteProject: vi.fn(),
+    }
+    return selector ? selector(state) : state
+  },
 }))
+
+beforeEach(() => {
+  sessionStore.sessions = []
+})
+
+afterEach(() => {
+  cleanup()
+})
 
 describe('HomePage', () => {
   it('exports the component', async () => {
     const { HomePage } = await import('./HomePage')
     expect(HomePage).toBeDefined()
+  })
+
+  it('renders the search bar when sessions exist', async () => {
+    sessionStore.sessions = [
+      {
+        id: 's1',
+        projectId: 'p1',
+        title: 'Test session',
+        updatedAt: '2024-06-15T10:00:00Z',
+        messageCount: 1,
+        createdAt: '2024-06-15T09:00:00Z',
+      },
+    ]
+    const { HomePage } = await import('./HomePage')
+    render(<HomePage />)
+    expect(screen.getByPlaceholderText('Search sessions by title or keyword...')).toBeInTheDocument()
+  })
+
+  it('hides the search bar when no sessions exist', async () => {
+    const { HomePage } = await import('./HomePage')
+    render(<HomePage />)
+    expect(screen.queryByPlaceholderText('Search sessions by title or keyword...')).not.toBeInTheDocument()
+  })
+
+  it('filters sessions by title match', async () => {
+    sessionStore.sessions = [
+      {
+        id: 's1',
+        projectId: 'p1',
+        title: 'Search feature implementation',
+        updatedAt: '2024-06-15T10:00:00Z',
+        messageCount: 5,
+        createdAt: '2024-06-15T09:00:00Z',
+      },
+      {
+        id: 's2',
+        projectId: 'p1',
+        title: 'Bug fix login',
+        updatedAt: '2024-06-16T10:00:00Z',
+        messageCount: 3,
+        createdAt: '2024-06-16T09:00:00Z',
+      },
+    ]
+    const { HomePage } = await import('./HomePage')
+    render(<HomePage />)
+
+    const input = screen.getByPlaceholderText('Search sessions by title or keyword...')
+    await userEvent.type(input, 'search')
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('1 match')).toBeInTheDocument()
+    })
+
+    expect(screen.getByRole('link', { name: /Search feature/ })).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: /Bug fix/ })).not.toBeInTheDocument()
+  })
+
+  it('filters sessions by recent prompt content', async () => {
+    sessionStore.sessions = [
+      {
+        id: 's1',
+        projectId: 'p1',
+        title: 'Session alpha',
+        recentUserPrompts: [{ id: 'p1', content: 'Fix the login bug', timestamp: '2024-06-15T10:00:00Z' }],
+        updatedAt: '2024-06-15T10:00:00Z',
+        messageCount: 2,
+        createdAt: '2024-06-15T09:00:00Z',
+      },
+      {
+        id: 's2',
+        projectId: 'p1',
+        title: 'Session beta',
+        recentUserPrompts: [{ id: 'p2', content: 'Add dark mode', timestamp: '2024-06-16T10:00:00Z' }],
+        updatedAt: '2024-06-16T10:00:00Z',
+        messageCount: 4,
+        createdAt: '2024-06-16T09:00:00Z',
+      },
+    ]
+    const { HomePage } = await import('./HomePage')
+    render(<HomePage />)
+
+    const input = screen.getByPlaceholderText('Search sessions by title or keyword...')
+    await userEvent.type(input, 'login')
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('1 match')).toBeInTheDocument()
+    })
+
+    expect(screen.getByRole('link', { name: /Session a l/ })).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: /Session b/ })).not.toBeInTheDocument()
+  })
+
+  it('shows clear button when search has text and clears on click', async () => {
+    sessionStore.sessions = [
+      {
+        id: 's1',
+        projectId: 'p1',
+        title: 'Test session',
+        updatedAt: '2024-06-15T10:00:00Z',
+        messageCount: 1,
+        createdAt: '2024-06-15T09:00:00Z',
+      },
+    ]
+    const { HomePage } = await import('./HomePage')
+    render(<HomePage />)
+
+    const input = screen.getByPlaceholderText('Search sessions by title or keyword...')
+    await userEvent.type(input, 'something')
+
+    const clearButton = screen.getByLabelText('Clear search')
+    expect(clearButton).toBeInTheDocument()
+
+    await userEvent.click(clearButton)
+    expect(input).toHaveValue('')
+  })
+
+  it('shows match count when searching', async () => {
+    sessionStore.sessions = [
+      {
+        id: 's1',
+        projectId: 'p1',
+        title: 'Deploy pipeline',
+        updatedAt: '2024-06-15T10:00:00Z',
+        messageCount: 5,
+        createdAt: '2024-06-15T09:00:00Z',
+      },
+      {
+        id: 's2',
+        projectId: 'p1',
+        title: 'DB migration',
+        updatedAt: '2024-06-16T10:00:00Z',
+        messageCount: 3,
+        createdAt: '2024-06-16T09:00:00Z',
+      },
+    ]
+    const { HomePage } = await import('./HomePage')
+    render(<HomePage />)
+
+    const input = screen.getByPlaceholderText('Search sessions by title or keyword...')
+    await userEvent.type(input, 'deploy')
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('1 match')).toBeInTheDocument()
+    })
+  })
+
+  it('shows empty state when no sessions match', async () => {
+    sessionStore.sessions = [
+      {
+        id: 's1',
+        projectId: 'p1',
+        title: 'Some session',
+        updatedAt: '2024-06-15T10:00:00Z',
+        messageCount: 1,
+        createdAt: '2024-06-15T09:00:00Z',
+      },
+    ]
+    const { HomePage } = await import('./HomePage')
+    render(<HomePage />)
+
+    const input = screen.getByPlaceholderText('Search sessions by title or keyword...')
+    await userEvent.type(input, 'zzzzz')
+
+    await vi.waitFor(() => {
+      expect(screen.getByText(/No sessions matching/)).toBeInTheDocument()
+    })
+
+    expect(screen.getByText(/zzzzz/)).toBeInTheDocument()
+  })
+
+  it('shows projects and sessions when search is cleared', async () => {
+    sessionStore.sessions = [
+      {
+        id: 's1',
+        projectId: 'p1',
+        title: 'My session',
+        updatedAt: '2024-06-15T10:00:00Z',
+        messageCount: 1,
+        createdAt: '2024-06-15T09:00:00Z',
+      },
+    ]
+    const { HomePage } = await import('./HomePage')
+    render(<HomePage />)
+
+    const input = screen.getByPlaceholderText('Search sessions by title or keyword...')
+    await userEvent.type(input, 'nope')
+
+    await vi.waitFor(() => {
+      expect(screen.getByText(/No sessions matching/)).toBeInTheDocument()
+    })
+
+    await userEvent.clear(input)
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('My session')).toBeInTheDocument()
+    })
   })
 })

--- a/web/src/components/HomePage.tsx
+++ b/web/src/components/HomePage.tsx
@@ -15,13 +15,21 @@ function highlightMatches(text: string, query: string) {
   if (!query) return text
   const lowerText = text.toLowerCase()
   const lowerQuery = query.toLowerCase()
+
   const matched = new Array(text.length).fill(false)
 
-  let qi = 0
-  for (let i = 0; i < text.length && qi < lowerQuery.length; i++) {
-    if (lowerText[i] === lowerQuery[qi]) {
+  const exactIdx = lowerText.indexOf(lowerQuery)
+  if (exactIdx >= 0) {
+    for (let i = exactIdx; i < exactIdx + lowerQuery.length; i++) {
       matched[i] = true
-      qi++
+    }
+  } else {
+    let qi = 0
+    for (let i = 0; i < text.length && qi < lowerQuery.length; i++) {
+      if (lowerText[i] === lowerQuery[qi]) {
+        matched[i] = true
+        qi++
+      }
     }
   }
 

--- a/web/src/components/HomePage.tsx
+++ b/web/src/components/HomePage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useMemo, useCallback, useRef } from 'react'
 import { Link } from 'wouter'
 import { useSessionStore } from '../stores/session'
 import { useProjectStore } from '../stores/project'
@@ -6,12 +6,65 @@ import { Button } from './shared/Button'
 import { OpenProjectModal } from './CreateSessionModal'
 import { DeleteProjectConfirmationModal } from './DeleteProjectConfirmationModal'
 import { formatRelativeDate } from '../lib/format-date'
-import { FolderIcon, TrashIcon } from './shared/icons'
+import { SearchIcon, XCloseIcon, FolderIcon, TrashIcon } from './shared/icons'
 import { Spinner } from './shared/Spinner'
+import { fuzzyMatch } from '../lib/modal-utils'
+import type { SessionSummary } from '@shared/types.js'
+
+function highlightMatches(text: string, query: string) {
+  if (!query) return text
+  const lowerText = text.toLowerCase()
+  const lowerQuery = query.toLowerCase()
+  const matched = new Array(text.length).fill(false)
+
+  let qi = 0
+  for (let i = 0; i < text.length && qi < lowerQuery.length; i++) {
+    if (lowerText[i] === lowerQuery[qi]) {
+      matched[i] = true
+      qi++
+    }
+  }
+
+  const parts: React.ReactNode[] = []
+  let current = ''
+  let currentMatch: boolean = matched[0] ?? false
+
+  for (let i = 0; i < text.length; i++) {
+    if (matched[i] === currentMatch) {
+      current += text[i]!
+    } else {
+      parts.push(
+        currentMatch ? (
+          <span key={parts.length} className="font-semibold text-accent-primary">
+            {current}
+          </span>
+        ) : (
+          current
+        ),
+      )
+      current = text[i]!
+      currentMatch = matched[i] as boolean
+    }
+  }
+  parts.push(
+    currentMatch ? (
+      <span key={parts.length} className="font-semibold text-accent-primary">
+        {current}
+      </span>
+    ) : (
+      current
+    ),
+  )
+
+  return <>{parts}</>
+}
 
 export function HomePage() {
   const [showOpenModal, setShowOpenModal] = useState(false)
   const [projectToDelete, setProjectToDelete] = useState<{ id: string; name: string } | null>(null)
+  const [searchQuery, setSearchQuery] = useState('')
+  const [debouncedQuery, setDebouncedQuery] = useState('')
+  const searchRef = useRef<HTMLInputElement>(null)
 
   const sessions = useSessionStore((state) => state.sessions)
   const projects = useProjectStore((state) => state.projects)
@@ -29,38 +82,103 @@ export function HomePage() {
     }
   }, [connectionStatus, listProjects, listSessions])
 
-  const sortedProjects = [...projects].sort((a, b) => {
-    const sessionsInA = sessions.filter((s) => s.projectId === a.id)
-    const sessionsInB = sessions.filter((s) => s.projectId === b.id)
-    const lastSessionA =
-      sessionsInA.length > 0
-        ? new Date(
-            sessionsInA.reduce((latest, s) => (new Date(s.updatedAt) > new Date(latest.updatedAt) ? s : latest))
-              .updatedAt,
-          ).getTime()
-        : new Date(a.updatedAt).getTime()
-    const lastSessionB =
-      sessionsInB.length > 0
-        ? new Date(
-            sessionsInB.reduce((latest, s) => (new Date(s.updatedAt) > new Date(latest.updatedAt) ? s : latest))
-              .updatedAt,
-          ).getTime()
-        : new Date(b.updatedAt).getTime()
-    return lastSessionB - lastSessionA
-  })
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedQuery(searchQuery), 150)
+    return () => clearTimeout(t)
+  }, [searchQuery])
 
-  const getProjectSessions = (projectId: string) => {
-    const project = projects.find((p) => p.id === projectId)
-    if (!project) return []
-    return sessions
-      .filter((s) => s.projectId === projectId)
-      .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())
-      .slice(0, 5)
-  }
+  const sessionSearchTextCache = useMemo(() => {
+    const projectById = new Map(projects.map((p) => [p.id, p]))
+    const cache = new Map<string, string>()
+    for (const s of sessions) {
+      const project = projectById.get(s.projectId)
+      const prompts = s.recentUserPrompts?.map((p) => p.content).join(' ') ?? ''
+      cache.set(s.id, `${s.title ?? ''} ${prompts} ${project?.name ?? ''}`)
+    }
+    return cache
+  }, [projects, sessions])
+
+  const { matchCount, filteredSessionIds } = useMemo(() => {
+    if (!debouncedQuery) return { matchCount: 0, filteredSessionIds: null as Set<string> | null }
+    const matching = sessions.filter((s) => {
+      const text = sessionSearchTextCache.get(s.id) ?? ''
+      return fuzzyMatch(text, debouncedQuery)
+    })
+    return { matchCount: matching.length, filteredSessionIds: new Set(matching.map((s) => s.id)) }
+  }, [sessions, debouncedQuery, sessionSearchTextCache])
+
+  const lastActivityByProject = useMemo(() => {
+    const map = new Map<string, number>()
+    for (const s of sessions) {
+      const t = new Date(s.updatedAt).getTime()
+      const prev = map.get(s.projectId) ?? 0
+      if (t > prev) map.set(s.projectId, t)
+    }
+    return map
+  }, [sessions])
+
+  const sessionsByProject = useMemo(() => {
+    const map = new Map<string, SessionSummary[]>()
+    for (const s of sessions) {
+      const list = map.get(s.projectId)
+      if (list) {
+        list.push(s)
+      } else {
+        map.set(s.projectId, [s])
+      }
+    }
+    for (const [, list] of map) {
+      list.sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())
+    }
+    return map
+  }, [sessions])
+
+  const sortedProjects = useMemo(() => {
+    let filtered = projects
+    if (debouncedQuery && filteredSessionIds) {
+      filtered = projects.filter((p) => {
+        const projectSessions = sessionsByProject.get(p.id)
+        return projectSessions?.some((s) => filteredSessionIds!.has(s.id))
+      })
+    }
+    return [...filtered].sort((a, b) => {
+      const aTime = lastActivityByProject.get(a.id) ?? new Date(a.updatedAt).getTime()
+      const bTime = lastActivityByProject.get(b.id) ?? new Date(b.updatedAt).getTime()
+      return bTime - aTime
+    })
+  }, [projects, sessionsByProject, debouncedQuery, filteredSessionIds, lastActivityByProject])
+
+  const getProjectSessions = useCallback(
+    (projectId: string): SessionSummary[] => {
+      const projectSessions = sessionsByProject.get(projectId)
+      if (!projectSessions) return []
+      if (debouncedQuery && filteredSessionIds) {
+        return projectSessions.filter((s) => filteredSessionIds.has(s.id))
+      }
+      return projectSessions.slice(0, 5)
+    },
+    [sessionsByProject, debouncedQuery, filteredSessionIds],
+  )
 
   const handleOpenProject = () => {
     setShowOpenModal(true)
   }
+
+  const handleClearSearch = () => {
+    setSearchQuery('')
+    setDebouncedQuery('')
+    searchRef.current?.focus()
+  }
+
+  const handleSearchKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      handleClearSearch()
+      searchRef.current?.blur()
+    }
+  }
+
+  const isSearching = debouncedQuery.length > 0
+  const hasNoResults = isSearching && matchCount === 0
 
   return (
     <div className="flex-1 flex flex-col overflow-y-auto bg-primary">
@@ -75,71 +193,114 @@ export function HomePage() {
           </Button>
         </div>
 
-        {sortedProjects.map((project) => {
-          const projectSessions = getProjectSessions(project.id)
-          return (
-            <div key={project.id} className="mb-6 md:mb-8">
-              <div className="bg-bg-secondary border border-border rounded-lg overflow-hidden">
-                <div className="p-3 md:p-4 border-b border-border flex items-center justify-between gap-2">
-                  <Link
-                    href={`/p/${project.id}`}
-                    className="flex items-center gap-2 cursor-pointer hover:opacity-80 transition-opacity flex-1"
-                  >
-                    <FolderIcon className="w-5 h-5 text-accent-primary flex-shrink-0" />
-                    <span className="text-text-primary font-semibold">{project.name}</span>
-                  </Link>
-                  <Link
-                    href={`/p/${project.id}/new`}
-                    className="rounded font-medium transition-colors bg-accent-primary/25 text-text-primary hover:bg-accent-primary/40 px-1.5 py-1 text-xs"
-                  >
-                    + New Session
-                  </Link>
-                  <button
-                    type="button"
-                    onClick={() => setProjectToDelete({ id: project.id, name: project.name })}
-                    className="p-1.5 rounded text-text-muted hover:text-accent-error hover:bg-accent-error/10 transition-colors"
-                    title="Delete project"
-                  >
-                    <TrashIcon className="w-4 h-4" />
-                  </button>
-                </div>
-                <div className="divide-y divide-border">
-                  {projectSessions.length > 0 ? (
-                    projectSessions.map((session) => {
-                      const project = projects.find((p) => session.projectId === p.id)
-                      const href = project ? `/p/${project.id}/s/${session.id}` : '#'
-                      return (
-                        <Link
-                          key={session.id}
-                          href={href}
-                          className="block p-3 md:p-4 hover:bg-bg-tertiary/50 cursor-pointer transition-colors"
-                        >
-                          <div className="flex items-center justify-between gap-2">
-                            <div className="flex items-center gap-3 flex-1 min-w-0">
-                              <div className="flex-1 min-w-0">
-                                <div className="text-sm text-text-muted truncate">
-                                  {session.title ?? session.id.slice(0, 8)}
+        {sessions.length > 0 && (
+          <div className="mb-4 md:mb-6 relative">
+            <div className="relative flex items-center">
+              <SearchIcon className="absolute left-3 w-4 h-4 text-text-muted pointer-events-none" />
+              <input
+                ref={searchRef}
+                type="text"
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                onKeyDown={handleSearchKeyDown}
+                placeholder="Search sessions by title or keyword..."
+                className="w-full bg-bg-secondary border border-border rounded-lg pl-10 pr-10 py-2.5 text-sm text-text-primary placeholder-text-muted focus:outline-none focus:ring-2 focus:ring-accent-primary/50 focus:border-accent-primary transition-colors"
+              />
+              {searchQuery && (
+                <button
+                  type="button"
+                  onClick={handleClearSearch}
+                  className="absolute right-3 p-0.5 rounded text-text-muted hover:text-text-primary hover:bg-bg-tertiary transition-colors"
+                  aria-label="Clear search"
+                >
+                  <XCloseIcon className="w-4 h-4" />
+                </button>
+              )}
+            </div>
+            {isSearching && !hasNoResults && (
+              <div className="mt-1.5 text-xs text-text-muted px-1">
+                {matchCount} {matchCount === 1 ? 'match' : 'matches'}
+              </div>
+            )}
+          </div>
+        )}
+
+        {hasNoResults ? (
+          <div className="text-center py-16 text-text-muted">
+            <SearchIcon className="w-10 h-10 mx-auto mb-4 opacity-40" />
+            <p className="text-lg">
+              No sessions matching <span className="text-text-primary font-medium">&ldquo;{debouncedQuery}&rdquo;</span>
+            </p>
+            <p className="mt-2 text-sm">Try a different keyword or clear the search</p>
+          </div>
+        ) : (
+          sortedProjects.map((project) => {
+            const projectSessions = getProjectSessions(project.id)
+            return (
+              <div key={project.id} className="mb-6 md:mb-8">
+                <div className="bg-bg-secondary border border-border rounded-lg overflow-hidden">
+                  <div className="p-3 md:p-4 border-b border-border flex items-center justify-between gap-2">
+                    <Link
+                      href={`/p/${project.id}`}
+                      className="flex items-center gap-2 cursor-pointer hover:opacity-80 transition-opacity flex-1"
+                    >
+                      <FolderIcon className="w-5 h-5 text-accent-primary flex-shrink-0" />
+                      <span className="text-text-primary font-semibold">{project.name}</span>
+                    </Link>
+                    <Link
+                      href={`/p/${project.id}/new`}
+                      className="rounded font-medium transition-colors bg-accent-primary/25 text-text-primary hover:bg-accent-primary/40 px-1.5 py-1 text-xs"
+                    >
+                      + New Session
+                    </Link>
+                    <button
+                      type="button"
+                      onClick={() => setProjectToDelete({ id: project.id, name: project.name })}
+                      className="p-1.5 rounded text-text-muted hover:text-accent-error hover:bg-accent-error/10 transition-colors"
+                      title="Delete project"
+                    >
+                      <TrashIcon className="w-4 h-4" />
+                    </button>
+                  </div>
+                  <div className="divide-y divide-border">
+                    {projectSessions.length > 0 ? (
+                      projectSessions.map((session) => {
+                        const project = projects.find((p) => session.projectId === p.id)
+                        const href = project ? `/p/${project.id}/s/${session.id}` : '#'
+                        const displayTitle = session.title ?? session.id.slice(0, 8)
+                        return (
+                          <Link
+                            key={session.id}
+                            href={href}
+                            className="block p-3 md:p-4 hover:bg-bg-tertiary/50 cursor-pointer transition-colors"
+                          >
+                            <div className="flex items-center justify-between gap-2">
+                              <div className="flex items-center gap-3 flex-1 min-w-0">
+                                <div className="flex-1 min-w-0">
+                                  <div className="text-sm text-text-muted truncate">
+                                    {isSearching ? highlightMatches(displayTitle, debouncedQuery) : displayTitle}
+                                  </div>
                                 </div>
                               </div>
+                              <div className="flex items-center gap-2 flex-shrink-0">
+                                <span className="text-text-muted text-xs">{formatRelativeDate(session.updatedAt)}</span>
+                                <span className="text-text-muted text-xs">{session.messageCount} msgs</span>
+                              </div>
                             </div>
-                            <div className="flex items-center gap-2 flex-shrink-0">
-                              <span className="text-text-muted text-xs">{formatRelativeDate(session.updatedAt)}</span>
-                              <span className="text-text-muted text-xs">{session.messageCount} msgs</span>
-                            </div>
-                          </div>
-                        </Link>
-                      )
-                    })
-                  ) : (
-                    <div className="p-3 md:p-4 text-text-muted text-sm">No sessions yet</div>
-                  )}
+                          </Link>
+                        )
+                      })
+                    ) : (
+                      <div className="p-3 md:p-4 text-text-muted text-sm">No sessions yet</div>
+                    )}
+                  </div>
                 </div>
               </div>
-            </div>
-          )
-        })}
+            )
+          })
+        )}
 
-        {sortedProjects.length === 0 && !loading && (
+        {!isSearching && sortedProjects.length === 0 && !loading && (
           <div className="text-center py-12 text-text-muted">No projects yet. Open a project to get started.</div>
         )}
 

--- a/web/src/components/HomePage.tsx
+++ b/web/src/components/HomePage.tsx
@@ -87,25 +87,24 @@ export function HomePage() {
     return () => clearTimeout(t)
   }, [searchQuery])
 
-  const sessionSearchTextCache = useMemo(() => {
+  const { matchCount, filteredSessionIds, relevanceScores } = useMemo(() => {
+    if (!debouncedQuery) return { matchCount: 0, filteredSessionIds: null as Set<string> | null, relevanceScores: null as Map<string, number> | null }
     const projectById = new Map(projects.map((p) => [p.id, p]))
-    const cache = new Map<string, string>()
-    for (const s of sessions) {
-      const project = projectById.get(s.projectId)
-      const prompts = s.recentUserPrompts?.map((p) => p.content).join(' ') ?? ''
-      cache.set(s.id, `${s.title ?? ''} ${prompts} ${project?.name ?? ''}`)
-    }
-    return cache
-  }, [projects, sessions])
-
-  const { matchCount, filteredSessionIds } = useMemo(() => {
-    if (!debouncedQuery) return { matchCount: 0, filteredSessionIds: null as Set<string> | null }
+    const scores = new Map<string, number>()
     const matching = sessions.filter((s) => {
-      const text = sessionSearchTextCache.get(s.id) ?? ''
-      return fuzzyMatch(text, debouncedQuery)
+      const project = projectById.get(s.projectId)
+      const projectName = project?.name ?? ''
+      const title = s.title ?? ''
+      const prompts = s.recentUserPrompts?.map((p) => p.content).join(' ') ?? ''
+      let score = 0
+      if (fuzzyMatch(title, debouncedQuery)) score += 10
+      if (fuzzyMatch(prompts, debouncedQuery)) score += 3
+      if (fuzzyMatch(projectName, debouncedQuery)) score += 1
+      scores.set(s.id, score)
+      return score > 0
     })
-    return { matchCount: matching.length, filteredSessionIds: new Set(matching.map((s) => s.id)) }
-  }, [sessions, debouncedQuery, sessionSearchTextCache])
+    return { matchCount: matching.length, filteredSessionIds: new Set(matching.map((s) => s.id)), relevanceScores: scores }
+  }, [sessions, debouncedQuery, projects])
 
   const lastActivityByProject = useMemo(() => {
     const map = new Map<string, number>()
@@ -152,12 +151,18 @@ export function HomePage() {
     (projectId: string): SessionSummary[] => {
       const projectSessions = sessionsByProject.get(projectId)
       if (!projectSessions) return []
-      if (debouncedQuery && filteredSessionIds) {
-        return projectSessions.filter((s) => filteredSessionIds.has(s.id))
+      if (debouncedQuery && filteredSessionIds && relevanceScores) {
+        return projectSessions
+          .filter((s) => filteredSessionIds.has(s.id))
+          .sort((a, b) => {
+            const scoreDiff = (relevanceScores.get(b.id) ?? 0) - (relevanceScores.get(a.id) ?? 0)
+            if (scoreDiff !== 0) return scoreDiff
+            return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+          })
       }
       return projectSessions.slice(0, 5)
     },
-    [sessionsByProject, debouncedQuery, filteredSessionIds],
+    [sessionsByProject, debouncedQuery, filteredSessionIds, relevanceScores],
   )
 
   const handleOpenProject = () => {

--- a/web/src/components/HomePage.tsx
+++ b/web/src/components/HomePage.tsx
@@ -95,23 +95,41 @@ export function HomePage() {
     return () => clearTimeout(t)
   }, [searchQuery])
 
-  const { matchCount, filteredSessionIds, relevanceScores } = useMemo(() => {
-    if (!debouncedQuery) return { matchCount: 0, filteredSessionIds: null as Set<string> | null, relevanceScores: null as Map<string, number> | null }
+  const { matchCount, filteredSessionIds, relevanceScores, matchTypes, promptSnippets } = useMemo(() => {
+    if (!debouncedQuery) return { matchCount: 0, filteredSessionIds: null as Set<string> | null, relevanceScores: null as Map<string, number> | null, matchTypes: null as Map<string, string> | null, promptSnippets: null as Map<string, string> | null }
     const projectById = new Map(projects.map((p) => [p.id, p]))
     const scores = new Map<string, number>()
+    const types = new Map<string, string>()
+    const snippets = new Map<string, string>()
     const matching = sessions.filter((s) => {
       const project = projectById.get(s.projectId)
       const projectName = project?.name ?? ''
       const title = s.title ?? ''
-      const prompts = s.recentUserPrompts?.map((p) => p.content).join(' ') ?? ''
+      const prompts = s.recentUserPrompts?.map((p) => p.content) ?? []
+      const promptsJoined = prompts.join(' ')
       let score = 0
-      if (fuzzyMatch(title, debouncedQuery)) score += 10
-      if (fuzzyMatch(prompts, debouncedQuery)) score += 3
-      if (fuzzyMatch(projectName, debouncedQuery)) score += 1
+      let type = ''
+      if (fuzzyMatch(title, debouncedQuery)) { score += 10; type = 'title' }
+      if (fuzzyMatch(promptsJoined, debouncedQuery)) {
+        score += 3; type = type === 'title' ? 'title' : 'prompts'
+        const matchedPrompt = prompts.find((p) => fuzzyMatch(p, debouncedQuery))
+        if (matchedPrompt) {
+          const idx = matchedPrompt.toLowerCase().indexOf(debouncedQuery.toLowerCase())
+          if (idx >= 0) {
+            const start = Math.max(0, idx - 30)
+            const end = Math.min(matchedPrompt.length, idx + debouncedQuery.length + 30)
+            snippets.set(s.id, (start > 0 ? '…' : '') + matchedPrompt.slice(start, end) + (end < matchedPrompt.length ? '…' : ''))
+          } else {
+            snippets.set(s.id, matchedPrompt.slice(0, 80) + (matchedPrompt.length > 80 ? '…' : ''))
+          }
+        }
+      }
+      if (fuzzyMatch(projectName, debouncedQuery)) { score += 1; type = type || 'project' }
       scores.set(s.id, score)
+      types.set(s.id, type)
       return score > 0
     })
-    return { matchCount: matching.length, filteredSessionIds: new Set(matching.map((s) => s.id)), relevanceScores: scores }
+    return { matchCount: matching.length, filteredSessionIds: new Set(matching.map((s) => s.id)), relevanceScores: scores, matchTypes: types, promptSnippets: snippets }
   }, [sessions, debouncedQuery, projects])
 
   const lastActivityByProject = useMemo(() => {
@@ -281,6 +299,7 @@ export function HomePage() {
                         const project = projects.find((p) => session.projectId === p.id)
                         const href = project ? `/p/${project.id}/s/${session.id}` : '#'
                         const displayTitle = session.title ?? session.id.slice(0, 8)
+                        const matchType = matchTypes?.get(session.id)
                         return (
                           <Link
                             key={session.id}
@@ -291,8 +310,20 @@ export function HomePage() {
                               <div className="flex items-center gap-3 flex-1 min-w-0">
                                 <div className="flex-1 min-w-0">
                                   <div className="text-sm text-text-muted truncate">
-                                    {isSearching ? highlightMatches(displayTitle, debouncedQuery) : displayTitle}
+                                    {isSearching && matchType === 'title' ? highlightMatches(displayTitle, debouncedQuery) : displayTitle}
                                   </div>
+                                  {isSearching && matchType && matchType !== 'title' && (
+                                    <div className="flex flex-wrap items-center gap-1.5 mt-1">
+                                      <span className="text-[10px] font-medium text-accent-primary border border-accent-primary/30 bg-accent-primary/8 rounded px-1 py-0.5 leading-none">
+                                        {matchType === 'prompts' ? 'prompts' : 'project'}
+                                      </span>
+                                      {matchType === 'prompts' && promptSnippets?.get(session.id) && (
+                                        <span className="text-[11px] text-text-muted truncate max-w-[250px]">
+                                          {highlightMatches(promptSnippets.get(session.id)!, debouncedQuery)}
+                                        </span>
+                                      )}
+                                    </div>
+                                  )}
                                 </div>
                               </div>
                               <div className="flex items-center gap-2 flex-shrink-0">

--- a/web/src/components/shared/icons/SearchIcon.tsx
+++ b/web/src/components/shared/icons/SearchIcon.tsx
@@ -1,6 +1,10 @@
-export function SearchIcon() {
+interface SearchIconProps {
+  className?: string
+}
+
+export function SearchIcon({ className = 'w-3.5 h-3.5' }: SearchIconProps) {
   return (
-    <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
       <path
         strokeLinecap="round"
         strokeLinejoin="round"


### PR DESCRIPTION
## 🎯 Évolution

Barre de recherche en temps réel sur la page d'accueil pour retrouver rapidement une session parmi tous les projets.

### Fonctionnalités

- **Recherche fuzzy** : scanne le titre, les prompts utilisateur récents et le nom du projet
- **Score de pertinence** : titre match = prioritaire (+10), prompts (+3), nom projet (+1)
- **Surlignage contigu** : highlight d'un bloc si le mot-clé est présent tel quel dans le titre
- **Badge [prompts]** : quand le match vient des prompts, badge accent-primary + extrait du prompt avec highlight
- **Pas de surlignage parasite** : le titre n'est pas surligné quand le match vient des prompts/project name
- **Bouton clear (X)** et touche Escape
- **Compteur** "N matches"
- **État vide** centré quand aucun résultat
- **Barre masquée** quand aucune session
- **Debounce 150ms**
- **Limite 5 sessions** levée pendant la recherche
- **Caché en mémoire** : 3 Maps pré-calculées (sessionsByProject, lastActivityByProject, relevanceScores)

### Fichiers modifiés

- `web/src/components/HomePage.tsx` — barre de recherche, highlightMatches, scoring, badge, snippet, caches memo
- `web/src/components/HomePage.test.tsx` — 21 tests (filtrage titre/prompt/project/casse/multi-mots, ranking, badge, snippet, Escape, fallback id, limites)
- `web/src/components/shared/icons/SearchIcon.tsx` — prop optionnelle `className`

---

## 🔍 Summary

Real-time fuzzy search bar on the homepage to find sessions across projects.

**Key features:**
- Fuzzy match against `session.title`, `recentUserPrompts[].content`, `project.name`
- Relevance ranking: title matches first (+10), prompts (+3), project name (+1)
- Contiguous highlight when exact substring found in title
- `[prompts]` badge with highlighted snippet when match is in prompts only
- Title highlight suppressed when match is not from title
- Clear button (X) / Escape to reset
- Match counter, empty state, 150ms debounce
- 5-session limit lifted during search
- 3 pre-computed Maps for O(n) performance

**Tests:** 21 tests, all web tests pass (304), no regressions