### PR TITLE
feat: support GitHub Copilot as an LLM provider via external plugin system

### DIFF
--- a/src/server/provider-manager.test.ts
+++ b/src/server/provider-manager.test.ts
@@ -347,7 +347,7 @@ describe('ProviderManager - Model Selection', () => {
         complete: vi.fn(),
         stream: vi.fn(),
       }
-      const adapters = { getTransport: vi.fn((id?: string) => (id === 'example-transport' ? transport : undefined)) }
+      const adapters = { getTransport: vi.fn((id?: string) => (id === 'example-transport' ? transport : undefined)), getAuth: vi.fn(() => undefined) }
       const chatConfig: Config = {
         ...config,
         providers: [
@@ -659,7 +659,7 @@ describe('ProviderManager - Model Selection', () => {
         complete: vi.fn(),
         stream: vi.fn(),
       }
-      const adapters = { getTransport: vi.fn((id?: string) => (id === 'example-transport' ? transport : undefined)) }
+      const adapters = { getTransport: vi.fn((id?: string) => (id === 'example-transport' ? transport : undefined)), getAuth: vi.fn(() => undefined) }
       const chatConfig: Config = {
         ...config,
         providers: [

--- a/src/server/provider-manager.ts
+++ b/src/server/provider-manager.ts
@@ -426,17 +426,36 @@ export function createProviderManager(config: Config, options: ProviderManagerOp
   function createClientForProvider(provider: Provider, model?: string): LLMClientWithModel {
     const resolvedModel = resolveProviderModel(provider, model)
     const transport = options.adapters?.getTransport(resolveTransportAdapter(provider))
-    return transport
-      ? createTransportLLMClient(provider, resolvedModel, transport)
-      : createLLMClient(createConfigForProvider(provider, resolvedModel))
+    if (transport) {
+      const authAdapter = provider.credentialRef && provider.authAdapter
+        ? options.adapters?.getAuth(provider.authAdapter)
+        : undefined
+      const resolveAuth = authAdapter && provider.credentialRef
+        ? () => authAdapter.getAccessContext(provider.credentialRef!)
+        : undefined
+      return createTransportLLMClient(provider, resolvedModel, transport, resolveAuth)
+    }
+    return createLLMClient(createConfigForProvider(provider, resolvedModel))
   }
 
   async function fetchProviderModels(provider: Provider): Promise<ModelConfig[]> {
     const transport = options.adapters?.getTransport(resolveTransportAdapter(provider))
     if (transport) {
+      let authContext: { accessToken?: string; headers?: Record<string, string> } | undefined
+      if (provider.credentialRef && provider.authAdapter) {
+        const authAdapter = options.adapters?.getAuth(provider.authAdapter)
+        if (authAdapter) {
+          try {
+            authContext = await authAdapter.getAccessContext(provider.credentialRef)
+          } catch (error) {
+            logger.debug('Auth resolution failed for provider models', { providerId: provider.id, error: String(error) })
+          }
+        }
+      }
       return transport.listModels({
         providerId: provider.id,
         ...(provider.credentialRef && { credentialRef: provider.credentialRef }),
+        ...(authContext ? { auth: authContext } : {}),
       })
     }
 
@@ -665,6 +684,12 @@ export function createProviderManager(config: Config, options: ProviderManagerOp
       const provider = providers.find((p) => p.id === providerId)
       if (!provider) {
         return []
+      }
+
+      // For transport-based providers (e.g. Copilot, Anthropic), always fetch fresh models
+      const transport = options.adapters?.getTransport(resolveTransportAdapter(provider))
+      if (transport) {
+        return fetchProviderModels(provider)
       }
 
       // Return stored models with context info

--- a/src/server/providers/adapters/transport-client.ts
+++ b/src/server/providers/adapters/transport-client.ts
@@ -2,12 +2,14 @@ import type { Provider } from '../../../shared/types.js'
 import { getBackendCapabilities, type Backend } from '../../llm/backend.js'
 import { getModelProfile } from '../../llm/profiles.js'
 import type { LLMClientWithModel } from '../../llm/client.js'
-import type { ProviderTransportAdapter } from '../../../provider/index.js'
+import type { ProviderTransportAdapter, ProviderRequestContext, ProviderAccessContext } from '../../../provider/index.js'
+import { logger } from '../../utils/logger.js'
 
 export function createTransportLLMClient(
   provider: Provider,
   modelId: string,
   transport: ProviderTransportAdapter,
+  resolveAuth?: () => Promise<ProviderAccessContext>,
 ): LLMClientWithModel {
   let model = modelId
   let backend = provider.backend as Backend
@@ -26,15 +28,23 @@ export function createTransportLLMClient(
   let profile = profileFor(model)
   void getBackendCapabilities(backend)
 
-  const context = () => {
+  const context = async (): Promise<ProviderRequestContext> => {
     const configured = provider.models.find((item) => item.id === model)
-    return {
+    const ctx: ProviderRequestContext = {
       providerId: provider.id,
       model: configured?.apiModelId ?? model,
       catalogModel: model,
       ...(configured?.requestBody && { requestBody: configured.requestBody }),
       ...(provider.credentialRef && { credentialRef: provider.credentialRef }),
     }
+    if (resolveAuth) {
+      try {
+        ctx.auth = await resolveAuth()
+      } catch (error) {
+        logger.debug('Auth resolution failed for transport client', { providerId: provider.id, error: String(error) })
+      }
+    }
+    return ctx
   }
 
   return {
@@ -48,7 +58,7 @@ export function createTransportLLMClient(
     setBackend(next) {
       backend = next
     },
-    complete: (request) => transport.complete(request, context()),
-    stream: (request) => transport.stream(request, context()),
+    complete: async (request) => transport.complete(request, await context()),
+    stream: async function* (request) { yield* transport.stream(request, await context()) },
   }
 }

--- a/web/src/components/shared/ProviderModal.tsx
+++ b/web/src/components/shared/ProviderModal.tsx
@@ -907,6 +907,8 @@ export function ProviderModal({
                   onClick={() => {
                     setFormBackend('unknown')
                     setFormIsLocal(false)
+                    setFormAuthAdapter(undefined)
+                    setFormTransportAdapter(undefined)
                     setFetchError(null)
                   }}
                   className={`p-2 rounded border text-center text-sm transition-colors ${
@@ -939,6 +941,8 @@ export function ProviderModal({
                         setFormUrl((prev) => prev || `http://localhost:${port}`)
                         setFormBackend(backendMap[port] ?? '')
                         setFormIsLocal(true)
+                        setFormAuthAdapter(undefined)
+                        setFormTransportAdapter(undefined)
                         setFetchError(null)
                       }}
                       className={`p-2 rounded border text-center text-sm transition-colors ${


### PR DESCRIPTION
## Résumé

Cette PR ajoute les bases nécessaires dans OpenFox pour supporter GitHub Copilot comme fournisseur de modèles LLM, via un mécanisme de plugin externe autonome.

## Modifications dans OpenFox

### Infrastructure générique (4 fichiers)

Ces changements ne sont pas spécifiques à Copilot — ils améliorent l'infrastructure des providers pour tous les plugins :

- **transport-client.ts** — `context()` devient `async` avec support optionnel d'un callback `resolveAuth` pour résoudre le token d'accès depuis le `credentialRef`
- **provider-manager.ts** — Résolution de l'auth avant `fetchProviderModels()` pour les providers transport-based ; modèles toujours récupérés à chaud ; logs en cas d'échec d'auth
- **provider-manager.test.ts** — Ajout du mock `getAuth` pour couvrir le nouveau code path
- **ProviderModal.tsx** — Correction des boutons "Other" et ports locaux pour réinitialiser les adapters (permet de repasser en mode générique après avoir cliqué sur un preset)

### Plugin externe `openfox-copilot`

Le provider Copilot est publié comme un package npm externe installable dynamiquement :
https://github.com/RenZan/openfox-copilot

- **Auth** — OAuth device flow GitHub + échange JWT Copilot via `api.github.com/copilot_internal/v2/token`
- **Transport** — OpenAI-compatible vers `api.githubcopilot.com/chat/completions` avec headers Copilot
- **~75 modèles** — GitHub Models Catalog + liste de modèles Copilot connus (Claude, Gemini, GPT-5.6, etc.)

### Installation

```bash
curl -fsSL https://raw.githubusercontent.com/RenZan/openfox-copilot/main/install.sh | bash
```

## Notes

- nécessite un abonnement GitHub Copilot actif
- Auth via device flow OAuth
- Aucune dépendance runtime externe
