### PR TITLE
fix: false 'outside workdir' prompts on Windows command switches

### DIFF
--- a/src/server/tools/path-security.test.ts
+++ b/src/server/tools/path-security.test.ts
@@ -36,8 +36,16 @@ let CANONICAL_PASSWD: string
 let CANONICAL_VAR_LOG_SYSLOG: string
 let CANONICAL_ETC_ENV: string
 
+const REAL_PLATFORM = process.platform
+
+/** Pin process.platform so platform-dependent extraction logic is deterministic. */
+function mockPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true })
+}
+
 describe('path-security', () => {
   beforeEach(async () => {
+    mockPlatform('linux')
     CANONICAL_TMP = await realpath(tmpdir())
     CANONICAL_PASSWD = await realpath('/etc/passwd')
     CANONICAL_VAR_LOG_SYSLOG = join(await realpath('/var'), 'log', 'syslog')
@@ -52,6 +60,7 @@ describe('path-security', () => {
   })
 
   afterEach(async () => {
+    mockPlatform(REAL_PLATFORM)
     // Cleanup
     await rm(TEST_DIR, { recursive: true, force: true })
   })
@@ -1498,5 +1507,57 @@ describe('path-security', () => {
       expect(onEvent).not.toHaveBeenCalled()
       expect(hasPendingPathConfirmation('call-sub-cmd-normal')).toBe(false)
     })
+  })
+})
+
+// Standalone: no fs fixtures needed, so it runs on any host (the main suite's
+// fixtures assume Unix paths like /etc/passwd).
+describe('extractAbsolutePathsFromCommand on Windows (cmd.exe shell)', () => {
+  beforeEach(() => {
+    mockPlatform('win32')
+  })
+
+  afterEach(() => {
+    mockPlatform(REAL_PLATFORM)
+  })
+
+  it('treats /tokens as cmd switches, not paths', () => {
+    expect(extractAbsolutePathsFromCommand('dir /s /b')).toEqual([])
+    expect(extractAbsolutePathsFromCommand('findstr /i /n "error" log.txt')).toEqual([])
+  })
+
+  it('extracts drive-letter absolute paths (the pre-fix security gap)', () => {
+    const paths = extractAbsolutePathsFromCommand('type C:\\secrets\\creds.txt')
+    expect(paths).toEqual(['C:\\secrets\\creds.txt'])
+  })
+
+  it('extracts drive-letter paths written with forward slashes', () => {
+    const paths = extractAbsolutePathsFromCommand('type C:/secrets/creds.txt')
+    expect(paths).toHaveLength(1)
+    // normalize() separator conversion depends on the host platform
+    expect(paths[0]).toMatch(/^C:[\\/]secrets[\\/]creds\.txt$/)
+  })
+
+  it('extracts quoted drive-letter paths with spaces', () => {
+    const paths = extractAbsolutePathsFromCommand('type "C:\\path with spaces\\file.txt"')
+    expect(paths).toEqual(['C:\\path with spaces\\file.txt'])
+  })
+
+  it('extracts the path but not the switches in a mixed command', () => {
+    expect(extractAbsolutePathsFromCommand('dir /s C:\\projects')).toEqual(['C:\\projects'])
+  })
+
+  it('deduplicates and handles multiple drive paths', () => {
+    const paths = extractAbsolutePathsFromCommand('copy D:\\a.txt E:\\b.txt & type D:\\a.txt')
+    expect(paths).toEqual(['D:\\a.txt', 'E:\\b.txt'])
+  })
+
+  it('does not extract unix-style quoted strings', () => {
+    expect(extractAbsolutePathsFromCommand('echo "/etc/passwd"')).toEqual([])
+  })
+
+  it('still expands tilde paths', () => {
+    const paths = extractAbsolutePathsFromCommand('cat ~/file.txt')
+    expect(paths).toContain(join(homedir(), 'file.txt'))
   })
 })

--- a/src/server/tools/path-security.ts
+++ b/src/server/tools/path-security.ts
@@ -221,6 +221,16 @@ function looksLikeRegex(str: string): boolean {
   return /[*?+[\]\\]/.test(str)
 }
 
