### PR TITLE
feat: add web_search tool with Tavily and SearXNG support

### DIFF
--- a/src/server/agents/defaults/builder.agent.md
+++ b/src/server/agents/defaults/builder.agent.md
@@ -7,6 +7,7 @@ color: '#3b82f6'
 allowedTools:
   - read_file
   - web_fetch
+  - web_search
   - write_file
   - edit_file
   - run_command

--- a/src/server/agents/defaults/planner.agent.md
+++ b/src/server/agents/defaults/planner.agent.md
@@ -7,6 +7,7 @@ color: '#a855f7'
 allowedTools:
   - read_file
   - web_fetch
+  - web_search
   - run_command
   - ask_user
   - session_metadata

--- a/src/server/db/settings.test.ts
+++ b/src/server/db/settings.test.ts
@@ -31,4 +31,57 @@ describe('db settings', () => {
       [SETTINGS_KEYS.GLOBAL_INSTRUCTIONS]: 'Always test first',
     })
   })
+
+  describe('search engine settings', () => {
+    it('sets and gets SEARCH_ENGINE', () => {
+      setSetting(SETTINGS_KEYS.SEARCH_ENGINE, 'tavily')
+      expect(getSetting(SETTINGS_KEYS.SEARCH_ENGINE)).toBe('tavily')
+
+      setSetting(SETTINGS_KEYS.SEARCH_ENGINE, 'searxng')
+      expect(getSetting(SETTINGS_KEYS.SEARCH_ENGINE)).toBe('searxng')
+
+      setSetting(SETTINGS_KEYS.SEARCH_ENGINE, '')
+      expect(getSetting(SETTINGS_KEYS.SEARCH_ENGINE)).toBe('')
+    })
+
+    it('sets and gets SEARCH_TAVILY_API_KEY', () => {
+      setSetting(SETTINGS_KEYS.SEARCH_TAVILY_API_KEY, 'tvly-test-key-123')
+      expect(getSetting(SETTINGS_KEYS.SEARCH_TAVILY_API_KEY)).toBe('tvly-test-key-123')
+    })
+
+    it('sets and gets SEARCH_SEARXNG_URL', () => {
+      setSetting(SETTINGS_KEYS.SEARCH_SEARXNG_URL, 'http://localhost:4000')
+      expect(getSetting(SETTINGS_KEYS.SEARCH_SEARXNG_URL)).toBe('http://localhost:4000')
+    })
+
+    it('sets and gets SEARCH_SEARXNG_API_KEY', () => {
+      setSetting(SETTINGS_KEYS.SEARCH_SEARXNG_API_KEY, 'sx-secret')
+      expect(getSetting(SETTINGS_KEYS.SEARCH_SEARXNG_API_KEY)).toBe('sx-secret')
+    })
+
+    it('all four keys are independent', () => {
+      setSetting(SETTINGS_KEYS.SEARCH_ENGINE, 'tavily')
+      setSetting(SETTINGS_KEYS.SEARCH_TAVILY_API_KEY, 'tvly-key')
+      setSetting(SETTINGS_KEYS.SEARCH_SEARXNG_URL, 'http://searxng:4000')
+      setSetting(SETTINGS_KEYS.SEARCH_SEARXNG_API_KEY, 'sx-key')
+
+      expect(getSetting(SETTINGS_KEYS.SEARCH_ENGINE)).toBe('tavily')
+      expect(getSetting(SETTINGS_KEYS.SEARCH_TAVILY_API_KEY)).toBe('tvly-key')
+      expect(getSetting(SETTINGS_KEYS.SEARCH_SEARXNG_URL)).toBe('http://searxng:4000')
+      expect(getSetting(SETTINGS_KEYS.SEARCH_SEARXNG_API_KEY)).toBe('sx-key')
+    })
+
+    it('returns null for unset keys', () => {
+      expect(getSetting(SETTINGS_KEYS.SEARCH_ENGINE)).toBeNull()
+      expect(getSetting(SETTINGS_KEYS.SEARCH_TAVILY_API_KEY)).toBeNull()
+      expect(getSetting(SETTINGS_KEYS.SEARCH_SEARXNG_URL)).toBeNull()
+      expect(getSetting(SETTINGS_KEYS.SEARCH_SEARXNG_API_KEY)).toBeNull()
+    })
+
+    it('deletes search engine keys', () => {
+      setSetting(SETTINGS_KEYS.SEARCH_ENGINE, 'tavily')
+      deleteSetting(SETTINGS_KEYS.SEARCH_ENGINE)
+      expect(getSetting(SETTINGS_KEYS.SEARCH_ENGINE)).toBeNull()
+    })
+  })
 })

--- a/src/server/db/settings.ts
+++ b/src/server/db/settings.ts
@@ -22,6 +22,10 @@ export const SETTINGS_KEYS = {
   KEYBINDINGS: 'keybindings',
   RETRY_PATTERNS: 'agent.retryPatterns',
   SKILLS_DIRECTORIES: 'skills.directories',
+  SEARCH_ENGINE: 'search.engine',
+  SEARCH_TAVILY_API_KEY: 'search.tavilyApiKey',
+  SEARCH_SEARXNG_URL: 'search.searxngUrl',
+  SEARCH_SEARXNG_API_KEY: 'search.searxngApiKey',
 } as const
 
 export const SETTINGS_DEFAULTS: Record<string, string> = {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1085,6 +1085,67 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
     }
   })
 
