### PR TITLE
feat: git worktree support for parallel sessions on same project

### DIFF
--- a/src/server/db/index.ts
+++ b/src/server/db/index.ts
@@ -236,5 +236,11 @@ function runMigrations(db: Database.Database): void {
     db.exec(`ALTER TABLE sessions ADD COLUMN cached_hash TEXT`)
   }
 
+  // Migration: Add worktree column for git worktree support
+  if (!columnNames.includes('worktree')) {
+    logger.info('Migrating sessions table: adding worktree column')
+    db.exec(`ALTER TABLE sessions ADD COLUMN worktree TEXT`)
+  }
+
   logger.info('Database migrations completed')
 }

--- a/src/server/db/sessions.ts
+++ b/src/server/db/sessions.ts
@@ -31,6 +31,7 @@ export function createSession(
   title?: string,
   providerId?: string | null,
   providerModel?: string | null,
+  worktree?: string,
 ): Session {
   const db = getDatabase()
   const now = new Date().toISOString()
@@ -39,15 +40,27 @@ export function createSession(
 
   db.prepare(
     `
-    INSERT INTO sessions (id, project_id, workdir, phase, mode, workflow_phase, is_running, created_at, updated_at, title, provider_id, provider_model, danger_level)
-    VALUES (?, ?, ?, 'idle', 'planner', 'plan', 0, ?, ?, ?, ?, ?, ?)
+    INSERT INTO sessions (id, project_id, workdir, worktree, phase, mode, workflow_phase, is_running, created_at, updated_at, title, provider_id, provider_model, danger_level)
+    VALUES (?, ?, ?, ?, 'idle', 'planner', 'plan', 0, ?, ?, ?, ?, ?, ?)
   `,
-  ).run(id, projectId, workdir, now, now, title ?? null, providerId ?? null, providerModel ?? null, dangerLevel)
+  ).run(
+    id,
+    projectId,
+    workdir,
+    worktree ?? null,
+    now,
+    now,
+    title ?? null,
+    providerId ?? null,
+    providerModel ?? null,
+    dangerLevel,
+  )
 
   return {
     id,
     projectId,
     workdir,
+    ...(worktree ? { worktree } : {}),
     mode: 'planner',
     phase: 'plan',
     isRunning: false,
@@ -274,6 +287,7 @@ export function listSessions(): SessionSummary[] {
       s.id,
       s.project_id,
       s.workdir,
+      s.worktree,
       s.mode,
       s.workflow_phase,
       s.is_running,
@@ -306,6 +320,7 @@ export function listSessionsByProject(
       s.id,
       s.project_id,
       s.workdir,
+      s.worktree,
       s.mode,
       s.workflow_phase,
       s.is_running,
@@ -338,6 +353,7 @@ function mapSessionBase(row: SessionRow | SessionSummaryRow): {
   id: string
   projectId: string
   workdir: string
+  worktree?: string
   mode: SessionMode
   phase: SessionPhase
   isRunning: boolean
@@ -350,6 +366,7 @@ function mapSessionBase(row: SessionRow | SessionSummaryRow): {
     id: row.id,
     projectId: row.project_id,
     workdir: row.workdir,
+    ...(row.worktree ? { worktree: row.worktree } : {}),
     mode: (row.mode ?? 'planner') as SessionMode,
     phase: (row.workflow_phase ?? 'plan') as SessionPhase,
     isRunning: Boolean(row.is_running),
@@ -378,6 +395,7 @@ interface SessionRow {
   id: string
   project_id: string
   workdir: string
+  worktree: string | null
   phase: string
   mode: string
   workflow_phase: string
@@ -401,6 +419,7 @@ interface SessionSummaryRow {
   id: string
   project_id: string
   workdir: string
+  worktree: string | null
   mode: string
   workflow_phase: string
   is_running: number

--- a/src/server/git/worktree.test.ts
+++ b/src/server/git/worktree.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { getGitBranch, listWorktrees, validateRef, addWorktree, ensureWorktreesIgnored, ensureWorktree } from './worktree.js'
+
+vi.mock('node:child_process', () => ({
+  spawn: vi.fn(),
+}))
+
+vi.mock('node:fs/promises', () => ({
+  readFile: vi.fn(),
+  appendFile: vi.fn(),
+  mkdir: vi.fn(),
+  stat: vi.fn(),
+}))
+
+vi.mock('../utils/logger.js', () => ({
+  logger: { debug: vi.fn(), warn: vi.fn(), info: vi.fn(), error: vi.fn() },
+}))
+
+import { spawn } from 'node:child_process'
+import { readFile, appendFile, mkdir, stat } from 'node:fs/promises'
+
+type MockProc = {
+  stdout: { on: (event: string, cb: (d: Buffer) => void) => void }
+  stderr: { on: (event: string, cb: (d: Buffer) => void) => void }
+  stdin?: { write: (d: Buffer) => void; end: () => void }
+  on: (event: string, cb: (code: number | Error) => void) => void
+}
+
+function makeMockProc(stdout: string, stderr = '', exitCode = 0): MockProc {
+  const listeners: Record<string, (arg: unknown) => void> = {}
+  return {
+    stdout: {
+      on: (event, cb) => {
+        if (event === 'data') setTimeout(() => cb(Buffer.from(stdout)), 0)
+      },
+    },
+    stderr: {
+      on: (event, cb) => {
+        if (event === 'data' && stderr) setTimeout(() => cb(Buffer.from(stderr)), 0)
+      },
+    },
+    on: (event, cb) => {
+      if (event === 'close') setTimeout(() => cb(exitCode), 0)
+      if (event === 'error') listeners['error'] = cb
+    },
+  }
+}
+
+const CWD = '/tmp/project'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('getGitBranch', () => {
+  it('returns the branch name', async () => {
+    vi.mocked(spawn).mockReturnValue(makeMockProc('main\n') as any)
+    const result = await getGitBranch(CWD)
+    expect(result).toBe('main')
+    expect(spawn).toHaveBeenCalledWith('git', ['rev-parse', '--abbrev-ref', 'HEAD'], expect.any(Object))
+  })
+
+  it('returns null on error', async () => {
+    vi.mocked(spawn).mockReturnValue(makeMockProc('', '', 1) as any)
+    const result = await getGitBranch(CWD)
+    expect(result).toBeNull()
+  })
+})
+
+describe('listWorktrees', () => {
+  it('parses worktree list --porcelain output', async () => {
+    vi.mocked(spawn).mockReturnValue(
+      makeMockProc(
+        'worktree /repo/main\nbranch refs/heads/main\n\nworktree /repo/worktrees/fix\nbranch refs/heads/fix/pagination\n\n',
+      ) as any,
+    )
+    const result = await listWorktrees(CWD)
+    expect(result).toEqual([
+      { path: '/repo/main', branch: 'main' },
+      { path: '/repo/worktrees/fix', branch: 'fix/pagination' },
+    ])
+  })
+
+  it('returns empty on error', async () => {
+    vi.mocked(spawn).mockReturnValue(makeMockProc('', '', 1) as any)
+    const result = await listWorktrees(CWD)
+    expect(result).toEqual([])
+  })
+})
+
+describe('validateRef', () => {
+  it('resolves for valid branch name', async () => {
+    vi.mocked(spawn).mockReturnValue(makeMockProc('') as any)
+    await expect(validateRef(CWD, 'feature/foo')).resolves.toBeUndefined()
+  })
+
+  it('rejects for invalid branch name', async () => {
+    vi.mocked(spawn).mockReturnValue(makeMockProc('', 'fatal: invalid ref format', 128) as any)
+    await expect(validateRef(CWD, 'bad name')).rejects.toThrow('fatal: invalid ref format')
+  })
+})
+
+describe('addWorktree', () => {
+  it('resolves on success', async () => {
+    vi.mocked(spawn).mockReturnValue(makeMockProc('') as any)
+    await expect(addWorktree(CWD, ['-b', 'fix', '/tmp/wt', 'main'])).resolves.toBeUndefined()
+  })
+
+  it('rejects on failure', async () => {
+    vi.mocked(spawn).mockReturnValue(makeMockProc('', 'fatal: could not create worktree', 128) as any)
+    await expect(addWorktree(CWD, ['/tmp/wt', 'main'])).rejects.toThrow('fatal: could not create worktree')
+  })
+})
+
+describe('ensureWorktreesIgnored', () => {
+  it('does nothing when worktrees/ already in gitignore', async () => {
+    vi.mocked(readFile).mockResolvedValue('node_modules/\nworktrees/\n')
+    await ensureWorktreesIgnored(CWD)
+    expect(appendFile).not.toHaveBeenCalled()
+  })
+
+  it('appends worktrees/ when missing', async () => {
+    vi.mocked(readFile).mockResolvedValue('node_modules/\n')
+    await ensureWorktreesIgnored(CWD)
+    expect(appendFile).toHaveBeenCalledWith('/tmp/project/.gitignore', 'worktrees/\n')
+  })
+
+  it('handles missing gitignore', async () => {
+    vi.mocked(readFile).mockRejectedValue({ code: 'ENOENT' })
+    await ensureWorktreesIgnored(CWD)
+    expect(appendFile).toHaveBeenCalledWith('/tmp/project/.gitignore', 'worktrees/\n')
+  })
+})
+
+describe('ensureWorktree', () => {
+  it('creates worktree and returns path', async () => {
+    vi.mocked(mkdir).mockResolvedValue(undefined)
+    vi.mocked(stat).mockRejectedValue({ code: 'ENOENT' })
+    vi.mocked(readFile).mockResolvedValue('node_modules/\n')
+    vi.mocked(appendFile).mockResolvedValue(undefined)
+    vi.mocked(spawn).mockReturnValue(makeMockProc('') as any)
+
+    const result = await ensureWorktree(CWD, 'feature/test')
+    expect(result.path).toContain('worktrees/feature-test')
+    expect(result.name).toBe('feature/test')
+    expect(mkdir).toHaveBeenCalledWith(expect.stringContaining('worktrees'), { recursive: true })
+    expect(spawn).toHaveBeenCalledWith('git', ['worktree', 'add', '-b', 'feature/test', expect.any(String), 'main'], expect.any(Object))
+  })
+
+  it('reuses existing worktree directory', async () => {
+    vi.mocked(mkdir).mockResolvedValue(undefined)
+    vi.mocked(stat).mockResolvedValue({ isDirectory: () => true } as any)
+    vi.mocked(readFile).mockResolvedValue('node_modules/\n')
+    vi.mocked(spawn).mockReturnValue(makeMockProc('main\n') as any) // getGitBranch called first
+
+    const result = await ensureWorktree(CWD, 'existing')
+    expect(result.path).toContain('worktrees/existing')
+    // Should not call addWorktree (git worktree add)
+    expect(spawn).toHaveBeenCalledTimes(1) // only getGitBranch
+    expect(spawn).toHaveBeenCalledWith('git', ['rev-parse', '--abbrev-ref', 'HEAD'], expect.any(Object))
+  })
+})

--- a/src/server/git/worktree.ts
+++ b/src/server/git/worktree.ts
@@ -1,0 +1,121 @@
+import { spawn } from 'node:child_process'
+import { mkdir, readFile, appendFile, stat } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { logger } from '../utils/logger.js'
+
+export function getGitBranch(cwd: string): Promise<string | null> {
+  return new Promise((resolve) => {
+    const proc = spawn('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { cwd, stdio: ['ignore', 'pipe', 'ignore'] })
+    let out = ''
+    proc.stdout.on('data', (d: Buffer) => { out += d.toString() })
+    proc.on('close', (code) => resolve(code === 0 && out.trim() ? out.trim() : null))
+    proc.on('error', () => resolve(null))
+  })
+}
+
+export function listWorktrees(cwd: string): Promise<{ path: string; branch: string }[]> {
+  return new Promise((resolve) => {
+    const proc = spawn('git', ['worktree', 'list', '--porcelain'], { cwd, stdio: ['ignore', 'pipe', 'ignore'] })
+    let out = ''
+    proc.stdout.on('data', (d: Buffer) => { out += d.toString() })
+    proc.on('close', (code) => {
+      if (code !== 0) { resolve([]); return }
+      const entries: { path: string; branch: string }[] = []
+      let current: { path?: string; branch?: string } = {}
+      for (const line of out.split('\n')) {
+        if (line.startsWith('worktree ')) current.path = line.slice(9)
+        else if (line.startsWith('branch ')) current.branch = line.slice(7).replace('refs/heads/', '')
+        else if (line === '' && current.path && current.branch) {
+          entries.push({ path: current.path, branch: current.branch })
+          current = {}
+        }
+      }
+      if (current.path && current.branch) entries.push({ path: current.path, branch: current.branch })
+      resolve(entries)
+    })
+    proc.on('error', () => resolve([]))
+  })
+}
+
+export function validateRef(cwd: string, name: string): Promise<void> {
+  return new Promise((resolvePromise, reject) => {
+    const proc = spawn('git', ['check-ref-format', `refs/heads/${name}`], { cwd, stdio: ['ignore', 'ignore', 'pipe'] })
+    let stderr = ''
+    proc.stderr.on('data', (d: Buffer) => { stderr += d.toString() })
+    proc.on('close', (code) => {
+      if (code === 0) resolvePromise()
+      else reject(new Error(stderr.trim() || 'Invalid git branch name'))
+    })
+    proc.on('error', (err) => reject(err))
+  })
+}
+
+export function addWorktree(cwd: string, args: string[]): Promise<void> {
+  return new Promise((resolvePromise, reject) => {
+    const proc = spawn('git', ['worktree', 'add', ...args], { cwd, stdio: ['ignore', 'pipe', 'pipe'] })
+    let stderr = ''
+    proc.stderr.on('data', (d: Buffer) => { stderr += d.toString() })
+    proc.on('close', (code) => {
+      if (code === 0) resolvePromise()
+      else reject(new Error(stderr.trim() || `git worktree add failed (code ${code})`))
+    })
+    proc.on('error', (err) => reject(err))
+  })
+}
+
+const WORKTREES_GITIGNORE_PATTERN = /^worktrees[/\s]|^\/worktrees[/\s]/m
+
+export async function ensureWorktreesIgnored(projectDir: string): Promise<void> {
+  const gitignorePath = resolve(projectDir, '.gitignore')
+  let content = ''
+  try {
+    content = await readFile(gitignorePath, 'utf-8')
+  } catch {
+    // File doesn't exist — will create it
+  }
+  if (WORKTREES_GITIGNORE_PATTERN.test(content)) return
+  const entry = content.length > 0 && !content.endsWith('\n') ? '\nworktrees/\n' : 'worktrees/\n'
+  await appendFile(gitignorePath, entry)
+}
+
+export interface WorktreeResult {
+  path: string
+  name: string
+}
+
+export async function ensureWorktree(projectDir: string, name: string, startBranch?: string): Promise<WorktreeResult> {
+  const worktreesDir = resolve(projectDir, 'worktrees')
+  const wtPath = resolve(worktreesDir, name.replace(/\//g, '-'))
+
+  try {
+    await mkdir(worktreesDir, { recursive: true })
+  } catch (err) {
+    logger.warn('Failed to create worktrees directory', { worktreesDir, error: String(err) })
+  }
+
+  try {
+    await ensureWorktreesIgnored(projectDir)
+  } catch (err) {
+    logger.warn('Failed to update .gitignore', { projectDir, error: String(err) })
+  }
+
+  const startBranchResolved = startBranch ?? (await getGitBranch(projectDir)) ?? 'main'
+
+  try {
+    const st = await stat(wtPath)
+    if (st.isDirectory()) return { path: wtPath, name }
+  } catch {
+    // Path doesn't exist — create the worktree
+  }
+
+  try {
+    await addWorktree(projectDir, ['-b', name, wtPath, startBranchResolved])
+  } catch {
+    await addWorktree(projectDir, [wtPath, name]).catch((err) => {
+      logger.warn('Worktree add failed', { name, error: String(err) })
+      throw err
+    })
+  }
+
+  return { path: wtPath, name }
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -4,6 +4,7 @@ import { createServer as createHttpServer } from 'node:http'
 import { fileURLToPath } from 'node:url'
 import { dirname, resolve, join } from 'node:path'
 import { readFile } from 'node:fs/promises'
+import { getGitBranch, listWorktrees, validateRef, ensureWorktree } from './git/worktree.js'
 import { createServer as createViteServer, type ViteDevServer } from 'vite'
 
 import type { Config, ModelConfig, ProviderBackend } from '../shared/types.js'
@@ -383,6 +384,49 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
     res.json({ project })
   })
 
+  // Git worktree endpoints (helpers imported from ./git/worktree.js)
+
+  /** Check if a directory is a git repo, return git info */
+  app.get('/api/projects/:id/git-info', async (req, res) => {
+    const { getProject } = await import('./db/projects.js')
+    const project = getProject(req.params.id)
+    if (!project) return res.status(404).json({ error: 'Project not found' })
+
+    const branch = await getGitBranch(project.workdir)
+    if (!branch) return res.json({ isGit: false, branch: null, worktrees: [] })
+
+    const worktrees = await listWorktrees(project.workdir)
+    res.json({ isGit: true, branch, worktrees })
+  })
+
+  /** List existing git worktrees */
+  app.get('/api/projects/:id/worktrees', async (req, res) => {
+    const { getProject } = await import('./db/projects.js')
+    const project = getProject(req.params.id)
+    if (!project) return res.status(404).json({ error: 'Project not found' })
+    const branch = await getGitBranch(project.workdir)
+    if (!branch) return res.status(400).json({ error: 'Project is not a git repository' })
+    const worktrees = await listWorktrees(project.workdir)
+    res.json({ worktrees })
+  })
+
+  /** Create a new git worktree */
+  app.post('/api/projects/:id/worktrees', async (req, res) => {
+    const { getProject } = await import('./db/projects.js')
+    const project = getProject(req.params.id)
+    if (!project) return res.status(404).json({ error: 'Project not found' })
+    const { name, branch } = req.body
+    if (!name || typeof name !== 'string') return res.status(400).json({ error: 'name is required' })
+    try {
+      await validateRef(project.workdir, name)
+    } catch {
+      return res.status(400).json({ error: `Invalid branch name: "${name}"` })
+    }
+    const startBranch = typeof branch === 'string' && branch ? branch : undefined
+    const result = await ensureWorktree(project.workdir, name, startBranch)
+    res.status(201).json({ worktree: { path: result.path, name, branch: name } })
+  })
+
   // Session endpoints (REST)
 
   app.get('/api/sessions', async (req, res) => {
@@ -412,7 +456,7 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
   })
 
   app.post('/api/sessions', async (req, res) => {
-    const { projectId, title } = req.body
+    const { projectId, title, worktree } = req.body
     if (!projectId) {
       return res.status(400).json({ error: 'projectId is required' })
     }
@@ -422,8 +466,24 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
       return res.status(404).json({ error: 'Project not found' })
     }
 
+    // Validate worktree name with git if provided
+    if (worktree && typeof worktree === 'string') {
+      try {
+        await validateRef(project.workdir, worktree)
+      } catch {
+        return res.status(400).json({ error: `Invalid branch name: "${worktree}"` })
+      }
+    }
+
     // Inherit provider/model from defaultModelSelection config
     const { providerId, model } = parseDefaultModelSelection(config.defaultModelSelection)
+
+    // If a worktree name is given, create it first
+    if (worktree && typeof worktree === 'string') {
+      const result = await ensureWorktree(project.workdir, worktree)
+      const session = sessionManager.createSession(projectId, title, providerId ?? null, model ?? null, result.path)
+      return res.status(201).json({ session })
+    }
 
     // maxTokens is no longer passed - it comes from providerManager.getCurrentModelContext() at query time
     const session = sessionManager.createSession(projectId, title, providerId ?? null, model ?? null)

--- a/src/server/session/manager.ts
+++ b/src/server/session/manager.ts
@@ -135,7 +135,13 @@ export class SessionManager {
    * Create a new session. Emits session.initialized event.
    * Note: maxTokens is no longer stored in the session - it comes from the current model config
    */
-  createSession(projectId: string, title?: string, providerId?: string | null, providerModel?: string | null): Session {
+  createSession(
+    projectId: string,
+    title?: string,
+    providerId?: string | null,
+    providerModel?: string | null,
+    worktree?: string,
+  ): Session {
     const project = getProject(projectId)
     if (!project) {
       throw new Error(`Project not found: ${projectId}`)
@@ -148,15 +154,17 @@ export class SessionManager {
       sessionTitle = `Session ${existingSessions.sessions.length + 1}`
     }
 
-    logger.debug('Creating session', { projectId, workdir: project.workdir, title: sessionTitle })
+    const effectiveWorkdir = worktree ?? project.workdir
+
+    logger.debug('Creating session', { projectId, workdir: effectiveWorkdir, title: sessionTitle })
 
     // Create session in DB (minimal: id, projectId, workdir, title, timestamps)
-    const dbSession = dbCreateSession(projectId, project.workdir, sessionTitle, providerId, providerModel)
+    const dbSession = dbCreateSession(projectId, effectiveWorkdir, sessionTitle, providerId, providerModel, worktree)
 
     // Emit session.initialized event to EventStore
     // maxTokens is NOT stored here - it comes from providerManager.getCurrentModelContext() at query time
     const contextWindowId = crypto.randomUUID()
-    emitSessionInitialized(dbSession.id, projectId, project.workdir, contextWindowId, sessionTitle)
+    emitSessionInitialized(dbSession.id, projectId, effectiveWorkdir, contextWindowId, sessionTitle)
 
     // Build full session object
     const session = this.buildSessionFromDb(dbSession)

--- a/src/server/ws/server.ts
+++ b/src/server/ws/server.ts
@@ -837,15 +837,16 @@ async function handleClientMessage(
 
       // Tab model: set active session for event routing
       client.activeSessionId = session.id
-      client.activeWorkdir = session.workdir
+      const effectiveWorkdir = session.worktree ?? session.workdir
+      client.activeWorkdir = effectiveWorkdir
 
       // Send initial git status immediately
-      if (session.workdir) {
-        const branch = await moduleGitBranch(session.workdir)
-        const { files } = await moduleGitDiff(session.workdir)
+      if (effectiveWorkdir) {
+        const branch = await moduleGitBranch(effectiveWorkdir)
+        const { files } = await moduleGitDiff(effectiveWorkdir)
         const msg = createGitStatusMessage(branch, files)
         send(msg)
-        if (branch) moduleStartGitPolling(session.workdir)
+        if (branch) moduleStartGitPolling(effectiveWorkdir)
       }
 
       ensureEventStoreSubscription(session.id)

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -31,6 +31,7 @@ export interface Session {
   id: string
   projectId: string
   workdir: string
+  worktree?: string // Optional git worktree path
   mode: SessionMode
   phase: SessionPhase // Current workflow phase
   isRunning: boolean // Is the agent actively working?
@@ -81,6 +82,7 @@ export interface SessionSummary {
   projectId: string
   title?: string
   workdir: string
+  worktree?: string // Optional git worktree path
   mode: SessionMode
   phase: SessionPhase // Current workflow phase
   isRunning: boolean

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -21,7 +21,6 @@ import { Header } from './components/layout/Header'
 import { Sidebar } from './components/layout/Sidebar'
 import { PageTitle } from './components/layout/PageTitle'
 import { HomePage } from './components/HomePage'
-import { NewSessionHandler } from './components/NewSessionHandler'
 import { EmptyProjectView } from './components/EmptyProjectView'
 import { PlanPanel } from './components/plan/PlanPanel'
 import { ReadonlySessionView } from './components/plan/ReadonlySessionView'
@@ -351,7 +350,16 @@ function App() {
               />
             </Route>
             <Route path="/p/:projectId/new">
-              <NewSessionHandler />
+              {(params: { projectId: string }) => {
+                const ProjectRedirect = () => {
+                  const [, navigate] = useLocation()
+                  useEffect(() => {
+                    navigate(`/p/${params.projectId}`, { replace: true })
+                  }, [])
+                  return null
+                }
+                return <ProjectRedirect />
+              }}
             </Route>
             <Route path="/p/:projectId">
               <ProjectView sidebarOpen={effectiveLeftOpen} onSidebarToggle={handleLeftToggle} />

--- a/web/src/components/NewSessionModal.tsx
+++ b/web/src/components/NewSessionModal.tsx
@@ -1,0 +1,136 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useLocation } from 'wouter'
+import { useSessionStore } from '../stores/session'
+import { authFetch } from '../lib/api'
+import { Spinner } from './shared/Spinner'
+
+interface NewSessionModalProps {
+  isOpen: boolean
+  onClose: () => void
+}
+
+interface GitInfo {
+  isGit: boolean
+  branch: string | null
+  worktrees: { path: string; branch: string }[]
+}
+
+function createSession(projectId: string, title?: string, worktree?: string): Promise<{ session: { id: string } }> {
+  return authFetch('/api/sessions', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ projectId, title, ...(worktree ? { worktree } : {}) }),
+  }).then(async (res) => {
+    if (!res.ok) {
+      const errBody = await res.json().catch(() => ({ error: 'Unknown error' }))
+      throw new Error(errBody.error || `Request failed (${res.status})`)
+    }
+    return res.json()
+  })
+}
+
+export function NewSessionModal({ isOpen, onClose }: NewSessionModalProps) {
+  const [, navigate] = useLocation()
+  const projectId = typeof window !== 'undefined' ? window.location.pathname.match(/\/p\/([^/]+)/)?.[1] : undefined
+  const resetPendingSessionCreate = useSessionStore((s) => s.resetPendingSessionCreate)
+
+  const [gitInfo, setGitInfo] = useState<GitInfo | null>(null)
+  const [worktreeName, setWorktreeName] = useState('')
+  const [creating, setCreating] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!isOpen || !projectId) return
+    setWorktreeName('')
+    setCreating(false)
+    setError(null)
+    setGitInfo(null)
+    authFetch(`/api/projects/${projectId}/git-info`)
+      .then((r) => r.json())
+      .then(async (info: GitInfo) => {
+        if (!info.isGit) {
+          handleCreate(undefined)
+          return
+        }
+        setGitInfo(info)
+      })
+      .catch(() => {
+        handleCreate(undefined)
+      })
+  }, [isOpen, projectId])
+
+  const handleCreate = useCallback(
+    async (wt?: string) => {
+      if (!projectId) return
+      setCreating(true)
+      setError(null)
+      try {
+        const data = await createSession(projectId, undefined, wt || undefined)
+        resetPendingSessionCreate()
+        onClose()
+        navigate(`/p/${projectId}/s/${data.session.id}`)
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'Failed to create session')
+        setCreating(false)
+      }
+    },
+    [projectId, resetPendingSessionCreate, onClose, navigate],
+  )
+
+  const handleSkip = useCallback(() => handleCreate(undefined), [handleCreate])
+  const handleCreateWithWorktree = useCallback(() => handleCreate(worktreeName.trim()), [handleCreate, worktreeName])
+
+  if (!isOpen) return null
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={onClose}>
+      <div
+        className="bg-bg-primary rounded-lg border border-border shadow-xl p-6 w-full max-w-md mx-4"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {creating ? (
+          <div className="flex items-center justify-center py-8">
+            <Spinner />
+          </div>
+        ) : !gitInfo ? (
+          <div className="flex items-center justify-center py-8">
+            <Spinner />
+          </div>
+        ) : (
+          <div>
+            <h2 className="text-lg font-semibold text-text-primary mb-2">New Session</h2>
+            <p className="text-sm text-text-muted mb-4">
+              Create in a git worktree? This lets you run multiple sessions in parallel without conflicts. Current
+              branch: <span className="font-mono text-text-secondary">{gitInfo.branch}</span>
+            </p>
+            {error && <p className="text-sm text-accent-error mb-3 bg-accent-error/10 p-2 rounded">{error}</p>}
+            <label className="block text-sm text-text-secondary mb-1">Worktree name</label>
+            <input
+              type="text"
+              value={worktreeName}
+              onChange={(e) => setWorktreeName(e.target.value)}
+              placeholder="feature/my-branch"
+              className="w-full px-3 py-2 rounded border border-border bg-bg-primary text-text-primary text-sm mb-4 focus:outline-none focus:border-accent-primary"
+              autoFocus
+            />
+            <div className="flex gap-2 justify-end">
+              <button
+                onClick={handleSkip}
+                className="px-4 py-2 text-sm rounded bg-bg-tertiary text-text-secondary hover:bg-bg-secondary transition-colors"
+              >
+                Create in project folder
+              </button>
+              <button
+                onClick={handleCreateWithWorktree}
+                disabled={!worktreeName.trim() || creating}
+                className="px-4 py-2 text-sm rounded bg-accent-primary text-white hover:opacity-90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                Create in new worktree
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -4,6 +4,7 @@ import { useSessionStore } from '../../stores/session'
 import { useProjectStore } from '../../stores/project'
 import type { SessionSummary } from '@shared/types.js'
 import { ProjectSettingsModal } from '../settings/ProjectSettingsModal'
+import { NewSessionModal } from '../NewSessionModal'
 import { DropdownMenu } from '../shared/DropdownMenu'
 import { CloseButton } from '../shared/CloseButton'
 import { EllipsisIcon, SpinIcon } from '../shared/icons'
@@ -18,6 +19,7 @@ interface SidebarProps {
 export function Sidebar({ projectId, isOpen = true, onClose }: SidebarProps) {
   const [, navigate] = useLocation()
   const [showSettings, setShowSettings] = useState(false)
+  const [showNewSession, setShowNewSession] = useState(false)
 
   const sessions = useSessionStore((state) => state.sessions)
   const currentSession = useSessionStore((state) => state.currentSession)
@@ -104,13 +106,13 @@ export function Sidebar({ projectId, isOpen = true, onClose }: SidebarProps) {
         `}
       >
         <div className="p-4 border-b border-border flex gap-2">
-          <Link
-            href={`/p/${projectId}/new`}
+          <button
+            onClick={() => setShowNewSession(true)}
             className="flex-1 block text-center rounded font-medium transition-colors bg-accent-primary/25 text-text-primary hover:bg-accent-primary/40 px-3 py-1.5 text-sm"
             data-testid="sidebar-new-session-button"
           >
             + New Session
-          </Link>
+          </button>
           <DropdownMenu
             items={[
               {
@@ -164,6 +166,9 @@ export function Sidebar({ projectId, isOpen = true, onClose }: SidebarProps) {
           )}
         </div>
       </aside>
+
+      {/* New Session Modal — outside sidebar to avoid clipping */}
+      <NewSessionModal isOpen={showNewSession} onClose={() => setShowNewSession(false)} />
     </>
   )
 }

--- a/web/src/stores/session/store.ts
+++ b/web/src/stores/session/store.ts
@@ -249,7 +249,7 @@ export const useSessionStore = create<SessionState>((set, get) => {
       set({ showPasswordModal: false, connectionStatus: 'disconnected' })
     },
 
-    createSession: async (projectId, title) => {
+    createSession: async (projectId, title, worktree) => {
       const state = get()
       if (state.pendingSessionCreate) {
         return null
@@ -260,11 +260,12 @@ export const useSessionStore = create<SessionState>((set, get) => {
         const res = await authFetch('/api/sessions', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ projectId, title }),
+          body: JSON.stringify({ projectId, title, ...(worktree ? { worktree } : {}) }),
         })
         if (!res.ok) {
           set({ pendingSessionCreate: false })
-          return null
+          const errBody = await res.json().catch(() => ({ error: 'Request failed' }))
+          throw new Error(errBody.error || `Request failed (${res.status})`)
         }
         const data = await res.json()
         try {
@@ -273,9 +274,9 @@ export const useSessionStore = create<SessionState>((set, get) => {
           /* empty */
         }
         return data.session
-      } catch {
+      } catch (err) {
         set({ pendingSessionCreate: false })
-        return null
+        throw err
       }
     },
 

--- a/web/src/stores/session/types.ts
+++ b/web/src/stores/session/types.ts
@@ -67,7 +67,7 @@ export interface SessionState {
   disconnect: () => void
   submitPassword: (password: string) => Promise<void>
   cancelPassword: () => void
-  createSession: (projectId: string, title?: string) => Promise<Session | null>
+  createSession: (projectId: string, title?: string, worktree?: string) => Promise<Session | null>
   loadSession: (sessionId: string) => Promise<void>
   listSessions: (projectId?: string, limit?: number) => Promise<void>
   deleteSession: (sessionId: string) => Promise<boolean>


### PR DESCRIPTION
## Summary

Ajoute le support des **git worktrees** dans OpenFox. Quand on lance une nouvelle session dans un projet git, l'utilisateur peut choisir de créer un worktree dédié. Cela permet d'avoir plusieurs sessions parallèles sur le même projet sans qu'elles interfèrent (chacune sa propre branche, son propre répertoire, ses propres modifications).

## Arborescence

Conformément au pattern dominant des agents de code (Claude Code, Cursor, Codex), les worktrees sont créés dans `worktrees/` à la racine du projet :

```
monrepo/
├── .gitignore          (contient worktrees/ — ajouté automatiquement)
└── worktrees/
    ├── feature-labels/   (branche feature/labels)
    ├── fix-pagination/   (branche fix/pagination)
    └── refactor-auth/    (branche refactor/auth)
```

Le dossier `worktrees/` est créé automatiquement s'il n'existe pas. Les `/` dans les noms de branche sont remplacés par `-` pour les noms de dossier. OpenFox ajoute automatiquement `worktrees/` au `.gitignore` du projet.

## API

| Endpoint | Description |
|----------|-------------|
| `POST /api/sessions` | Crée session (worktree optionnel) |
| `GET /api/projects/:id/git-info` | `{ isGit, branch, worktrees }` |
| `GET /api/projects/:id/worktrees` | Liste les worktrees |
| `POST /api/projects/:id/worktrees` | Crée un worktree |

La création de worktree est unifiée dans `ensureWorktree(projectDir, name)` : crée `worktrees/`, met à jour `.gitignore`, détecte les worktrees existants, `git worktree add -b` avec fallback sans `-b`.

## Stockage session→worktree

- Colonne `worktree` dans la table `sessions`
- `Session.worktree` optionnel dans le type partagé
- `session.worktree ?? session.workdir` utilisé par le polling git et l'event store
- Les sub-agents, workflows et LSP utilisent `session.workdir` qui contient déjà le chemin du worktree — zéro changement nécessaire

## UI

- Modal overlay centré au clic "+ New Session" si le projet est un repo git
- Deux choix : **Create in project folder** / **Create in new worktree**
- Navigation SPA via `wouter` — pas de rechargement complet
- Si pas de repo git : session créée directement, pas de modal

## Helpers factorisés

`src/server/git/worktree.ts` :
- `getGitBranch(cwd)` — branche courante
- `listWorktrees(cwd)` — `git worktree list --porcelain`
- `validateRef(cwd, name)` — `git check-ref-format`
- `addWorktree(cwd, args)` — `git worktree add`
- `ensureWorktreesIgnored(projectDir)` — `.gitignore`
- `ensureWorktree(projectDir, name)` — création complète (mkdir + gitignore + worktree add)

## Tests

13 tests unitaires dans `src/server/git/worktree.test.ts` couvrant tous les helpers (parsing porcelain, validation ref, ajout worktree, gitignore, création/réutilisation).

## Dépendances

Aucune — que des commandes git système.

## Stats

13 fichiers modifiés, +553/-24, 2082/2092 tests pass (timeouts réseau préexistants sur `auto-update.test.ts`).