### PR TITLE
feat: PDF reading support via pdfjs-dist

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "mime-types": "^3.0.2",
         "node-pty": "^1.2.0-beta.12",
         "open": "^11.0.0",
+        "pdfjs-dist": "^6.1.200",
         "pyright": "^1.1.408",
         "react-markdown": "^10.1.0",
         "react-syntax-highlighter": "^16.1.1",
@@ -2711,6 +2712,271 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
+    },
+    "node_modules/@napi-rs/canvas": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-1.0.2.tgz",
+      "integrity": "sha512-EYEqlMYaCbpZDz+IgDH5xp9MTd3ui4dmGqbQYryhMLnSRxrhHKq5KQWHHKxFUcEP4Hp8/BWgvqXocX4j7iSbOQ==",
+      "license": "MIT",
+      "optional": true,
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "1.0.2",
+        "@napi-rs/canvas-darwin-arm64": "1.0.2",
+        "@napi-rs/canvas-darwin-x64": "1.0.2",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "1.0.2",
+        "@napi-rs/canvas-linux-arm64-gnu": "1.0.2",
+        "@napi-rs/canvas-linux-arm64-musl": "1.0.2",
+        "@napi-rs/canvas-linux-riscv64-gnu": "1.0.2",
+        "@napi-rs/canvas-linux-x64-gnu": "1.0.2",
+        "@napi-rs/canvas-linux-x64-musl": "1.0.2",
+        "@napi-rs/canvas-win32-arm64-msvc": "1.0.2",
+        "@napi-rs/canvas-win32-x64-msvc": "1.0.2"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-1.0.2.tgz",
+      "integrity": "sha512-IMXKVQod0ol4vt3gmClUfXz4JAgHYESGPCUqmH3lQxBoL0K/2greJaQE1HVBVxWWFKfLc4OLZVdxg7kXVyXv+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-1.0.2.tgz",
+      "integrity": "sha512-Sc8tPi6cF+5lqOzCCKFALJHhDiRwyMzTPYm3bbhdXsOunU0lQO5f05ucyOzN2r55I23Hg5bsjH63uSCvWp3EgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-1.0.2.tgz",
+      "integrity": "sha512-niDXZ9LhKB1zLrUdYB64RHQFDGz9rr0eGx061qtJJU3U20EMMIx28ADF5fVYbhtOgkWQrBjFicfaye1yM0U62A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-1.0.2.tgz",
+      "integrity": "sha512-sgatQL9JxGRH/Amzcvu0P3t8Am3duou74CisfuJ41Dwt8cWy723z/9KZ8LlgmxfypEwEZxSTNFJtU8d281lmhQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-1.0.2.tgz",
+      "integrity": "sha512-dgKuX0peF3xwY6ZF5QxGS4wbfDqpoFAJYXiLSp+guZKARQUKMkRqZSDrXKj7nfrec3UCMzC0PFCPte0ES98AiA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-1.0.2.tgz",
+      "integrity": "sha512-qwROoDIC9upfvDoRLuPn2aNg9CGW1x0Ygr4k2Or+8paA9d0qBLwk87U+g8KQpoOviKoPoiwl97kvBYuYD7qZoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-1.0.2.tgz",
+      "integrity": "sha512-fXRjnPihdnbO6qy1QQOgxAonb68A0TCEG7rj1x7v7rxNElsE8EVIKIEUTvyDtU+sthYSbX+8e7g3oZiLGnOmxw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-1.0.2.tgz",
+      "integrity": "sha512-nPR97DXhbWIAy7yazF3jc06kEPMqYMLmPzFOVNlwKPfIoSChnI+x7dc0hTLaihz3jxrjL6j4BbA7earxfx4X3g==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-1.0.2.tgz",
+      "integrity": "sha512-l7zZY5+jL5qnBZtDz7CoBtY6p7EkHu422g/0zWwrOrzIwWyWxZFRfZZORY1UG7YApymPLx+UbOkN206xXn/c1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-1.0.2.tgz",
+      "integrity": "sha512-yE0koHCFF4PIbMc2o2SEALhnipz7WBISh5glLvQiomtIoCcW0np3H4Lw93ceJAfJttTTeIIWFbwH84F7EVzjMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-1.0.2.tgz",
+      "integrity": "sha512-okU8/t2foV6C31n0GtvEMbfD5rOFc70+/6xUNME9Guld29sgSOIGUEDScAWFlcP3k5TYQRl9TNkwJEEjh15w8A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -10237,6 +10503,18 @@
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true
+    },
+    "node_modules/pdfjs-dist": {
+      "version": "6.1.200",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-6.1.200.tgz",
+      "integrity": "sha512-o8MolyzirkkLrcdsae/HEOiIcXWI7DS5zGpvqW8xTC2YUsW30rltFw2bDGvw/fskUdEMrQm2br68jzDS5BH2vw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=22.13.0 || >=24"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^1.0.0"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "mime-types": "^3.0.2",
     "node-pty": "^1.2.0-beta.12",
     "open": "^11.0.0",
+    "pdfjs-dist": "^6.1.200",
     "pyright": "^1.1.408",
     "react-markdown": "^10.1.0",
     "react-syntax-highlighter": "^16.1.1",

--- a/src/server/tools/pdf-utils.ts
+++ b/src/server/tools/pdf-utils.ts
@@ -1,0 +1,70 @@
+import { OUTPUT_LIMITS } from './types.js'
+import { getDocument } from 'pdfjs-dist/legacy/build/pdf.mjs'
+
+const PDF_HEADER = Buffer.from('%PDF')
+
+export function isPdfBuffer(buffer: Buffer): boolean {
+  return buffer.length > 4 && buffer.subarray(0, 4).equals(PDF_HEADER)
+}
+
+export interface PdfResult {
+  text: string
+  pageCount: number
+  title: string | null
+  author: string | null
+}
+
+export interface ProcessedPdf {
+  output: string
+  truncated: boolean
+  isScanned: boolean
+}
+
+export function isPasswordError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err)
+  return message.toLowerCase().includes('password') || message.toLowerCase().includes('encrypt')
+}
+
+export function processPdfContent(text: string, maxBytes: number): ProcessedPdf {
+  let output = text
+  let truncated = false
+
+  if (output.length > maxBytes) {
+    output = output.slice(0, maxBytes) + '\n\n[Output truncated due to size limit]'
+    truncated = true
+  }
+
+  const isScanned = output.replace(/\[Page \d+\/\d+\]\n/g, '').trim().length === 0
+
+  return { output, truncated, isScanned }
+}
+
+export async function extractPdfText(buffer: Buffer): Promise<PdfResult> {
+  const doc = await getDocument({ data: Uint8Array.from(buffer) }).promise
+  const pageCount = doc.numPages
+
+  const rawMeta = await doc.getMetadata()
+  const info = rawMeta.info as Record<string, unknown> | undefined
+  const title = (info?.['Title'] as string) || null
+  const author = (info?.['Author'] as string) || null
+
+  const pages: string[] = []
+  const limitedPageCount = Math.min(pageCount, OUTPUT_LIMITS.read_file.maxPdfPages)
+
+  for (let i = 1; i <= limitedPageCount; i++) {
+    const page = await doc.getPage(i)
+    const content = await page.getTextContent()
+    const pageText = content.items.map((item) => ('str' in item ? item.str : '')).join(' ')
+    pages.push(`[Page ${i}/${pageCount}]\n${pageText}`)
+    page.cleanup()
+  }
+
+  doc.cleanup()
+
+  let text = pages.join('\n\n')
+  if (pageCount > limitedPageCount) {
+    text += `\n\n[PDF has ${pageCount} pages, showing first ${limitedPageCount}. Use a shell command to process more.]`
+  }
+
+  return { text, pageCount, title, author }
+}

