### PR TITLE
Fix stale provider adapters when switching inference engines

### DIFF
--- a/web/src/components/shared/ProviderModal.test.tsx
+++ b/web/src/components/shared/ProviderModal.test.tsx
@@ -305,4 +305,71 @@ describe('ProviderModal - thinkingLevel persistence', () => {
       }),
     )
   })
+
+  it.each([
+    ['Ollama', 'ollama'],
+    ['Other', 'unknown'],
+  ])('clears preset adapters when switching to %s', async (engineName, expectedBackend) => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input)
+        if (url.includes('/api/provider-presets')) {
+          return new Response(
+            JSON.stringify({
+              presets: [
+                {
+                  id: 'account-provider',
+                  name: 'Account Provider',
+                  defaults: {
+                    name: 'Account Provider',
+                    url: 'https://provider.example/api',
+                    backend: 'openai',
+                  },
+                  authAdapter: 'account-auth',
+                  transportAdapter: 'custom-transport',
+                },
+              ],
+            }),
+            { status: 200 },
+          )
+        }
+        if (url.includes('/api/providers/models')) {
+          return new Response(JSON.stringify({ models: [], url: 'http://localhost:11434' }), { status: 200 })
+        }
+        return new Response(JSON.stringify({}), { status: 200 })
+      }),
+    )
+
+    await new Promise<void>((resolve) => {
+      root.render(
+        <ProviderModal isOpen={true} onClose={vi.fn()} onSave={onSaveMock as (provider: ProviderFormData) => void} />,
+      )
+      setTimeout(resolve, 100)
+    })
+
+    const buttonByText = (text: string) =>
+      Array.from(container.querySelectorAll('button')).find((button) => button.textContent?.trim() === text) as
+        | HTMLButtonElement
+        | undefined
+
+    buttonByText('Account Provider')?.click()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    buttonByText(engineName)?.click()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    const nextButton = container.querySelector('[data-testid="provider-modal-next"]') as HTMLButtonElement | null
+    expect(nextButton?.disabled).toBe(false)
+    nextButton?.click()
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    const saveButton = container.querySelector('[data-testid="provider-modal-save"]') as HTMLButtonElement | null
+    saveButton?.click()
+
+    expect(onSaveMock).toHaveBeenCalledTimes(1)
+    const savedData: ProviderFormData = onSaveMock.mock.calls[0]![0]!
+    expect(savedData.backend).toBe(expectedBackend)
+    expect(savedData.authAdapter).toBeUndefined()
+    expect(savedData.transportAdapter).toBeUndefined()
+  })
 })

--- a/web/src/components/shared/ProviderModal.tsx
+++ b/web/src/components/shared/ProviderModal.tsx
@@ -907,7 +907,10 @@ export function ProviderModal({
                   onClick={() => {
                     setFormBackend('unknown')
                     setFormIsLocal(false)
+                    setFormAuthAdapter(undefined)
+                    setFormTransportAdapter(undefined)
                     setFetchError(null)
+                    resetStep2()
                   }}
                   className={`p-2 rounded border text-center text-sm transition-colors ${
                     formBackend === 'unknown'
@@ -939,7 +942,10 @@ export function ProviderModal({
                         setFormUrl((prev) => prev || `http://localhost:${port}`)
                         setFormBackend(backendMap[port] ?? '')
                         setFormIsLocal(true)
+                        setFormAuthAdapter(undefined)
+                        setFormTransportAdapter(undefined)
                         setFetchError(null)
+                        resetStep2()
                       }}
                       className={`p-2 rounded border text-center text-sm transition-colors ${
                         formBackend === backendMap[port]


### PR DESCRIPTION
## Summary

- clear preset auth and transport adapters when selecting a local inference engine
- clear preset adapters when selecting Other
- reset step 2 state when changing engine
- add provider-agnostic regression coverage for Ollama and Other

## Validation

- `npx vitest run web/src/components/shared/ProviderModal.test.tsx --reporter=verbose`: 9 passed
- `npm run typecheck`: passed
- unit suite: 2071 passed, 3 skipped
- full E2E suite currently has 12 unrelated local failures in builder, path-security, provider-plugin, and write-tool tests

Fixes #65