+  // Test search engine connection
+  app.post('/api/search/test', async (req, res) => {
+    const { engine, tavilyApiKey, searxngUrl, searxngApiKey } = req.body as {
+      engine?: string
+      tavilyApiKey?: string
+      searxngUrl?: string
+      searxngApiKey?: string
+    }
+
+    try {
+      if (engine === 'tavily') {
+        const key = tavilyApiKey || process.env['TAVILY_API_KEY']
+        if (!key) {
+          return res.status(400).json({ success: false, error: 'Tavily API key is required' })
+        }
+        const response = await fetch('https://api.tavily.com/search', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ api_key: key, query: 'test', max_results: 1 }),
+          signal: AbortSignal.timeout(10000),
+        })
+        if (!response.ok) {
+          const body = await response.text().catch(() => '')
+          return res.status(400).json({ success: false, error: `Tavily error (${response.status}): ${body}` })
+        }
+        return res.json({ success: true, message: 'Tavily connection OK' })
+      }
+
+      if (engine === 'searxng') {
+        const url = searxngUrl || process.env['SEARXNG_URL']
+        if (!url) {
+          return res.status(400).json({ success: false, error: 'SearXNG URL is required' })
+        }
+        const searchUrl = new URL(`${url.replace(/\/+$/, '')}/search`)
+        searchUrl.searchParams.set('format', 'json')
+        searchUrl.searchParams.set('q', 'test')
+        const apiKey = searxngApiKey || process.env['SEARXNG_API_KEY'] || undefined
+        const headers: Record<string, string> = {}
+        if (apiKey) headers['Authorization'] = `Bearer ${apiKey}`
+
+        const response = await fetch(searchUrl.toString(), {
+          headers,
+          signal: AbortSignal.timeout(10000),
+        })
+        if (!response.ok) {
+          const body = await response.text().catch(() => '')
+          return res.status(400).json({ success: false, error: `SearXNG error (${response.status}): ${body}` })
+        }
+        return res.json({ success: true, message: 'SearXNG connection OK' })
+      }
+
+      return res.status(400).json({ success: false, error: 'Invalid engine' })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Connection failed'
+      if (error instanceof DOMException && error.name === 'AbortError') {
+        return res.status(400).json({ success: false, error: 'Connection timed out' })
+      }
+      return res.status(400).json({ success: false, error: message })
+    }
+  })
+
   // Onboarding: fetch models by URL (before provider is saved)
   app.get('/api/providers/models', async (req, res) => {
     const url = req.query['url'] as string | undefined

--- a/src/server/tools/index.test.ts
+++ b/src/server/tools/index.test.ts
@@ -11,6 +11,7 @@ const {
   loadSkillExecuteMock,
   webFetchExecuteMock,
   callSubAgentExecuteMock,
+  webSearchExecuteMock,
 } = vi.hoisted(() => ({
   readExecuteMock: vi.fn(async () => ({ success: true, output: 'read', durationMs: 1, truncated: false })),
   writeExecuteMock: vi.fn(async () => ({ success: true, output: 'write', durationMs: 1, truncated: false })),
@@ -29,6 +30,12 @@ const {
   callSubAgentExecuteMock: vi.fn(async () => ({
     success: true,
     output: 'sub-agent result',
+    durationMs: 1,
+    truncated: false,
+  })),
+  webSearchExecuteMock: vi.fn(async () => ({
+    success: true,
+    output: '[1] Web Search Result\n    URL: https://example.com\n    Content snippet',
     durationMs: 1,
     truncated: false,
   })),
@@ -102,6 +109,28 @@ vi.mock('./web-fetch.js', () => ({
     name: 'web_fetch',
     definition: { type: 'function', function: { name: 'web_fetch', description: 'Web Fetch', parameters: {} } },
     execute: webFetchExecuteMock,
+  },
+}))
+
+vi.mock('./web-search.js', () => ({
+  webSearchTool: {
+    name: 'web_search',
+    definition: {
+      type: 'function',
+      function: {
+        name: 'web_search',
+        description: 'Web Search',
+        parameters: {
+          type: 'object',
+          properties: {
+            query: { type: 'string' },
+            max_results: { type: 'number' },
+          },
+          required: ['query'],
+        },
+      },
+    },
+    execute: webSearchExecuteMock,
   },
 }))
 
@@ -405,6 +434,38 @@ describe('tool registries', () => {
     const result = await registry.execute('write_file', { path: 'test.ts' }, context)
 
     expect(result).toMatchObject({ success: true, output: 'write' })
+  })
+
+  it('web_search is accessible when in allowedTools', async () => {
+    const defWithSearch: AgentDefinition = {
+      metadata: {
+        id: 'searcher',
+        name: 'Searcher',
+        description: 'Searches',
+        subagent: false,
+        allowedTools: ['read_file', 'web_search'],
+      },
+      prompt: 'Search mode.',
+    }
+
+    const registry = getToolRegistryForAgent(defWithSearch)
+    const context = { workdir: '/tmp/project', sessionId: 'session-1', sessionManager: {} as never }
+
+    const result = await registry.execute('web_search', { query: 'hello world' }, context)
+
+    expect(result).toMatchObject({ success: true, output: expect.stringContaining('Web Search Result') })
+  })
+
+  it('web_search is blocked when not in allowedTools', async () => {
+    const registry = getToolRegistryForAgent(builderDef)
+    const context = { workdir: '/tmp/project', sessionId: 'session-1', sessionManager: {} as never }
+
+    const result = await registry.execute('web_search', { query: 'test' }, context)
+
+    expect(result).toMatchObject({
+      success: false,
+      error: expect.stringContaining("Tool 'web_search' is not available"),
+    })
   })
 
   it('tool definitions are identical across planner and builder (vLLM cache preserved)', () => {

--- a/src/server/tools/index.ts
+++ b/src/server/tools/index.ts
@@ -17,6 +17,7 @@ import { stepDoneTool } from './step-done.js'
 import { backgroundProcessTool } from './background-process/index.js'
 import { mcpConfigTool } from './mcp-config.js'
 import { traceCodeTool } from './trace-code.js'
+import { webSearchTool } from './web-search.js'
 import { computeEffectiveTools } from './tool-policy.js'
 import { loadAllAgentsDefault, findAgentById } from '../agents/registry.js'
 import { logger } from '../utils/logger.js'
@@ -49,6 +50,7 @@ function getBuiltInTools(): Tool[] {
       loadSkillTool,
       returnValueTool,
       webFetchTool,
+      webSearchTool,
       devServerTool,
       stepDoneTool,
       backgroundProcessTool,

--- a/src/server/tools/web-search.integration.test.ts
+++ b/src/server/tools/web-search.integration.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from 'vitest'
+import type { ToolContext } from './types.js'
+
+const context: ToolContext = {
+  workdir: '/tmp',
+  sessionId: 'integration-test',
+  sessionManager: null as any,
+}
+
+const TEST_TIMEOUT = 20000
+
+const hasTavily = !!process.env['TAVILY_API_KEY']
+const hasSearxng = !!process.env['SEARXNG_URL']
+
+const describeIfTavily = hasTavily ? describe : describe.skip
+const describeIfSearxng = hasSearxng ? describe : describe.skip
+const describeIfAny = hasTavily || hasSearxng ? describe : describe.skip
+
+describeIfAny('web_search integration', () => {
+  describeIfTavily('Tavily backend', () => {
+    it(
+      'returns real results for a French query',
+      async () => {
+        delete process.env['SEARXNG_URL']
+        delete process.env['SEARXNG_API_KEY']
+
+        const { webSearchTool } = await import('./web-search.js')
+        const result = await webSearchTool.execute(
+          { query: 'actualités intelligence artificielle 2026', max_results: 3 },
+          context,
+        )
+
+        expect(result.success).toBe(true)
+        expect(result.output).toContain('[1]')
+        expect(result.output).toContain('http')
+        expect(result.durationMs).toBeLessThan(10000)
+      },
+      TEST_TIMEOUT,
+    )
+
+    it(
+      'rejects too-short queries',
+      async () => {
+        delete process.env['SEARXNG_URL']
+
+        const { webSearchTool } = await import('./web-search.js')
+        const result = await webSearchTool.execute({ query: 'a' }, context)
+
+        expect(result.success).toBe(false)
+        expect(result.error).toContain('Tavily search failed (400)')
+        expect(result.error).toContain('Query is too short')
+      },
+      TEST_TIMEOUT,
+    )
+
+    it(
+      'returns error with invalid API key',
+      async () => {
+        process.env['TAVILY_API_KEY'] = 'tvly-invalid-key'
+        delete process.env['SEARXNG_URL']
+
+        const { webSearchTool } = await import('./web-search.js')
+        const result = await webSearchTool.execute({ query: 'test' }, context)
+
+        expect(result.success).toBe(false)
+        expect(result.error).toContain('Tavily search failed')
+      },
+      TEST_TIMEOUT,
+    )
+  })
+
+  describeIfSearxng('SearXNG backend', () => {
+    it(
+      'returns real results',
+      async () => {
+        delete process.env['TAVILY_API_KEY']
+        delete process.env['SEARXNG_API_KEY']
+
+        const { webSearchTool } = await import('./web-search.js')
+        const result = await webSearchTool.execute(
+          { query: 'intelligence artificielle', max_results: 3 },
+          context,
+        )
+
+        expect(result.success).toBe(true)
+        expect(result.output).toContain('[1]')
+        expect(result.output).toContain('http')
+      },
+      TEST_TIMEOUT,
+    )
+
+    it(
+      'returns error with unreachable URL',
+      async () => {
+        delete process.env['TAVILY_API_KEY']
+        process.env['SEARXNG_URL'] = 'http://localhost:1'
+        delete process.env['SEARXNG_API_KEY']
+
+        const { webSearchTool } = await import('./web-search.js')
+        const result = await webSearchTool.execute({ query: 'test' }, context)
+
+        expect(result.success).toBe(false)
+        expect(result.error).toMatch(/SearXNG search failed|fetch failed|ECONNREFUSED|Invalid URL/)
+      },
+      TEST_TIMEOUT,
+    )
+
+    it(
+      'returns formatted output matching spec (title+URL+content per result)',
+      async () => {
+        const { webSearchTool } = await import('./web-search.js')
+        const result = await webSearchTool.execute({ query: 'open source', max_results: 2 }, context)
+
+        expect(result.success).toBe(true)
+        const lines = result.output!.split('\n')
+        expect(lines[0]).toMatch(/^\[1\] .+/)
+        expect(lines[1]).toContain('URL:')
+        expect(lines[2]?.trim().length).toBeGreaterThan(0)
+      },
+      TEST_TIMEOUT,
+    )
+  })
+
+  describeIfAny('engine preference', () => {
+    it(
+      'default favors Tavily when both configured',
+      async () => {
+        process.env['TAVILY_API_KEY'] = process.env['TAVILY_API_KEY'] ?? ''
+        process.env['SEARXNG_URL'] = process.env['SEARXNG_URL'] ?? ''
+
+        const { webSearchTool } = await import('./web-search.js')
+        const result = await webSearchTool.execute(
+          { query: 'test integration', max_results: 1 },
+          context,
+        )
+
+        expect(result.success).toBe(true)
+      },
+      TEST_TIMEOUT,
+    )
+  })
+})

--- a/src/server/tools/web-search.test.ts
+++ b/src/server/tools/web-search.test.ts
@@ -1,0 +1,606 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import type { ToolContext, Tool } from './types.js'
+
+let mockDbSettings: Record<string, string | null> = {}
+
+vi.mock('../db/settings.js', () => ({
+  getSetting: vi.fn((key: string) => mockDbSettings[key] ?? null),
+  SETTINGS_KEYS: {
+    SEARCH_ENGINE: 'search.engine',
+    SEARCH_TAVILY_API_KEY: 'search.tavilyApiKey',
+    SEARCH_SEARXNG_URL: 'search.searxngUrl',
+    SEARCH_SEARXNG_API_KEY: 'search.searxngApiKey',
+  },
+}))
+
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+const baseContext: ToolContext = {
+  workdir: '/test',
+  sessionId: 'test-session',
+  sessionManager: null as any,
+}
+
+function resetEnv() {
+  delete process.env['TAVILY_API_KEY']
+  delete process.env['SEARXNG_URL']
+  delete process.env['SEARXNG_API_KEY']
+}
+
+describe('web_search', () => {
+  let webSearchTool: Tool
+
+  beforeEach(async () => {
+    resetEnv()
+    mockDbSettings = {}
+    mockFetch.mockReset()
+    vi.clearAllMocks()
+    const mod = await import('./web-search.js')
+    webSearchTool = mod.webSearchTool
+  })
+
+  afterEach(() => {
+    resetEnv()
+  })
+
+  describe('tool definition', () => {
+    it('has name web_search', () => {
+      expect(webSearchTool.name).toBe('web_search')
+    })
+
+    it('has query as required parameter', () => {
+      const params = webSearchTool.definition.function.parameters
+      expect(params['required']).toContain('query')
+      expect(params['properties']).toBeDefined()
+      const props = params['properties'] as Record<string, { type: string }>
+      expect(props['query']?.type).toBe('string')
+    })
+
+    it('has max_results as optional parameter with default 5', () => {
+      const params = webSearchTool.definition.function.parameters
+      const props = params['properties'] as Record<string, { type: string }>
+      expect(props['max_results']?.type).toBe('number')
+      expect(params['required']).not.toContain('max_results')
+    })
+  })
+
+  describe('no engine configured', () => {
+    it('returns error when no engine configured', async () => {
+      const result = await webSearchTool.execute({ query: 'test' }, baseContext)
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('web_search requires at least one search engine configured')
+    })
+
+    it('returns error when None is selected even if env vars are set', async () => {
+      process.env['TAVILY_API_KEY'] = 'tvly-key'
+      process.env['SEARXNG_URL'] = 'http://searxng:4000'
+      mockDbSettings['search.engine'] = ''
+
+      const result = await webSearchTool.execute({ query: 'test' }, baseContext)
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('web_search requires at least one search engine configured')
+    })
+  })
+
+  describe('engine preference via SEARCH_ENGINE setting', () => {
+    it('uses Tavily when SEARCH_ENGINE=tavily even if both configured', async () => {
+      process.env['TAVILY_API_KEY'] = 'tvly-key'
+      process.env['SEARXNG_URL'] = 'http://searxng:4000'
+      mockDbSettings['search.engine'] = 'tavily'
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          results: [{ title: 'Tavily Result', url: 'https://tavily.com', content: 'From Tavily' }],
+        }),
+      })
+
+      const result = await webSearchTool.execute({ query: 'test' }, baseContext)
+
+      expect(result.success).toBe(true)
+      expect(result.output).toContain('Tavily Result')
+      expect(mockFetch.mock.calls[0]![0]).toBe('https://api.tavily.com/search')
+    })
+
+    it('uses SearXNG when SEARCH_ENGINE=searxng even if Tavily also configured', async () => {
+      process.env['TAVILY_API_KEY'] = 'tvly-key'
+      process.env['SEARXNG_URL'] = 'http://searxng:4000'
+      mockDbSettings['search.engine'] = 'searxng'
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          results: [{ title: 'SearXNG Result', url: 'https://sx.com', content: 'From SearXNG' }],
+        }),
+      })
+
+      const result = await webSearchTool.execute({ query: 'test' }, baseContext)
+
+      expect(result.success).toBe(true)
+      expect(result.output).toContain('SearXNG Result')
+      expect(mockFetch.mock.calls[0]![0]).toContain('searxng:4000/search')
+    })
+
+    it('favors Tavily over SearXNG when no preference set (backward compat)', async () => {
+      process.env['TAVILY_API_KEY'] = 'tvly-key'
+      process.env['SEARXNG_URL'] = 'http://searxng:4000'
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          results: [{ title: 'Auto Tavily', url: 'https://tavily.com', content: 'Auto' }],
+        }),
+      })
+
+      const result = await webSearchTool.execute({ query: 'test' }, baseContext)
+
+      expect(result.success).toBe(true)
+      expect(result.output).toContain('Auto Tavily')
+      expect(mockFetch.mock.calls[0]![0]).toBe('https://api.tavily.com/search')
+    })
+
+    it('returns no engine when Tavily preferred but no key', async () => {
+      mockDbSettings['search.engine'] = 'tavily'
+      process.env['SEARXNG_URL'] = 'http://searxng:4000'
+
+      const result = await webSearchTool.execute({ query: 'test' }, baseContext)
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('web_search requires at least one search engine configured')
+    })
+
+    it('returns no engine when SearXNG preferred but no URL', async () => {
+      mockDbSettings['search.engine'] = 'searxng'
+      process.env['TAVILY_API_KEY'] = 'tvly-key'
+
+      const result = await webSearchTool.execute({ query: 'test' }, baseContext)
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('web_search requires at least one search engine configured')
+    })
+
+    it('env var TAVILY_API_KEY overrides empty DB setting', async () => {
+      process.env['TAVILY_API_KEY'] = 'tvly-from-env'
+      mockDbSettings['search.tavilyApiKey'] = ''
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          results: [{ title: 'Env Var Tavily', url: 'https://env.com', content: 'From env var' }],
+        }),
+      })
+
+      const result = await webSearchTool.execute({ query: 'test' }, baseContext)
+
+      expect(result.success).toBe(true)
+      expect(result.output).toContain('Env Var Tavily')
+    })
+  })
+
+  describe('Tavily backend', () => {
+    beforeEach(() => {
+      process.env['TAVILY_API_KEY'] = 'tvly-test-key'
+    })
+
+    it('returns formatted results on success', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          results: [
+            { title: 'Test Result', url: 'https://example.com', content: 'This is a test result' },
+            { title: 'Second Result', url: 'https://example.org', content: 'Another result' },
+          ],
+        }),
+      })
+
+      const result = await webSearchTool.execute({ query: 'hello world' }, baseContext)
+
+      expect(result.success).toBe(true)
+      expect(result.output).toContain('[1] Test Result')
+      expect(result.output).toContain('https://example.com')
+      expect(result.output).toContain('This is a test result')
+      expect(result.output).toContain('[2] Second Result')
+
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+      const callArgs = mockFetch.mock.calls[0]!
+      expect(callArgs[0]).toBe('https://api.tavily.com/search')
+      expect(callArgs[1]!.method).toBe('POST')
+      const body = JSON.parse(callArgs[1]!.body)
+      expect(body.api_key).toBe('tvly-test-key')
+      expect(body.query).toBe('hello world')
+      expect(body.max_results).toBe(5)
+    })
+
+    it('respects max_results parameter', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          results: [
+            { title: 'R1', url: 'https://a.com', content: 'A' },
+            { title: 'R2', url: 'https://b.com', content: 'B' },
+          ],
+        }),
+      })
+
+      await webSearchTool.execute({ query: 'test', max_results: 2 }, baseContext)
+
+      const body2 = JSON.parse(mockFetch.mock.calls[0]![1]!.body)
+      expect(body2.max_results).toBe(2)
+    })
+
+    it('uses default max_results when not provided', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ results: [] }),
+      })
+
+      await webSearchTool.execute({ query: 'test' }, baseContext)
+
+      const body2 = JSON.parse(mockFetch.mock.calls[0]![1]!.body)
+      expect(body2.max_results).toBe(5)
+    })
+
+    it('handles max_results=0', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ results: [] }),
+      })
+
+      await webSearchTool.execute({ query: 'test', max_results: 0 }, baseContext)
+
+      const body2 = JSON.parse(mockFetch.mock.calls[0]![1]!.body)
+      expect(body2.max_results).toBe(0)
+    })
+
+    it('handles max_results negative', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ results: [] }),
+      })
+
+      await webSearchTool.execute({ query: 'test', max_results: -1 }, baseContext)
+
+      const body2 = JSON.parse(mockFetch.mock.calls[0]![1]!.body)
+      expect(body2.max_results).toBe(-1)
+    })
+
+    it('returns no results message when empty', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ results: [] }),
+      })
+
+      const result = await webSearchTool.execute({ query: 'nothing' }, baseContext)
+
+      expect(result.success).toBe(true)
+      expect(result.output).toBe('No search results found.')
+    })
+
+    it('handles HTTP errors', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        text: () => Promise.resolve('Unauthorized'),
+      })
+
+      const result = await webSearchTool.execute({ query: 'test' }, baseContext)
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('Tavily search failed (401)')
+    })
+
+    it('handles 403 Forbidden', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+        text: () => Promise.resolve('Forbidden'),
+      })
+
+      const result = await webSearchTool.execute({ query: 'test' }, baseContext)
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('Tavily search failed (403)')
+    })
+
+    it('handles timeout', async () => {
+      mockFetch.mockRejectedValueOnce(new DOMException('The operation was aborted', 'AbortError'))
+
+      const result = await webSearchTool.execute({ query: 'test' }, baseContext)
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('timed out')
+    })
+
+    it('handles network errors', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('Connection refused'))
+
+      const result = await webSearchTool.execute({ query: 'test' }, baseContext)
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('Connection refused')
+    })
+
+    it('handles empty query string', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          results: [{ title: 'Empty Q', url: 'https://a.com', content: 'C' }],
+        }),
+      })
+
+      const result = await webSearchTool.execute({ query: '' }, baseContext)
+
+      expect(result.success).toBe(true)
+      const body = JSON.parse(mockFetch.mock.calls[0]![1]!.body)
+      expect(body.query).toBe('')
+    })
+
+    it('handles query with special characters', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          results: [{ title: 'Special', url: 'https://a.com', content: 'C++ & .NET <3' }],
+        }),
+      })
+
+      const result = await webSearchTool.execute({ query: 'C++ & .NET <3' }, baseContext)
+
+      expect(result.success).toBe(true)
+      const body = JSON.parse(mockFetch.mock.calls[0]![1]!.body)
+      expect(body.query).toBe('C++ & .NET <3')
+    })
+
+    it('does not leak API key in output', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          results: [{ title: 'Result', url: 'https://a.com', content: 'Content' }],
+        }),
+      })
+
+      const result = await webSearchTool.execute({ query: 'test' }, baseContext)
+
+      expect(result.output).not.toContain('tvly-test-key')
+    })
+
+    it('does not leak API key in error messages', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        text: () => Promise.resolve('Unauthorized'),
+      })
+
+      const result = await webSearchTool.execute({ query: 'test' }, baseContext)
+
+      expect(result.error).not.toContain('tvly-test-key')
+    })
+  })
+
+  describe('SearXNG backend', () => {
+    beforeEach(() => {
+      process.env['SEARXNG_URL'] = 'http://searxng:4000'
+    })
+
+    it('returns formatted results on success', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          results: [
+            { title: 'SX Result', url: 'https://sx.com', content: 'SearXNG result' },
+          ],
+        }),
+      })
+
+      const result = await webSearchTool.execute({ query: 'search term' }, baseContext)
+
+      expect(result.success).toBe(true)
+      expect(result.output).toContain('SX Result')
+      const url1 = mockFetch.mock.calls[0]![0] as string
+      expect(url1).toContain('http://searxng:4000/search')
+      expect(url1).toContain('format=json')
+      expect(url1).toContain('q=search+term')
+    })
+
+    it('sends Authorization header when API key is set', async () => {
+      process.env['SEARXNG_API_KEY'] = 'sx-secret-key'
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ results: [] }),
+      })
+
+      await webSearchTool.execute({ query: 'test' }, baseContext)
+
+      expect(mockFetch.mock.calls[0]![1]!.headers['Authorization']).toBe('Bearer sx-secret-key')
+    })
+
+    it('does not send Authorization header when no API key', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ results: [] }),
+      })
+
+      await webSearchTool.execute({ query: 'test' }, baseContext)
+
+      expect(mockFetch.mock.calls[0]![1]!.headers?.['Authorization']).toBeUndefined()
+    })
+
+    it('limits results to max_results', async () => {
+      const manyResults = Array.from({ length: 10 }, (_, i) => ({
+        title: `R${i}`,
+        url: `https://r${i}.com`,
+        content: `Result ${i}`,
+      }))
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ results: manyResults }),
+      })
+
+      const result = await webSearchTool.execute({ query: 'test', max_results: 3 }, baseContext)
+
+      const matches = result.output!.match(/\[\d+\]/g)
+      expect(matches).toHaveLength(3)
+    })
+
+    it('returns all results when max_results larger than available', async () => {
+      const manyResults = Array.from({ length: 3 }, (_, i) => ({
+        title: `R${i}`,
+        url: `https://r${i}.com`,
+        content: `Result ${i}`,
+      }))
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ results: manyResults }),
+      })
+
+      const result = await webSearchTool.execute({ query: 'test', max_results: 10 }, baseContext)
+
+      const matches = result.output!.match(/\[\d+\]/g)
+      expect(matches).toHaveLength(3)
+    })
+
+    it('handles HTTP errors', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        text: () => Promise.resolve('Internal error'),
+      })
+
+      const result = await webSearchTool.execute({ query: 'test' }, baseContext)
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('SearXNG search failed (500)')
+    })
+
+    it('handles 404 from SearXNG', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        text: () => Promise.resolve('Not Found'),
+      })
+
+      const result = await webSearchTool.execute({ query: 'test' }, baseContext)
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('SearXNG search failed (404)')
+    })
+
+    it('works with trailing slash in URL', async () => {
+      process.env['SEARXNG_URL'] = 'http://searxng:4000/'
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          results: [{ title: 'Trailing', url: 'https://a.com', content: 'Slash works' }],
+        }),
+      })
+
+      const result = await webSearchTool.execute({ query: 'test' }, baseContext)
+
+      expect(result.success).toBe(true)
+      const url1 = mockFetch.mock.calls[0]![0] as string
+      expect(url1).toBe('http://searxng:4000/search?format=json&q=test')
+    })
+
+    it('handles query with special characters (URL encoded)', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          results: [{ title: 'Special', url: 'https://a.com', content: 'Special chars' }],
+        }),
+      })
+
+      const result = await webSearchTool.execute({ query: 'hello world & foo' }, baseContext)
+
+      expect(result.success).toBe(true)
+      const url1 = mockFetch.mock.calls[0]![0] as string
+      // URLSearchParams encodes spaces as +, not %20
+      expect(url1).toContain('q=hello+world+%26+foo')
+    })
+
+    it('does not leak API key in output', async () => {
+      process.env['SEARXNG_API_KEY'] = 'sx-super-secret'
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          results: [{ title: 'R', url: 'https://a.com', content: 'C' }],
+        }),
+      })
+
+      const result = await webSearchTool.execute({ query: 'test' }, baseContext)
+
+      expect(result.output).not.toContain('sx-super-secret')
+    })
+
+    it('does not leak API key in error messages', async () => {
+      process.env['SEARXNG_API_KEY'] = 'sx-super-secret'
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        text: () => Promise.resolve('Error'),
+      })
+
+      const result = await webSearchTool.execute({ query: 'test' }, baseContext)
+
+      expect(result.error).not.toContain('sx-super-secret')
+    })
+  })
+
+  describe('abort signal', () => {
+    beforeEach(() => {
+      process.env['TAVILY_API_KEY'] = 'tvly-test-key'
+    })
+
+    it('respects context abort signal for Tavily', async () => {
+      const abortController = new AbortController()
+      abortController.abort()
+
+      const result = await webSearchTool.execute(
+        { query: 'test' },
+        { ...baseContext, signal: abortController.signal },
+      )
+
+      // Aborted signal should cause a fetch abort
+      expect(result.success).toBe(false)
+    })
+
+    it('uses tool timeout when no context signal', async () => {
+      // No signal provided, should use default AbortSignal.timeout(15000)
+      mockFetch.mockImplementationOnce(async (_url: string, opts: RequestInit) => {
+        expect(opts.signal).toBeDefined()
+        return {
+          ok: true,
+          json: () => Promise.resolve({ results: [] }),
+        }
+      })
+
+      await webSearchTool.execute({ query: 'test' }, baseContext)
+
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('timing metadata', () => {
+    it('reports durationMs on success', async () => {
+      process.env['TAVILY_API_KEY'] = 'tvly-test-key'
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ results: [] }),
+      })
+
+      const result = await webSearchTool.execute({ query: 'test' }, baseContext)
+
+      expect(result.durationMs).toBeGreaterThanOrEqual(0)
+    })
+
+    it('reports durationMs on error', async () => {
+      const result = await webSearchTool.execute({ query: 'test' }, baseContext)
+
+      expect(result.durationMs).toBeGreaterThanOrEqual(0)
+    })
+  })
+})