--- a/src/server/tools/read.test.ts
+++ b/src/server/tools/read.test.ts
@@ -7,6 +7,44 @@ import { readFileTool } from './read.js'
 import type { ToolContext } from './types.js'
 import { OUTPUT_LIMITS } from './types.js'
 
+function makeSimplePdf(): Buffer {
+  const stream = 'BT /F1 12 Tf 100 700 Td (Hello World PDF test) Tj ET'
+  const len = Buffer.byteLength(stream, 'latin1')
+  return Buffer.from(
+    `%PDF-1.4\n1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj\n3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 612 792]/Resources<</Font<</F1 4 0 R>>>>/Contents 5 0 R>>endobj\n4 0 obj<</Type/Font/Subtype/Type1/BaseFont/Helvetica>>endobj\n5 0 obj<</Length ${len}>>stream\n${stream}\nendstream\nxref\n0 6\n0000000000 65535 f \n0000000009 00000 n \n0000000061 00000 n \n0000000114 00000 n \n0000000268 00000 n \n0000000342 00000 n \ntrailer<</Size 6/Root 1 0 R>>\nstartxref\n428\n%%EOF`,
+    'latin1',
+  )
+}
+
+function makeEmptyPdf(): Buffer {
+  const stream = 'BT /F1 12 Tf 100 700 Td () Tj ET'
+  const len = Buffer.byteLength(stream, 'latin1')
+  return Buffer.from(
+    `%PDF-1.4\n1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj\n3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 612 792]/Resources<</Font<</F1 4 0 R>>>>/Contents 5 0 R>>endobj\n4 0 obj<</Type/Font/Subtype/Type1/BaseFont/Helvetica>>endobj\n5 0 obj<</Length ${len}>>stream\n${stream}\nendstream\nxref\n0 6\n0000000000 65535 f \n0000000009 00000 n \n0000000061 00000 n \n0000000114 00000 n \n0000000268 00000 n \n0000000342 00000 n \ntrailer<</Size 6/Root 1 0 R>>\nstartxref\n426\n%%EOF`,
+    'latin1',
+  )
+}
+
+function makeMultiPagePdf(): Buffer {
+  const t1 = 'Page 1 content',
+    t2 = 'Page 2 content'
+  const s1 = `BT /F1 12 Tf 100 700 Td (${t1}) Tj ET`,
+    s2 = `BT /F1 12 Tf 100 600 Td (${t2}) Tj ET`
+  const l1 = Buffer.byteLength(s1, 'latin1'),
+    l2 = Buffer.byteLength(s2, 'latin1')
+  return Buffer.from(
+    `%PDF-1.4\n1 0 obj<</Type/Catalog/Pages 3 0 R>>endobj\n2 0 obj<</Type/Font/Subtype/Type1/BaseFont/Helvetica>>endobj\n3 0 obj<</Type/Pages/Kids[4 0 R 6 0 R]/Count 2>>endobj\n4 0 obj<</Type/Page/Parent 3 0 R/MediaBox[0 0 612 792]/Resources<</Font<</F1 2 0 R>>>>/Contents 5 0 R>>endobj\n5 0 obj<</Length ${l1}>>stream\n${s1}\nendstream\n6 0 obj<</Type/Page/Parent 3 0 R/MediaBox[0 0 612 792]/Resources<</Font<</F1 2 0 R>>>>/Contents 7 0 R>>endobj\n7 0 obj<</Length ${l2}>>stream\n${s2}\nendstream\nxref\n0 8\n0000000000 65535 f \n0000000009 00000 n \n0000000061 00000 n \n0000000107 00000 n \n0000000177 00000 n \n0000000308 00000 n \n0000000367 00000 n \n0000000498 00000 n \ntrailer<</Size 8/Root 1 0 R>>\nstartxref\n558\n%%EOF`,
+    'latin1',
+  )
+}
+
+function makeEncryptedPdf(): Buffer {
+  return Buffer.from(
+    `%PDF-1.4\n1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n2 0 obj<</Type/Pages/Kids[]/Count 0>>endobj\n3 0 obj<</Filter/Standard/V 2/Length 128/O<${'00'.repeat(16)}>/U<${'00'.repeat(16)}>/P 0>>endobj\nxref\n0 4\n0000000000 65535 f \n0000000009 00000 n \n0000000061 00000 n \n0000000114 00000 n \ntrailer<</Size 4/Root 1 0 R/Encrypt 3 0 R>>\nstartxref\n206\n%%EOF`,
+    'latin1',
+  )
+}
+
 // Mock fs/promises using vi.mock factory pattern
 vi.mock('node:fs/promises', async (importOriginal) => {
   const actual = (await importOriginal()) as any
@@ -333,6 +371,99 @@ describe('readFileTool - Image Support', () => {
       // Verify it's valid base64 by decoding
       const decoded = Buffer.from(base64Data, 'base64')
       expect(decoded.equals(mockPngBuffer)).toBe(true)
+    })
+  })
+
+  describe('readFileTool - PDF Support', () => {
+    beforeEach(() => {
+      vi.clearAllMocks()
+    })
+
+    it('should extract text from a valid PDF', async () => {
+      const pdfBuffer = makeSimplePdf()
+
+      vi.mocked(readFile).mockResolvedValue(pdfBuffer as any)
+      vi.mocked(stat).mockResolvedValue({
+        isDirectory: () => false,
+        size: pdfBuffer.length,
+      } as any)
+
+      const result = await readFileTool.execute({ path: 'test.pdf' }, mockContext)
+
+      expect(result.success).toBe(true)
+      expect(result.output).toContain('[Page 1/1]')
+      expect(result.output).toContain('Hello World PDF test')
+      expect(result.metadata).toBeDefined()
+      expect(result.metadata?.['format']).toBe('pdf')
+      expect(result.metadata?.['pageCount']).toBe(1)
+      expect(result.metadata?.['path']).toBe('/test/workdir/test.pdf')
+    })
+
+    it('should return scanned PDF message when no text layer', async () => {
+      const pdfBuffer = makeEmptyPdf()
+
+      vi.mocked(readFile).mockResolvedValue(pdfBuffer as any)
+      vi.mocked(stat).mockResolvedValue({
+        isDirectory: () => false,
+        size: pdfBuffer.length,
+      } as any)
+
+      const result = await readFileTool.execute({ path: 'test.pdf' }, mockContext)
+
+      expect(result.success).toBe(true)
+      expect(result.output).toContain('has no text layer')
+      expect(result.output).toContain('OCR')
+      expect(result.metadata?.['format']).toBe('pdf')
+      expect(result.metadata?.['pageCount']).toBe(1)
+    })
+
+    it('should return error for password-protected PDF', async () => {
+      const pdfBuffer = makeEncryptedPdf()
+
+      vi.mocked(readFile).mockResolvedValue(pdfBuffer as any)
+      vi.mocked(stat).mockResolvedValue({
+        isDirectory: () => false,
+        size: pdfBuffer.length,
+      } as any)
+
+      const result = await readFileTool.execute({ path: 'test.pdf' }, mockContext)
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('password-protected')
+    })
+
+    it('should reject PDFs larger than 20MB', async () => {
+      const oversizedSize = OUTPUT_LIMITS.read_file.maxPdfBytes + 1
+
+      vi.mocked(stat).mockResolvedValue({
+        isDirectory: () => false,
+        size: oversizedSize,
+      } as any)
+
+      const result = await readFileTool.execute({ path: 'large.pdf' }, mockContext)
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('exceeds maximum file size')
+      expect(result.error).toContain('20MB')
+    })
+
+    it('should extract text from a multi-page PDF', async () => {
+      const pdfBuffer = makeMultiPagePdf()
+
+      vi.mocked(readFile).mockResolvedValue(pdfBuffer as any)
+      vi.mocked(stat).mockResolvedValue({
+        isDirectory: () => false,
+        size: pdfBuffer.length,
+      } as any)
+
+      const result = await readFileTool.execute({ path: 'test.pdf' }, mockContext)
+
+      expect(result.success).toBe(true)
+      expect(result.output).toContain('[Page 1/2]')
+      expect(result.output).toContain('[Page 2/2]')
+      expect(result.output).toContain('Page 1 content')
+      expect(result.output).toContain('Page 2 content')
+      expect(result.metadata?.['pageCount']).toBe(2)
     })
   })
 })

