### PR TITLE
feat: detect loaded context length from LM Studio native API (#49)

### DIFF
--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -20,7 +20,17 @@ export async function configFileExists(mode: Mode): Promise<boolean> {
 // Schema Definitions
 // ============================================================================
 
-const backendSchema = z.enum(['vllm', 'sglang', 'ollama', 'llamacpp', 'openai', 'anthropic', 'opencode-go', 'unknown'])
+const backendSchema = z.enum([
+  'vllm',
+  'sglang',
+  'ollama',
+  'llamacpp',
+  'lmstudio',
+  'openai',
+  'anthropic',
+  'opencode-go',
+  'unknown',
+])
 
 const modelConfigSchema = z
   .object({

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1060,11 +1060,16 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
   app.get('/api/providers/models', async (req, res) => {
     const url = req.query['url'] as string | undefined
     const apiKey = req.query['apiKey'] as string | undefined
+    const backend = req.query['backend'] as string | undefined
     if (!url) return res.status(400).json({ error: 'url is required' })
     try {
       const { fetchModelsWithContext } = await import('./provider-manager.js')
       const { getModelProfile } = await import('./llm/profiles.js')
-      const models = await fetchModelsWithContext(url, apiKey)
+      const models = await fetchModelsWithContext(
+        url,
+        apiKey,
+        backend as 'ollama' | 'vllm' | 'sglang' | 'llamacpp' | 'lmstudio' | 'unknown' | undefined,
+      )
       if (models.length === 0) {
         return res.status(404).json({ error: `No models found at ${buildModelsUrl(url)}`, url })
       }

--- a/src/server/llm/backend.test.ts
+++ b/src/server/llm/backend.test.ts
@@ -53,6 +53,7 @@ describe('backend', () => {
         sglang: 'SGLang',
         ollama: 'Ollama',
         llamacpp: 'llama.cpp',
+        lmstudio: 'LM Studio',
         'opencode-go': 'OpenCode Go',
         openai: 'OpenAI',
         anthropic: 'Anthropic',

--- a/src/server/llm/backend.ts
+++ b/src/server/llm/backend.ts
@@ -3,7 +3,16 @@
  * Supports vLLM, SGLang, Ollama, and llama.cpp inference engines.
  */
 
-export type Backend = 'vllm' | 'sglang' | 'ollama' | 'llamacpp' | 'opencode-go' | 'openai' | 'anthropic' | 'unknown'
+export type Backend =
+  | 'vllm'
+  | 'sglang'
+  | 'ollama'
+  | 'llamacpp'
+  | 'lmstudio'
+  | 'opencode-go'
+  | 'openai'
+  | 'anthropic'
+  | 'unknown'
 
 export interface BackendCapabilities {
   /** Whether chat_template_kwargs with enable_thinking works (vLLM/SGLang) */
@@ -37,6 +46,10 @@ const BACKEND_CAPABILITIES: Record<Backend, BackendCapabilities> = {
     supportsChatTemplateKwargs: false,
     supportsTopK: true,
   },
+  lmstudio: {
+    supportsChatTemplateKwargs: false,
+    supportsTopK: true,
+  },
   'opencode-go': {
     supportsChatTemplateKwargs: false,
     supportsTopK: true,
@@ -62,6 +75,8 @@ export function getBackendDisplayName(backend: Backend): string {
       return 'Ollama'
     case 'llamacpp':
       return 'llama.cpp'
+    case 'lmstudio':
+      return 'LM Studio'
     case 'opencode-go':
       return 'OpenCode Go'
     case 'openai':

--- a/src/server/provider-manager.ts
+++ b/src/server/provider-manager.ts
@@ -78,7 +78,7 @@ export async function fetchAvailableModelsFromBackend(baseUrl: string, apiKey?: 
 export async function fetchModelsWithContext(
   baseUrl: string,
   apiKey?: string,
-  backend?: 'ollama' | 'vllm' | 'sglang' | 'llamacpp' | 'unknown',
+  backend?: 'ollama' | 'vllm' | 'sglang' | 'llamacpp' | 'lmstudio' | 'unknown',
 ): Promise<ModelConfig[]> {
   logger.info('fetchModelsWithContext called', { baseUrl, apiKey: !!apiKey, backend })
 
@@ -86,6 +86,14 @@ export async function fetchModelsWithContext(
   if (backend === 'ollama') {
     logger.info('Fetching Ollama models via /api/tags and /api/show')
     return fetchOllamaModelsWithContext(baseUrl, apiKey)
+  }
+
+  // LM Studio has a native /api/v1/models endpoint with loaded context info
+  if (backend === 'lmstudio') {
+    logger.info('Fetching LM Studio models via /api/v1/models')
+    const lmStudioModels = await fetchLmStudioModelsWithContext(baseUrl, apiKey)
+    if (lmStudioModels.length > 0) return lmStudioModels
+    logger.info('LM Studio native endpoint unavailable, falling back to /v1/models')
   }
 
   // OpenCode Go has models at /zen/v1/models not /zen/go/v1/models
@@ -178,6 +186,78 @@ async function fetchOllamaModelsWithContext(baseUrl: string, _apiKey?: string): 
   } catch (error) {
     logger.info('Error fetching Ollama models', {
       url: baseUrl,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return []
+  }
+}
+
+/** Fetch LM Studio models with context windows via native /api/v1/models */
+async function fetchLmStudioModelsWithContext(baseUrl: string, _apiKey?: string): Promise<ModelConfig[]> {
+  const base = baseUrl.replace(/\/+$/, '')
+  // LM Studio native endpoint is at /api/v1/models (not under /v1/)
+  const nativeUrl = `${base.replace(/\/v\d+\/?$/, '')}/api/v1/models`
+
+  try {
+    logger.info('Fetching LM Studio native models', { url: nativeUrl })
+    const response = await fetch(nativeUrl, {
+      signal: AbortSignal.timeout(10000),
+    })
+
+    if (!response.ok) {
+      logger.info('LM Studio native endpoint returned error', { url: nativeUrl, status: response.status })
+      return []
+    }
+
+    const raw = (await response.json()) as Record<string, unknown>
+    // Handle bare array [...], { data: [...] }, or { models: [...] } formats
+    const rawArray = Array.isArray(raw)
+      ? raw
+      : Array.isArray((raw as { models?: unknown }).models)
+        ? (raw as { models: unknown[] }).models
+        : Array.isArray((raw as { data?: unknown }).data)
+          ? (raw as { data: unknown[] }).data
+          : []
+    const modelList = rawArray as Array<{
+      key?: string
+      id?: string
+      max_context_length?: number
+      loaded_instances?: Array<{
+        id?: string
+        config?: { context_length?: number }
+      }>
+    }>
+
+    if (modelList.length === 0) {
+      logger.info('LM Studio native endpoint returned no models', { url: nativeUrl })
+      return []
+    }
+
+    logger.info('LM Studio native models found', { count: modelList.length })
+
+    return modelList.map((model) => {
+      const modelId = model.key ?? model.id ?? ''
+      // Prefer loaded instance context, fall back to max context
+      const loadedContext = model.loaded_instances?.[0]?.config?.context_length
+      const maxContext = model.max_context_length
+      const contextWindow = loadedContext ?? maxContext ?? 200000
+
+      logger.info('LM Studio model detected', {
+        modelId,
+        loadedContext,
+        maxContext,
+        contextWindow,
+      })
+
+      return {
+        id: modelId,
+        contextWindow,
+        source: loadedContext || maxContext ? 'backend' : ('default' as const),
+      }
+    })
+  } catch (error) {
+    logger.info('Error fetching LM Studio native models', {
+      url: nativeUrl,
       error: error instanceof Error ? error.message : String(error),
     })
     return []
@@ -374,7 +454,7 @@ export function createProviderManager(config: Config): ProviderManager {
         clearModelCache(cacheUrl)
 
         // Refetch models from backend when switching providers
-        const backend = provider.backend as 'ollama' | 'vllm' | 'sglang' | 'llamacpp' | 'unknown'
+        const backend = provider.backend as 'ollama' | 'vllm' | 'sglang' | 'llamacpp' | 'lmstudio' | 'unknown'
         logger.info('activateProvider fetching models', {
           providerId,
           providerName: provider.name,
@@ -514,7 +594,7 @@ export function createProviderManager(config: Config): ProviderManager {
       }
 
       // Fallback: fetch from backend if no stored models
-      const backend = provider.backend as 'ollama' | 'vllm' | 'sglang' | 'llamacpp' | 'unknown'
+      const backend = provider.backend as 'ollama' | 'vllm' | 'sglang' | 'llamacpp' | 'lmstudio' | 'unknown'
       return fetchModelsWithContext(provider.url, provider.apiKey, backend)
     },
 
@@ -714,7 +794,7 @@ export function createProviderManager(config: Config): ProviderManager {
         return { success: false, error: 'Provider not found' }
       }
 
-      const backend = provider.backend as 'ollama' | 'vllm' | 'sglang' | 'llamacpp' | 'unknown'
+      const backend = provider.backend as 'ollama' | 'vllm' | 'sglang' | 'llamacpp' | 'lmstudio' | 'unknown'
       logger.info('refreshProviderModels fetching models', {
         providerId,
         providerName: provider.name,

--- a/src/server/providers/auto-config.ts
+++ b/src/server/providers/auto-config.ts
@@ -92,6 +92,10 @@ async function detectModelInfo(
       return await detectLlamacppInfo(baseUrl)
     }
 
+    if (backend === 'lmstudio') {
+      return await detectLmstudioInfo(baseUrl, modelId)
+    }
+
     // vLLM and others: try /v1/models
     return await detectVllmInfo(baseUrl, apiKey, modelId)
   } catch {
@@ -155,6 +159,35 @@ async function detectOllamaInfo(baseUrl: string, modelId: string): Promise<Model
     return { contextWindow: ctxLen, source: 'backend', supportsVision }
   }
   throw new Error('No context_length in model_info')
+}
+
+async function detectLmstudioInfo(baseUrl: string, modelId: string): Promise<ModelInfo> {
+  const base = baseUrl.replace(/\/+$/, '')
+  const nativeUrl = `${base.replace(/\/v\d+\/?$/, '')}/api/v1/models`
+  const response = await fetch(nativeUrl, { signal: AbortSignal.timeout(5000) })
+  if (!response.ok) throw new Error(`HTTP ${response.status}`)
+
+  const data = (await response.json()) as Array<{
+    key?: string
+    id?: string
+    max_context_length?: number
+    loaded_instances?: Array<{
+      config?: { context_length?: number }
+    }>
+    capabilities?: { vision?: boolean }
+  }>
+
+  const model = data.find((m) => (m.key ?? m.id) === modelId)
+  if (!model) throw new Error(`Model ${modelId} not found in LM Studio`)
+
+  const loadedContext = model.loaded_instances?.[0]?.config?.context_length
+  const ctxLen = loadedContext ?? model.max_context_length
+  const supportsVision = model.capabilities?.vision ?? false
+
+  if (ctxLen) {
+    return { contextWindow: ctxLen, source: 'backend', supportsVision }
+  }
+  throw new Error('No context_length in LM Studio response')
 }
 
 // ============================================================================

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -472,7 +472,7 @@ export interface Diagnostic {
 // ============================================================================
 
 /** Supported LLM inference backends */
-export type LlmBackend = 'vllm' | 'sglang' | 'ollama' | 'llamacpp' | 'opencode-go' | 'unknown'
+export type LlmBackend = 'vllm' | 'sglang' | 'ollama' | 'llamacpp' | 'lmstudio' | 'opencode-go' | 'unknown'
 
 /** Extended backend type including cloud providers */
 export type ProviderBackend = LlmBackend | 'openai' | 'anthropic'

--- a/web/src/components/shared/ProviderModal.tsx
+++ b/web/src/components/shared/ProviderModal.tsx
@@ -5,7 +5,7 @@ import type { ModelConfig as SharedModelConfig } from '@shared/types.js'
 import { ChevronDownIcon } from './icons'
 import { QueryParamsInput } from './QueryParamsInput'
 
-const COMMON_PORTS = [8080, 11434, 8000]
+const COMMON_PORTS = [8080, 11434, 8000, 1234]
 
 interface ModelInfo {
   id: string
@@ -420,6 +420,7 @@ export function ProviderModal({
     try {
       const params = new URLSearchParams({ url })
       if (formApiKey) params.set('apiKey', formApiKey)
+      if (formBackend) params.set('backend', formBackend)
       const response = await authFetch(`/api/providers/models?${params.toString()}`)
       if (response.ok) {
         const data = (await response.json()) as { models: ModelInfo[]; url: string }
@@ -633,7 +634,7 @@ export function ProviderModal({
           <div className="px-6 py-4 space-y-4">
             <div>
               <label className="block text-sm text-text-secondary mb-2">Inference engine</label>
-              <div className="grid grid-cols-4 gap-2">
+              <div className="grid grid-cols-5 gap-2">
                 <button
                   key="other"
                   type="button"
@@ -655,11 +656,13 @@ export function ProviderModal({
                     8000: 'vllm',
                     11434: 'ollama',
                     8080: 'llamacpp',
+                    1234: 'lmstudio',
                   }
                   const nameMap: Record<number, string> = {
                     8000: 'vLLM',
                     11434: 'Ollama',
                     8080: 'llama.cpp',
+                    1234: 'LM Studio',
                   }
                   return (
                     <button

--- a/web/src/stores/config.ts
+++ b/web/src/stores/config.ts
@@ -4,7 +4,16 @@ import type { ModelConfig } from '@shared/types.js'
 
 type LlmStatus = 'connected' | 'disconnected' | 'unknown'
 
-type Backend = 'vllm' | 'sglang' | 'ollama' | 'llamacpp' | 'openai' | 'anthropic' | 'opencode-go' | 'unknown'
+type Backend =
+  | 'vllm'
+  | 'sglang'
+  | 'ollama'
+  | 'llamacpp'
+  | 'lmstudio'
+  | 'openai'
+  | 'anthropic'
+  | 'opencode-go'
+  | 'unknown'
 type ProviderStatus = 'connected' | 'disconnected' | 'unknown'
 
 interface Provider {
@@ -66,6 +75,8 @@ function getBackendDisplayName(backend: Backend): string {
       return 'Ollama'
     case 'llamacpp':
       return 'llama.cpp'
+    case 'lmstudio':
+      return 'LM Studio'
     case 'openai':
       return 'OpenAI'
     case 'anthropic':


### PR DESCRIPTION
## Problem

OpenFox discovers models via `/v1/models` (OpenAI-compatible), which only returns model IDs. LM Studio has a native API at `/api/v1/models` that exposes the **actually loaded** context length (`loaded_instances[0].config.context_length`), which is often smaller than the model's theoretical max. OpenFox defaults to 200K, overestimates the context, and LM Studio rejects requests when compaction triggers too late.

## Solution

Add `lmstudio` as a first-class backend type (like Ollama). When selected, OpenFox hits LM Studio's native `GET /api/v1/models` endpoint to extract the loaded context length instead of defaulting to 200K.

## Changes

- **`src/shared/types.ts`** — Add `'lmstudio'` to `LlmBackend`
- **`src/server/llm/backend.ts`** — Add capabilities and display name for `lmstudio`
- **`src/server/provider-manager.ts`** — Add `fetchLmStudioModelsWithContext()` with fallback to `/v1/models`
- **`src/server/providers/auto-config.ts`** — Add `detectLmstudioInfo()` for auto-config probing
- **`src/server/index.ts`** — Pass `backend` param to `/api/providers/models` endpoint
- **`web/src/components/shared/ProviderModal.tsx`** — Add LM Studio button (port 1234)
- **`web/src/stores/config.ts`** — Add `lmstudio` to frontend Backend type

## How it works

1. User selects **LM Studio** (port 1234) as the backend in the provider modal
2. Model discovery hits `GET {baseUrl}/api/v1/models` (native endpoint)
3. Context extraction prefers `loaded_instances[0].config.context_length` over `max_context_length`
4. Falls back to standard `/v1/models` + 200K default if native endpoint is unreachable

## Context window priority

1. `loaded_instances[].config.context_length` (actually loaded)
2. `max_context_length` (model's theoretical max)
3. User-configured value (`source: 'user'`)

Closes #49