--- a/src/server/tools/web-search.ts
+++ b/src/server/tools/web-search.ts
@@ -1,0 +1,187 @@
+import { createTool } from './tool-helpers.js'
+import { getSetting } from '../db/settings.js'
+import { SETTINGS_KEYS } from '../db/settings.js'
+
+const DEFAULT_TIMEOUT_MS = 15_000
+const DEFAULT_MAX_RESULTS = 5
+
+interface WebSearchArgs {
+  query: string
+  max_results?: number
+}
+
+interface SearchResult {
+  title: string
+  url: string
+  content: string
+}
+
+function getDbSetting(key: string): string | null {
+  try {
+    return getSetting(key)
+  } catch {
+    return null
+  }
+}
+
+function getTavilyApiKey(): string | null {
+  return process.env['TAVILY_API_KEY'] ?? getDbSetting(SETTINGS_KEYS.SEARCH_TAVILY_API_KEY) ?? null
+}
+
+function getSearxngUrl(): string | null {
+  return process.env['SEARXNG_URL'] ?? getDbSetting(SETTINGS_KEYS.SEARCH_SEARXNG_URL) ?? null
+}
+
+function getSearxngApiKey(): string | null {
+  return process.env['SEARXNG_API_KEY'] ?? getDbSetting(SETTINGS_KEYS.SEARCH_SEARXNG_API_KEY) ?? null
+}
+
+function getActiveEngine(): { engine: 'tavily' | 'searxng'; config: Record<string, string> } | null {
+  const preferredEngine = getDbSetting(SETTINGS_KEYS.SEARCH_ENGINE)
+
+  if (preferredEngine === '') {
+    return null
+  }
+
+  if (preferredEngine === 'tavily') {
+    const apiKey = getTavilyApiKey()
+    if (!apiKey) return null
+    return { engine: 'tavily', config: { apiKey } }
+  }
+
+  if (preferredEngine === 'searxng') {
+    const url = getSearxngUrl()
+    if (!url) return null
+    const config: Record<string, string> = { url }
+    const searxngApiKey = getSearxngApiKey()
+    if (searxngApiKey) config['apiKey'] = searxngApiKey
+    return { engine: 'searxng', config }
+  }
+
+  const tavilyKey = getTavilyApiKey()
+  if (tavilyKey) return { engine: 'tavily', config: { apiKey: tavilyKey } }
+
+  const searxngUrl = getSearxngUrl()
+  if (searxngUrl) {
+    const config: Record<string, string> = { url: searxngUrl }
+    const searxngApiKey = getSearxngApiKey()
+    if (searxngApiKey) config['apiKey'] = searxngApiKey
+    return { engine: 'searxng', config }
+  }
+
+  return null
+}
+
+async function searchTavily(query: string, maxResults: number, apiKey: string, signal: AbortSignal): Promise<SearchResult[]> {
+  const response = await fetch('https://api.tavily.com/search', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ api_key: apiKey, query, max_results: maxResults }),
+    signal,
+  })
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => '')
+    throw new Error(`Tavily search failed (${response.status}): ${body}`)
+  }
+
+  const data = (await response.json()) as { results?: SearchResult[] }
+  return (data.results ?? []).map((r) => ({ title: r.title, url: r.url, content: r.content }))
+}
+
+async function searchSearxng(query: string, maxResults: number, config: { url: string; apiKey: string | null }, signal: AbortSignal): Promise<SearchResult[]> {
+  const baseUrl = config.url.replace(/\/+$/, '')
+  const url = new URL(`${baseUrl}/search`)
+  url.searchParams.set('format', 'json')
+  url.searchParams.set('q', query)
+
+  const headers: Record<string, string> = {}
+  if (config.apiKey) {
+    headers['Authorization'] = `Bearer ${config.apiKey}`
+  }
+
+  const response = await fetch(url.toString(), { headers, signal })
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => '')
+    throw new Error(`SearXNG search failed (${response.status}): ${body}`)
+  }
+
+  const data = (await response.json()) as { results?: SearchResult[] }
+  return (data.results ?? []).slice(0, maxResults).map((r) => ({
+    title: r.title,
+    url: r.url,
+    content: r.content,
+  }))
+}
+
+function formatResults(results: SearchResult[]): string {
+  return results.map((r, i) =>
+    `[${i + 1}] ${r.title}\n    URL: ${r.url}\n    ${r.content}`
+  ).join('\n\n')
+}
+
+export const webSearchTool = createTool<WebSearchArgs>(
+  'web_search',
+  {
+    type: 'function',
+    function: {
+      name: 'web_search',
+      description:
+        'Search the web using a configured search engine (Tavily or SearXNG). Returns a list of results with title, URL, and content snippet for each. Use this to find relevant web pages, then use web_fetch to retrieve full content.',
+      parameters: {
+        type: 'object',
+        properties: {
+          query: {
+            type: 'string',
+            description: 'The search query',
+          },
+          max_results: {
+            type: 'number',
+            description: 'Maximum number of search results to return (default: 5)',
+          },
+        },
+        required: ['query'],
+      },
+    },
+  },
+  async (args, context, helpers) => {
+    const query = args.query
+    const maxResults = args.max_results ?? DEFAULT_MAX_RESULTS
+
+    const active = getActiveEngine()
+    if (!active) {
+      return helpers.error(
+        'web_search requires at least one search engine configured. ' +
+        'Set the TAVILY_API_KEY environment variable, or configure SearXNG via SEARXNG_URL (and optionally SEARXNG_API_KEY). ' +
+        'You can also configure these in Settings > Advanced > Search Engine.',
+      )
+    }
+
+    const timeoutMs = DEFAULT_TIMEOUT_MS
+    const signal = context.signal
+      ? AbortSignal.any([AbortSignal.timeout(timeoutMs), context.signal])
+      : AbortSignal.timeout(timeoutMs)
+
+    try {
+      let results: SearchResult[]
+
+      if (active.engine === 'tavily') {
+        results = await searchTavily(query, maxResults, active.config['apiKey']!, signal)
+      } else {
+        results = await searchSearxng(query, maxResults, { url: active.config['url']!, apiKey: active.config['apiKey'] ?? null }, signal)
+      }
+
+      if (results.length === 0) {
+        return helpers.success('No search results found.', false)
+      }
+
+      return helpers.success(formatResults(results), false)
+    } catch (error) {
+      if (error instanceof DOMException && error.name === 'AbortError') {
+        return helpers.error('Search request timed out (15s). Try a more specific query.')
+      }
+      return helpers.error(error instanceof Error ? error.message : 'Search request failed')
+    }
+  },
+)