--- a/src/server/tools/read.ts
+++ b/src/server/tools/read.ts
@@ -5,6 +5,7 @@ import { createTool } from './tool-helpers.js'
 import { computeFileHash } from './file-tracker.js'
 import { detectEncoding, decodeContent } from '../utils/encoding.js'
 import { fileTypeFromBuffer } from 'file-type'
+import { isPdfBuffer, extractPdfText, processPdfContent, isPasswordError } from './pdf-utils.js'
 
 interface ReadFileArgs {
   path: string
@@ -92,7 +93,7 @@ export const readFileTool = createTool<ReadFileArgs>(
     function: {
       name: 'read_file',
       description:
-        'Read the contents of a file or list directory contents. For text files: returns file content. For images (PNG, JPEG, GIF, WebP, BMP, SVG): returns base64-encoded data with MIME type metadata. For directories: returns a tree-formatted listing of entries with file sizes.',
+        'Read the contents of a file or list directory contents. For text files: returns file content. For images (PNG, JPEG, GIF, WebP, BMP, SVG): returns base64-encoded data with MIME type metadata. For PDF files: extracts text content page by page. For directories: returns a tree-formatted listing of entries with file sizes.',
       parameters: {
         type: 'object',
         properties: {
@@ -126,6 +127,13 @@ export const readFileTool = createTool<ReadFileArgs>(
       if (stats.isDirectory()) {
         const listing = await listDirectory(fullPath, args.path)
         return helpers.success(listing)
+      }
+
+      // General file size safety cap (checked before type-specific limits)
+      if (stats.size > OUTPUT_LIMITS.read_file.maxFileBytes) {
+        return helpers.error(
+          `File size (${stats.size} bytes) exceeds maximum file size (20MB). Use shell command to process large files.`,
+        )
       }
 
       // Check image size limit before reading
@@ -164,6 +172,51 @@ export const readFileTool = createTool<ReadFileArgs>(
           path: fullPath,
         },
       })
+    }
+
+    // Detect if this is a PDF file
+    if (isPdfBuffer(rawBuffer)) {
+      try {
+        const { text, pageCount, title, author } = await extractPdfText(rawBuffer)
+        const { output, truncated, isScanned } = processPdfContent(text, OUTPUT_LIMITS.read_file.maxBytes)
+
+        // Record file read with content hash for write validation
+        const contentHash = await computeFileHash(fullPath)
+        if (contentHash) {
+          context.sessionManager.recordFileRead(context.sessionId, fullPath, contentHash)
+        }
+
+        if (isScanned) {
+          return helpers.success(
+            `[PDF: ${args.path} — This PDF has no text layer (scanned or image-only). Use a shell command with OCR to extract text.]`,
+            false,
+            {
+              metadata: {
+                format: 'pdf',
+                pageCount,
+                title,
+                author,
+                path: fullPath,
+              },
+            },
+          )
+        }
+
+        return helpers.success(output, truncated, {
+          metadata: {
+            format: 'pdf',
+            pageCount,
+            title,
+            author,
+            path: fullPath,
+          },
+        })
+      } catch (err) {
+        if (isPasswordError(err)) {
+          return helpers.error('This PDF is password-protected. Unlock it with an external tool first.')
+        }
+        return helpers.error(`Failed to read PDF: ${err instanceof Error ? err.message : String(err)}`)
+      }
     }
 
     // Handle as text file

--- a/src/server/tools/types.ts
+++ b/src/server/tools/types.ts
@@ -41,6 +41,9 @@ export const OUTPUT_LIMITS = {
     maxLines: 2000,
     maxBytes: 100_000,
     maxImageBytes: 2_097_152, // 2MB for images
+    maxPdfBytes: 20_971_520, // 20MB for PDFs
+    maxPdfPages: 50,
+    maxFileBytes: 20_971_520, // 20MB general file safety limit
   },
   run_command: {
     maxLines: 2000,

--- a/src/server/tools/web-fetch.test.ts
+++ b/src/server/tools/web-fetch.test.ts
@@ -2,6 +2,31 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import type { ToolContext } from './types.js'
 import { webFetchTool } from './web-fetch.js'
 
+function makeSimplePdf(): Buffer {
+  const stream = 'BT /F1 12 Tf 100 700 Td (Hello World PDF test) Tj ET'
+  const len = Buffer.byteLength(stream, 'latin1')
+  return Buffer.from(
+    `%PDF-1.4\n1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj\n3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 612 792]/Resources<</Font<</F1 4 0 R>>>>/Contents 5 0 R>>endobj\n4 0 obj<</Type/Font/Subtype/Type1/BaseFont/Helvetica>>endobj\n5 0 obj<</Length ${len}>>stream\n${stream}\nendstream\nxref\n0 6\n0000000000 65535 f \n0000000009 00000 n \n0000000061 00000 n \n0000000114 00000 n \n0000000268 00000 n \n0000000342 00000 n \ntrailer<</Size 6/Root 1 0 R>>\nstartxref\n428\n%%EOF`,
+    'latin1',
+  )
+}
+
+function makeEmptyPdf(): Buffer {
+  const stream = 'BT /F1 12 Tf 100 700 Td () Tj ET'
+  const len = Buffer.byteLength(stream, 'latin1')
+  return Buffer.from(
+    `%PDF-1.4\n1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj\n3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 612 792]/Resources<</Font<</F1 4 0 R>>>>/Contents 5 0 R>>endobj\n4 0 obj<</Type/Font/Subtype/Type1/BaseFont/Helvetica>>endobj\n5 0 obj<</Length ${len}>>stream\n${stream}\nendstream\nxref\n0 6\n0000000000 65535 f \n0000000009 00000 n \n0000000061 00000 n \n0000000114 00000 n \n0000000268 00000 n \n0000000342 00000 n \ntrailer<</Size 6/Root 1 0 R>>\nstartxref\n426\n%%EOF`,
+    'latin1',
+  )
+}
+
+function makeEncryptedPdf(): Buffer {
+  return Buffer.from(
+    `%PDF-1.4\n1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n2 0 obj<</Type/Pages/Kids[]/Count 0>>endobj\n3 0 obj<</Filter/Standard/V 2/Length 128/O<${'00'.repeat(16)}>/U<${'00'.repeat(16)}>/P 0>>endobj\nxref\n0 4\n0000000000 65535 f \n0000000009 00000 n \n0000000061 00000 n \n0000000114 00000 n \ntrailer<</Size 4/Root 1 0 R/Encrypt 3 0 R>>\nstartxref\n206\n%%EOF`,
+    'latin1',
+  )
+}
+
 describe('web_fetch tool', () => {
   const mockContext: ToolContext = {
     workdir: '/test/workdir',
@@ -192,5 +217,71 @@ describe('web_fetch tool', () => {
     expect(webFetchTool.name).toBe('web_fetch')
     expect(webFetchTool.definition.function.name).toBe('web_fetch')
     expect((webFetchTool.definition.function.parameters as any).required).toEqual(['url'])
+  })
+
+  describe('web_fetch - PDF Support', () => {
+    it('should extract text from a PDF URL', async () => {
+      const pdfBuffer = makeSimplePdf()
+      fetchSpy.mockResolvedValueOnce(
+        new Response(pdfBuffer, {
+          status: 200,
+          headers: { 'content-type': 'application/pdf' },
+        }),
+      )
+
+      const result = await webFetchTool.execute({ url: 'https://example.com/doc.pdf' }, mockContext)
+      expect(result.success).toBe(true)
+      expect(result.output).toContain('[Page 1/1]')
+      expect(result.output).toContain('Hello World PDF test')
+      expect(result.metadata).toBeDefined()
+      expect(result.metadata!['format']).toBe('pdf')
+      expect(result.metadata!['pageCount']).toBe(1)
+    })
+
+    it('should detect PDF by content even without content-type', async () => {
+      const pdfBuffer = makeSimplePdf()
+      fetchSpy.mockResolvedValueOnce(
+        new Response(pdfBuffer, {
+          status: 200,
+          headers: { 'content-type': 'application/octet-stream' },
+        }),
+      )
+
+      const result = await webFetchTool.execute({ url: 'https://example.com/doc.pdf' }, mockContext)
+      expect(result.success).toBe(true)
+      expect(result.output).toContain('[Page 1/1]')
+      expect(result.output).toContain('Hello World PDF test')
+    })
+
+    it('should return scanned PDF message when no text layer', async () => {
+      const pdfBuffer = makeEmptyPdf()
+      fetchSpy.mockResolvedValueOnce(
+        new Response(pdfBuffer, {
+          status: 200,
+          headers: { 'content-type': 'application/pdf' },
+        }),
+      )
+
+      const result = await webFetchTool.execute({ url: 'https://example.com/scanned.pdf' }, mockContext)
+      expect(result.success).toBe(true)
+      expect(result.output).toContain('has no text layer')
+      expect(result.output).toContain('OCR')
+      expect(result.metadata!['format']).toBe('pdf')
+      expect(result.metadata!['pageCount']).toBe(1)
+    })
+
+    it('should return error for password-protected PDF', async () => {
+      const pdfBuffer = makeEncryptedPdf()
+      fetchSpy.mockResolvedValueOnce(
+        new Response(pdfBuffer, {
+          status: 200,
+          headers: { 'content-type': 'application/pdf' },
+        }),
+      )
+
+      const result = await webFetchTool.execute({ url: 'https://example.com/protected.pdf' }, mockContext)
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('password-protected')
+    })
   })
 })

--- a/src/server/tools/web-fetch.ts
+++ b/src/server/tools/web-fetch.ts
@@ -1,6 +1,7 @@
 import TurndownService from 'turndown'
 import { createTool } from './tool-helpers.js'
 import { OUTPUT_LIMITS } from './types.js'
+import { isPdfBuffer, extractPdfText, processPdfContent, isPasswordError } from './pdf-utils.js'
 
 const MAX_RESPONSE_SIZE = 5 * 1024 * 1024 // 5MB
 const DEFAULT_TIMEOUT_MS = 30_000
@@ -69,7 +70,7 @@ export const webFetchTool = createTool<WebFetchArgs>(
     function: {
       name: 'web_fetch',
       description:
-        'Fetch content from a URL and return it as text, markdown, or HTML. Use this to retrieve and analyze web content such as documentation, API references, or web pages.',
+        'Fetch content from a URL and return it as text, markdown, or HTML. For PDF URLs, extracts text content page by page. Use this to retrieve and analyze web content such as documentation, API references, or web pages.',
       parameters: {
         type: 'object',
         properties: {
@@ -144,6 +145,48 @@ export const webFetchTool = createTool<WebFetchArgs>(
           contentType,
         },
       })
+    }
+
+    // Detect if this is a PDF
+    const rawBuffer = Buffer.from(arrayBuffer)
+    const isPdfResponse = mime === 'application/pdf' || isPdfBuffer(rawBuffer)
+
+    if (isPdfResponse) {
+      try {
+        const { text, pageCount, title, author } = await extractPdfText(rawBuffer)
+        const { output, truncated, isScanned } = processPdfContent(text, OUTPUT_LIMITS.web_fetch.maxBytes)
+
+        if (isScanned) {
+          return helpers.success(
+            '[PDF: This PDF has no text layer (scanned or image-only). Use an external tool with OCR to extract text.]',
+            false,
+            {
+              metadata: {
+                format: 'pdf',
+                pageCount,
+                title,
+                author,
+                url,
+              },
+            },
+          )
+        }
+
+        return helpers.success(output, truncated, {
+          metadata: {
+            format: 'pdf',
+            pageCount,
+            title,
+            author,
+            url,
+          },
+        })
+      } catch (err) {
+        if (isPasswordError(err)) {
+          return helpers.error('This PDF is password-protected. Unlock it with an external tool first.')
+        }
+        return helpers.error(`Failed to read PDF: ${err instanceof Error ? err.message : String(err)}`)
+      }
     }
 
     const rawContent = new TextDecoder().decode(arrayBuffer)


### PR DESCRIPTION
## Résumé

Ajout de la capacité de lire des documents PDF dans les outils `read_file` et `web_fetch` via `pdfjs-dist`.

## Changements

- **Nouvelle dépendance** : `pdfjs-dist` (legacy build) pour l'extraction texte des PDF côté serveur
- **`src/server/tools/pdf-utils.ts`** (nouveau) : module partagé avec `isPdfBuffer()`, `extractPdfText()`, `processPdfContent()`, `isPasswordError()`
- **`read_file`** : détection des PDF par magic bytes `%PDF`, extraction page par page avec séparateur `[Page X/N]`, metadata `format`, `pageCount`, `title`, `author`. Limites : 50 pages, 20MB, 100KB output
- **`web_fetch`** : pareil, détection par content-type `application/pdf` + magic bytes
- **Limites dans `OUTPUT_LIMITS`** : `maxPdfPages: 50`, `maxPdfBytes: 20MB`, `maxFileBytes: 20MB` (safety cap général)
- **Tests** : 18 tests read_file (dont 5 PDF), 17 tests web_fetch (dont 4 PDF), générateurs PDF inline dans les tests (pas de fixture binaire)

## Cas gérés

| Cas | Comportement |
|-----|-------------|
| PDF valide avec texte | Texte extrait page par page |
| PDF scanné (pas de text layer) | Message "has no text layer, use OCR" |
| PDF protégé par mot de passe | Error explicite |
| PDF multi-pages (2+) | Chaque page préfixée `[Page X/N]` |
| PDF > 20MB | Rejeté avant lecture |
| PDF > 50 pages | Seules les 50 premières pages sont extraites |
| Texte extrait > 100KB | Tronqué avec notice |