+/** Evaluated at call time so tests can stub process.platform. */
+const isWindows = () => process.platform === 'win32'
+
+/**
+ * Check if a string is a Windows drive-letter absolute path (C:\... or C:/...).
+ */
+function isWindowsAbsolutePath(str: string): boolean {
+  return /^[A-Za-z]:[\\/]/.test(str)
+}
+
 /**
  * Check if a string is a placeholder marker left by sanitization.
  * These are not real paths and should be skipped.
@@ -306,7 +316,12 @@ export function extractAbsolutePathsFromCommand(command: string): string[] {
     }
 
     // Check for absolute path
-    if (content.startsWith('/')) {
+    if (isWindowsAbsolutePath(content)) {
+      const resolved = normalize(content)
+      if (!isSafePath(resolved)) {
+        paths.push(resolved)
+      }
+    } else if (!isWindows() && content.startsWith('/')) {
       const resolved = normalize(content)
       if (!isSafePath(resolved)) {
         paths.push(resolved)
@@ -326,21 +341,37 @@ export function extractAbsolutePathsFromCommand(command: string): string[] {
   // Pattern 3: Unquoted absolute paths
   // Strategy: boundary + broad character class + predicate pipeline.
   // Each predicate is a small, named function with a single responsibility.
-  const absolutePattern = /(?:^|[\s=(])(\/[^\s"'|&;<>`()]+)/g
-  while ((match = absolutePattern.exec(sanitized)) !== null) {
-    const candidate = match[1]!
+  if (isWindows()) {
+    // On Windows (cmd.exe), "/token" is a command switch (dir /s, findstr /i),
+    // not a path. Only drive-letter paths (C:\... or C:/...) are absolute paths.
+    // looksLikeRegex is skipped: backslashes are separators here, and the
+    // drive-letter prefix is diagnostic enough.
+    const winAbsolutePattern = /(?:^|[\s=(])([A-Za-z]:[\\/][^\s"'|&;<>`()]+)/g
+    while ((match = winAbsolutePattern.exec(sanitized)) !== null) {
+      const candidate = match[1]!
+      if (isPlaceholderToken(candidate)) continue
+      const resolved = normalize(candidate)
+      if (!isSafePath(resolved)) {
+        paths.push(resolved)
+      }
+    }
+  } else {
+    const absolutePattern = /(?:^|[\s=(])(\/[^\s"'|&;<>`()]+)/g
+    while ((match = absolutePattern.exec(sanitized)) !== null) {
+      const candidate = match[1]!
 
-    // Skip placeholder markers left by sanitization
-    if (isPlaceholderToken(candidate)) continue
+      // Skip placeholder markers left by sanitization
+      if (isPlaceholderToken(candidate)) continue
 
-    // Skip if it looks like a regex pattern with metacharacters
-    if (looksLikeRegex(candidate)) continue
+      // Skip if it looks like a regex pattern with metacharacters
+      if (looksLikeRegex(candidate)) continue
 
-    const resolved = normalize(candidate)
-    // Skip root or empty (e.g. "//" comment lines normalize to "/")
-    if (resolved === '/' || resolved === '') continue
-    if (!isSafePath(resolved)) {
-      paths.push(resolved)
+      const resolved = normalize(candidate)
+      // Skip root or empty (e.g. "//" comment lines normalize to "/")
+      if (resolved === '/' || resolved === '') continue
+      if (!isSafePath(resolved)) {
+        paths.push(resolved)
+      }
     }
   }
 


### PR DESCRIPTION
### Symptoms
- Commands like `dir /s` or `findstr /i` triggered a spurious "paths outside workdir" confirmation on Windows.
- POSIX-style paths emitted by models (`/d/github/...`) were mangled the same way.

### Root cause
`extractAbsolutePathsFromCommand` treated every `/token` in a command as a Unix absolute path.
On Windows, where the shell is `cmd.exe`, command switches were extracted as paths and resolved
against the current drive (`/s` → `D:\s`). Meanwhile, genuine drive-letter paths (`C:\...`)
were never extracted at all.

### Fix
- On `win32`, extract only drive-letter paths (`C:\...` or `C:/...`).
- Unix behavior unchanged.
- As a side effect, genuine out-of-sandbox access via absolute Windows paths now prompts as intended.

### Tests
Adds platform-pinned unit tests: cmd switches ignored, drive-letter paths now extracted (closes a confirmation bypass), quoted/tilde/dedup cases.