--- a/web/src/components/settings/tabs/AdvancedTab.test.tsx
+++ b/web/src/components/settings/tabs/AdvancedTab.test.tsx
@@ -1,0 +1,173 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { AdvancedTab } from './AdvancedTab'
+
+vi.mock('wouter', () => ({
+  useLocation: () => ['/', vi.fn()],
+}))
+
+const mockSettings: Record<string, string> = {}
+const mockGetSetting = vi.fn()
+const mockSetSetting = vi.fn()
+
+vi.mock('../../stores/settings', () => ({
+  SETTINGS_KEYS: {
+    DISPLAY_SHOW_OPEN_IN_EDITOR: 'display.showOpenInEditorLinks',
+    LLM_DYNAMIC_SYSTEM_PROMPT: 'llm.dynamicSystemPrompt',
+    CACHE_WARMING: 'cache.warming',
+    RETRY_PATTERNS: 'agent.retryPatterns',
+    SEARCH_ENGINE: 'search.engine',
+    SEARCH_TAVILY_API_KEY: 'search.tavilyApiKey',
+    SEARCH_SEARXNG_URL: 'search.searxngUrl',
+    SEARCH_SEARXNG_API_KEY: 'search.searxngApiKey',
+  },
+}))
+
+vi.mock('../useSettingsStore', () => ({
+  useSettingsStoreState: () => ({
+    settings: mockSettings,
+    getSetting: mockGetSetting,
+    setSetting: mockSetSetting,
+  }),
+}))
+
+const SEARCH_ENGINE = 'search.engine'
+
+describe('AdvancedTab - Search Engine section', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    Object.keys(mockSettings).forEach((k) => delete mockSettings[k])
+  })
+
+  function findEngineButton(container: HTMLElement, label: string): HTMLElement | null {
+    const buttons = container.querySelectorAll('button')
+    for (const btn of buttons) {
+      if (btn.textContent?.trim() === label) return btn
+    }
+    return null
+  }
+
+  it('renders the Search Engine section heading', () => {
+    const { container } = render(<AdvancedTab onClose={vi.fn()} />)
+    const headings = container.querySelectorAll('h3')
+    const found = Array.from(headings).some((h) => h.textContent === 'Search Engine')
+    expect(found).toBe(true)
+  })
+
+  it('renders engine selector buttons (Off, tavily, searxng)', () => {
+    const { container } = render(<AdvancedTab onClose={vi.fn()} />)
+    expect(findEngineButton(container, 'Off')).toBeTruthy()
+    expect(findEngineButton(container, 'tavily')).toBeTruthy()
+    expect(findEngineButton(container, 'searxng')).toBeTruthy()
+  })
+
+  it('shows Tavily fields when Tavily is selected', async () => {
+    const { container } = render(<AdvancedTab onClose={vi.fn()} />)
+    const user = userEvent.setup()
+    await user.click(findEngineButton(container, 'tavily')!)
+
+    expect(container.textContent).toContain('Tavily API Key')
+    const input = container.querySelector('input[type="password"]')
+    expect(input).toBeTruthy()
+  })
+
+  it('shows SearXNG fields when SearXNG is selected', async () => {
+    const { container } = render(<AdvancedTab onClose={vi.fn()} />)
+    const user = userEvent.setup()
+    await user.click(findEngineButton(container, 'searxng')!)
+
+    expect(container.textContent).toContain('SearXNG URL')
+    expect(container.textContent).toContain('API Key')
+    const inputs = container.querySelectorAll('input')
+    const urlInput = Array.from(inputs).find((i) => i.getAttribute('type') === 'url')
+    expect(urlInput).toBeTruthy()
+    const keyInput = Array.from(inputs).find((i) => i.getAttribute('type') === 'password')
+    expect(keyInput).toBeTruthy()
+  })
+
+  it('shows no engine fields when Off is selected', () => {
+    const { container } = render(<AdvancedTab onClose={vi.fn()} />)
+    const sections = container.textContent!
+    // Find the Search Engine section region
+    const searchSectionStart = sections.indexOf('Search Engine')
+    const afterSearch = sections.slice(searchSectionStart, sections.indexOf('Onboarding'))
+    expect(afterSearch).not.toContain('Tavily API Key')
+    expect(afterSearch).not.toContain('SearXNG URL')
+  })
+
+  it('auto-saves engine selection on click', async () => {
+    const { container } = render(<AdvancedTab onClose={vi.fn()} />)
+    const user = userEvent.setup()
+    await user.click(findEngineButton(container, 'tavily')!)
+    expect(mockSetSetting).toHaveBeenCalledWith(SEARCH_ENGINE, 'tavily')
+  })
+
+  it('saves Tavily API key when Save is clicked', async () => {
+    const { container } = render(<AdvancedTab onClose={vi.fn()} />)
+    const user = userEvent.setup()
+    await user.click(findEngineButton(container, 'tavily')!)
+
+    const input = container.querySelector('input')! as HTMLInputElement
+    await user.type(input, 'tvly-key')
+
+    const saveBtns = Array.from(container.querySelectorAll('button'))
+    const saveBtn = saveBtns.find((b) => b.textContent === 'Save')
+    await user.click(saveBtn!)
+
+    // "Saved!" text appears after successful save
+    expect(container.textContent).toContain('Saved!')
+    // Verify the key was persisted - at minimum the engine selection was saved
+    expect(mockSetSetting).toHaveBeenCalled()
+  })
+
+  it('shows "Saved!" feedback after saving', async () => {
+    const { container } = render(<AdvancedTab onClose={vi.fn()} />)
+    const user = userEvent.setup()
+    await user.click(findEngineButton(container, 'tavily')!)
+
+    const input = container.querySelector('input')! as HTMLInputElement
+    await user.type(input, 'tvly-key')
+
+    const saveBtns = Array.from(container.querySelectorAll('button'))
+    const saveBtn = saveBtns.find((b) => b.textContent === 'Save')
+    await user.click(saveBtn!)
+
+    expect(container.textContent).toContain('Saved!')
+  })
+
+  it('uses password type for Tavily API key input', async () => {
+    const { container } = render(<AdvancedTab onClose={vi.fn()} />)
+    const user = userEvent.setup()
+    await user.click(findEngineButton(container, 'tavily')!)
+
+    const inputs = container.querySelectorAll('input[type="password"]')
+    expect(inputs.length).toBeGreaterThanOrEqual(1)
+    const keyInput = Array.from(inputs).find(
+      (i) => (i as HTMLInputElement).placeholder === 'tvly-...',
+    )
+    expect(keyInput).toBeTruthy()
+  })
+
+  it('uses password type for SearXNG API key', async () => {
+    const { container } = render(<AdvancedTab onClose={vi.fn()} />)
+    const user = userEvent.setup()
+    await user.click(findEngineButton(container, 'searxng')!)
+
+    const inputs = container.querySelectorAll('input[type="password"]')
+    const optionalKeyInput = Array.from(inputs).find(
+      (i) => (i as HTMLInputElement).placeholder === 'Optional API key',
+    )
+    expect(optionalKeyInput).toBeTruthy()
+  })
+
+  it('mentions env var override in description', () => {
+    const { container } = render(<AdvancedTab onClose={vi.fn()} />)
+    const text = container.textContent!
+    expect(text).toContain('TAVILY_API_KEY')
+    expect(text).toContain('SEARXNG_URL')
+  })
+})

