### PR TITLE
fix: folder selection broken on Windows (backslash paths)

### DIFF
--- a/web/src/components/CreateSessionModal.tsx
+++ b/web/src/components/CreateSessionModal.tsx
@@ -4,7 +4,7 @@ import { useProjectStore } from '../stores/project'
 import { Modal } from './shared/Modal'
 import { Button } from './shared/Button'
 import { FolderIcon, TrashIcon } from './shared/icons'
-import { truncateMiddle } from '../lib/path'
+import { truncateMiddle, pathBasename } from '../lib/path'
 import { DeleteProjectConfirmationModal } from './DeleteProjectConfirmationModal.js'
 import { CreateProjectModal } from './CreateProjectModal.js'
 import { DirectoryBrowser } from './shared/DirectoryBrowser.js'
@@ -69,7 +69,7 @@ export function OpenProjectModal({ isOpen, onClose }: OpenProjectModalProps) {
   }
 
   async function handleProjectCreation(path: string): Promise<boolean> {
-    const basename = path.split('/').filter(Boolean).pop() ?? ''
+    const basename = pathBasename(path)
     const result = await createProject(basename, path)
     listProjects()
     if (isPermissionDenied(result)) {

--- a/web/src/components/layout/ProjectDropdown.tsx
+++ b/web/src/components/layout/ProjectDropdown.tsx
@@ -6,6 +6,7 @@ import { ChevronDownIcon, CheckIcon, StarIcon, StarFilledIcon, PlusMdIcon, Folde
 import { CreateProjectModal } from '../CreateProjectModal.js'
 import { DirectoryBrowser } from '../shared/DirectoryBrowser.js'
 import { useWorkdir } from '../../hooks/useWorkdir.js'
+import { pathBasename } from '../../lib/path'
 
 interface ProjectDropdownProps {
   projects: Array<{ id: string; name: string; workdir: string; isStarred?: boolean }>
@@ -24,7 +25,7 @@ export function ProjectDropdown({ projects, currentProject }: ProjectDropdownPro
 
   const handleDirectorySelect = useCallback(
     async (path: string): Promise<boolean> => {
-      const basename = path.split('/').filter(Boolean).pop() ?? ''
+      const basename = pathBasename(path)
       const project = await createProject(basename, path)
       if (project && 'id' in project) {
         await listProjects()

--- a/web/src/components/shared/DirectoryBrowser.tsx
+++ b/web/src/components/shared/DirectoryBrowser.tsx
@@ -3,6 +3,7 @@ import { Modal } from './Modal'
 import { ArrowLeftIcon, ChevronDownIcon, FolderIcon, SearchIcon } from './icons'
 import { Spinner } from './Spinner'
 import { authFetch } from '../../lib/api'
+import { pathBreadcrumbs } from '../../lib/path'
 import { Input } from './Input'
 
 interface DirectoryEntry {
@@ -51,13 +52,7 @@ export function DirectoryBrowser({ onSelect, onClose, initialPath }: DirectoryBr
     fetchDir(initialPath)
   }, [initialPath, fetchDir])
 
-  const crumbs = (listing?.current ?? '')
-    .split('/')
-    .filter(Boolean)
-    .map((part, i, arr) => ({
-      name: part,
-      path: '/' + arr.slice(0, i + 1).join('/'),
-    }))
+  const crumbs = pathBreadcrumbs(listing?.current ?? '')
 
   const filteredDirs =
     listing?.directories.filter(

--- a/web/src/lib/path.test.ts
+++ b/web/src/lib/path.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { pathBasename, pathBreadcrumbs } from './path'
+
+describe('pathBasename', () => {
+  it('returns the last segment of a Unix path', () => {
+    expect(pathBasename('/home/user/projects/my-app')).toBe('my-app')
+  })
+
+  it('returns the last segment of a Windows path', () => {
+    expect(pathBasename('C:\\Users\\me\\projects\\my-app')).toBe('my-app')
+  })
+
+  it('handles Windows paths with forward slashes', () => {
+    expect(pathBasename('C:/Users/me/my-app')).toBe('my-app')
+  })
+
+  it('ignores trailing separators', () => {
+    expect(pathBasename('/home/user/my-app/')).toBe('my-app')
+    expect(pathBasename('C:\\Users\\me\\my-app\\')).toBe('my-app')
+  })
+
+  it('returns empty string for empty input', () => {
+    expect(pathBasename('')).toBe('')
+    expect(pathBasename('/')).toBe('')
+  })
+})
+
+describe('pathBreadcrumbs', () => {
+  it('builds crumbs for a Unix path', () => {
+    expect(pathBreadcrumbs('/home/user/projects')).toEqual([
+      { name: 'home', path: '/home' },
+      { name: 'user', path: '/home/user' },
+      { name: 'projects', path: '/home/user/projects' },
+    ])
+  })
+
+  it('builds crumbs for a Windows path, keeping the drive root navigable', () => {
+    expect(pathBreadcrumbs('D:\\github\\Openfox')).toEqual([
+      // 'D:' alone would be drive-relative on Windows; the crumb must be 'D:\'
+      { name: 'D:', path: 'D:\\' },
+      { name: 'github', path: 'D:\\github' },
+      { name: 'Openfox', path: 'D:\\github\\Openfox' },
+    ])
+  })
+
+  it('returns no crumbs for an empty path', () => {
+    expect(pathBreadcrumbs('')).toEqual([])
+  })
+})

--- a/web/src/lib/path.ts
+++ b/web/src/lib/path.ts
@@ -1,3 +1,31 @@
+/** Last segment of a path, handling both / and \ separators. */
+export function pathBasename(path: string): string {
+  return path.split(/[\\/]/).filter(Boolean).pop() ?? ''
+}
+
+export interface Breadcrumb {
+  name: string
+  path: string
+}
+
+/**
+ * Breadcrumb trail for a native path (Unix or Windows).
+ * On Windows the drive crumb is 'X:\' — 'X:' alone would be drive-relative.
+ */
+export function pathBreadcrumbs(path: string): Breadcrumb[] {
+  const sep = path.includes('\\') ? '\\' : '/'
+  return path
+    .split(/[\\/]/)
+    .filter(Boolean)
+    .map((part, i, arr) => ({
+      name: part,
+      path:
+        sep === '/'
+          ? '/' + arr.slice(0, i + 1).join('/')
+          : arr.slice(0, i + 1).join('\\') + (i === 0 ? '\\' : ''),
+    }))
+}
+
 export function truncateMiddle(path: string, maxLen = 28): string {
   if (path.length <= maxLen) return path
   const parts = path.split('/').filter(Boolean)


### PR DESCRIPTION
### Symptoms
- The **Select** button did nothing (no response) when navigating **Open Project > Select Folder**
- `DirectoryBrowser` breadcrumbs rendered as a single unusable crumb.

### Root cause
The `directories` API returns native backslash paths on Windows (`C:\...\project`).
Project-name extraction in `ProjectDropdown` and `CreateSessionModal` split only on `'/'`,
so the full path (with `:` and `\`) became the project name — rejected by `validateProjectName`.
The breadcrumbs made the same separator assumption.

### Fix
- Split on both separators (`/` and `\`).
- Build breadcrumb paths using the detected separator.

### Tests
-  Path helpers extracted to web/src/lib/path.ts and unit-tested (Unix + Windows separators).