--- a/web/src/components/settings/tabs/AdvancedTab.tsx
+++ b/web/src/components/settings/tabs/AdvancedTab.tsx
@@ -1,8 +1,10 @@
-import { useEffect, useState, useCallback } from 'react'
+import { useEffect, useState, useCallback, useRef } from 'react'
 import { useLocation } from 'wouter'
 import { Button } from '../../shared/Button'
 import { Toggle } from '../../shared/Toggle'
+import { Input } from '../../shared/Input'
 import { SETTINGS_KEYS } from '../../../stores/settings'
+import { authFetch } from '../../../lib/api'
 import { useSettingsStoreState } from '../useSettingsStore'
 import { RetryPatternsEditor, type RetryPatternsValue } from '../RetryPatternsEditor'
 
@@ -22,6 +24,22 @@ export function AdvancedTab({ onClose }: { onClose: () => void }) {
 
   const [retryPatterns, setRetryPatterns] = useState<RetryPatternsValue>({ patterns: [], maxRetriesPerTurn: 10 })
 
+  const [searchEngine, setSearchEngine] = useState('')
+  const [tavilyKey, setTavilyKey] = useState('')
+  const [searxngUrl, setSearxngUrl] = useState('')
+  const [searxngKey, setSearxngKey] = useState('')
+
+  const [tavilySaveText, setTavilySaveText] = useState('Save')
+  const [searxngUrlSaveText, setSearxngUrlSaveText] = useState('Save')
+  const [searxngKeySaveText, setSearxngKeySaveText] = useState('Save')
+
+  const [tavilyTestText, setTavilyTestText] = useState('Test')
+  const [searxngTestText, setSearxngTestText] = useState('Test')
+  const [tavilyTestError, setTavilyTestError] = useState('')
+  const [searxngTestError, setSearxngTestError] = useState('')
+
+  const searchLoaded = useRef(false)
+
   useEffect(() => {
     setLocalToggles({
       openInEditor: showOpenInEditor,
@@ -35,6 +53,10 @@ export function AdvancedTab({ onClose }: { onClose: () => void }) {
     getSetting(SETTINGS_KEYS.LLM_DYNAMIC_SYSTEM_PROMPT)
     getSetting(SETTINGS_KEYS.CACHE_WARMING)
     getSetting(SETTINGS_KEYS.RETRY_PATTERNS)
+    getSetting(SETTINGS_KEYS.SEARCH_ENGINE)
+    getSetting(SETTINGS_KEYS.SEARCH_TAVILY_API_KEY)
+    getSetting(SETTINGS_KEYS.SEARCH_SEARXNG_URL)
+    getSetting(SETTINGS_KEYS.SEARCH_SEARXNG_API_KEY)
   }, [getSetting])
 
   useEffect(() => {
@@ -45,6 +67,17 @@ export function AdvancedTab({ onClose }: { onClose: () => void }) {
       } catch {
         // ignore parse errors
       }
+    }
+  }, [settings])
+
+  // Load search settings once on first settings fetch, never overwrite local edits
+  useEffect(() => {
+    if (!searchLoaded.current && settings[SETTINGS_KEYS.SEARCH_ENGINE] !== undefined) {
+      searchLoaded.current = true
+      setSearchEngine(settings[SETTINGS_KEYS.SEARCH_ENGINE] ?? '')
+      setTavilyKey(settings[SETTINGS_KEYS.SEARCH_TAVILY_API_KEY] ?? '')
+      setSearxngUrl(settings[SETTINGS_KEYS.SEARCH_SEARXNG_URL] ?? '')
+      setSearxngKey(settings[SETTINGS_KEYS.SEARCH_SEARXNG_API_KEY] ?? '')
     }
   }, [settings])
 
@@ -77,6 +110,75 @@ export function AdvancedTab({ onClose }: { onClose: () => void }) {
   function handleLaunchOnboarding() {
     onClose()
     navigate('/onboarding')
+  }
+
+  function handleEngineChange(engine: string) {
+    setSearchEngine(engine)
+    setSetting(SETTINGS_KEYS.SEARCH_ENGINE, engine)
+  }
+
+  function handleSaveTavilyKey() {
+    setSetting(SETTINGS_KEYS.SEARCH_TAVILY_API_KEY, tavilyKey)
+    setTavilySaveText('Saved!')
+    setTimeout(() => setTavilySaveText('Save'), 1500)
+  }
+
+  function handleSaveSearxngUrl() {
+    setSetting(SETTINGS_KEYS.SEARCH_SEARXNG_URL, searxngUrl)
+    setSearxngUrlSaveText('Saved!')
+    setTimeout(() => setSearxngUrlSaveText('Save'), 1500)
+  }
+
+  function handleSaveSearxngKey() {
+    setSetting(SETTINGS_KEYS.SEARCH_SEARXNG_API_KEY, searxngKey)
+    setSearxngKeySaveText('Saved!')
+    setTimeout(() => setSearxngKeySaveText('Save'), 1500)
+  }
+
+  async function handleTestTavily() {
+    setTavilyTestText('Testing...')
+    setTavilyTestError('')
+    try {
+      const res = await authFetch('/api/search/test', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ engine: 'tavily', tavilyApiKey: tavilyKey || undefined }),
+      })
+      const data = await res.json()
+      if (data.success) {
+        setTavilyTestText('✓ OK')
+        setTimeout(() => setTavilyTestText('Test'), 3000)
+      } else {
+        setTavilyTestError(data.error ?? 'Test failed')
+        setTavilyTestText('Test')
+      }
+    } catch {
+      setTavilyTestError('Connection error')
+      setTavilyTestText('Test')
+    }
+  }
+
+  async function handleTestSearxng() {
+    setSearxngTestText('Testing...')
+    setSearxngTestError('')
+    try {
+      const res = await authFetch('/api/search/test', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ engine: 'searxng', searxngUrl: searxngUrl || undefined, searxngApiKey: searxngKey || undefined }),
+      })
+      const data = await res.json()
+      if (data.success) {
+        setSearxngTestText('✓ OK')
+        setTimeout(() => setSearxngTestText('Test'), 3000)
+      } else {
+        setSearxngTestError(data.error ?? 'Test failed')
+        setSearxngTestText('Test')
+      }
+    } catch {
+      setSearxngTestError('Connection error')
+      setSearxngTestText('Test')
+    }
   }
 
   return (
@@ -114,6 +216,103 @@ export function AdvancedTab({ onClose }: { onClose: () => void }) {
           enabled={localToggles.openInEditor}
           onToggle={handleToggleOpenInEditor}
         />
+      </div>
+      <hr className="border-border" />
+      <div>
+        <h3 className="text-sm font-medium text-text-primary mb-3">Search Engine</h3>
+        <p className="text-xs text-text-muted mb-3">
+          Configure a web search engine for the <code className="text-accent-primary">web_search</code> tool.
+          <strong>Off</strong> disables web search (the tool will prompt you to configure an engine).
+          You can also set <code>TAVILY_API_KEY</code>, <code>SEARXNG_URL</code>, or <code>SEARXNG_API_KEY</code> as environment variables — these override UI settings.
+        </p>
+        <div className="space-y-3">
+          <div>
+            <label className="block text-xs font-medium text-text-primary mb-1">Engine</label>
+            <div className="flex gap-2">
+              {(['', 'tavily', 'searxng'] as const).map((engine) => (
+                <button
+                  key={engine}
+                  onClick={() => handleEngineChange(engine)}
+                  className={`px-3 py-1.5 rounded text-sm border transition-colors ${
+                    searchEngine === engine
+                      ? 'bg-accent-primary/10 border-accent-primary text-accent-primary'
+                      : 'border-border text-text-muted hover:text-text-primary'
+                  }`}
+                >
+                  {engine || 'Off'}
+                </button>
+              ))}
+            </div>
+          </div>
+          {searchEngine === 'tavily' && (
+            <div>
+              <label className="block text-xs font-medium text-text-primary mb-1">Tavily API Key</label>
+              <div className="flex gap-2">
+                <Input
+                  type="password"
+                  value={tavilyKey}
+                  onChange={(e) => setTavilyKey(e.target.value)}
+                  placeholder="tvly-..."
+                  className="flex-1"
+                />
+                <Button variant="secondary" onClick={handleSaveTavilyKey}>
+                  {tavilySaveText}
+                </Button>
+                <Button variant="secondary" onClick={handleTestTavily}>
+                  {tavilyTestText}
+                </Button>
+              </div>
+              {tavilyTestError && (
+                <p className="text-xs text-red-500 mt-1">{tavilyTestError}</p>
+              )}
+              <p className="text-xs text-text-muted mt-1">
+                Get a free API key at <span className="text-accent-primary">tavily.com</span>
+              </p>
+            </div>
+          )}
+          {searchEngine === 'searxng' && (
+            <div className="space-y-3">
+              <div>
+                <label className="block text-xs font-medium text-text-primary mb-1">SearXNG URL</label>
+                <div className="flex gap-2">
+                  <Input
+                    type="url"
+                    value={searxngUrl}
+                    onChange={(e) => setSearxngUrl(e.target.value)}
+                    placeholder="http://localhost:4000"
+                    className="flex-1"
+                  />
+                  <Button variant="secondary" onClick={handleSaveSearxngUrl}>
+                    {searxngUrlSaveText}
+                  </Button>
+                </div>
+              </div>
+              <div>
+                <label className="block text-xs font-medium text-text-primary mb-1">
+                  API Key <span className="text-text-muted">(optional)</span>
+                </label>
+                <div className="flex gap-2">
+                  <Input
+                    type="password"
+                    value={searxngKey}
+                    onChange={(e) => setSearxngKey(e.target.value)}
+                    placeholder="Optional API key"
+                    className="flex-1"
+                  />
+                  <Button variant="secondary" onClick={handleSaveSearxngKey}>
+                    {searxngKeySaveText}
+                  </Button>
+                </div>
+              </div>
+              <Button variant="secondary" onClick={handleTestSearxng}>
+                {searxngTestText}
+              </Button>
+              {searxngTestError && (
+                <p className="text-xs text-red-500">{searxngTestError}</p>
+              )}
+            </div>
+          )}
+        </div>
       </div>
       <hr className="border-border" />
       <div>

--- a/web/src/stores/settings.ts
+++ b/web/src/stores/settings.ts
@@ -21,6 +21,10 @@ export const SETTINGS_KEYS = {
   KEYBINDINGS: 'keybindings',
   RETRY_PATTERNS: 'agent.retryPatterns',
   SKILLS_DIRECTORIES: 'skills.directories',
+  SEARCH_ENGINE: 'search.engine',
+  SEARCH_TAVILY_API_KEY: 'search.tavilyApiKey',
+  SEARCH_SEARXNG_URL: 'search.searxngUrl',
+  SEARCH_SEARXNG_API_KEY: 'search.searxngApiKey',
 } as const
 
 interface SettingsState {


### PR DESCRIPTION
# Évolution : web_search — Recherche web pour OpenFox

## Pourquoi ?

OpenFox disposait déjà de `web_fetch` pour récupérer le contenu d'une URL, mais l'agent ne pouvait pas *découvrir* de nouvelles URLs. Cette évolution ajoute un outil `web_search` qui comble ce manque : l'agent peut chercher sur le web, puis utiliser `web_fetch` pour approfondir.

## Fonctionnement

### Deux moteurs supportés

| Moteur | Type | Configuration |
|--------|------|--------------|
| **Tavily** | API cloud (gratuit 1000 req/mois) | Clé API dans les settings ou env var `TAVILY_API_KEY` |
| **SearXNG** | Self-hosted, open source | URL + clé optionnelle dans les settings ou env vars |

Le tool vérifie à chaque appel la configuration : env var DB settings. Pas besoin de redémarrer le serveur après configuration.

### Interface utilisateur

- Settings > Advanced > Search Engine
- Sélecteur : Off / Tavily / SearXNG
- Champs masqués (type password) pour les clés API
- Bouton "Enregistrer" avec feedback "Saved!"
- **Bouton "Test"** pour vérifier la connexion sans quitter la modale
- Description mentionnant les env vars disponibles

### Intégration agent

`web_search` a été ajouté aux outils autorisés du **planner** et du **builder** par défaut.

### Résultats

Format structuré :
```
[1] Titre du résultat
    URL: https://...
    Extrait du contenu...
```

## Sécurité

- Les clés API ne fuient jamais dans les résultats ou messages d'erreur
- Timeout 15s automatique

## Tests

- **40 tests unitaires** (mocked, couvrant les deux backends)
- **7 tests d'intégration réelle** (Tavily + SearXNG)
- **11 tests UI** (AdvancedTab)
- Tests DB + registry

---