### PR TITLE
feat(settings): Shell picker (cmd / PowerShell / Git Bash) on Windows

### DIFF
--- a/src/server/chat/prompts.ts
+++ b/src/server/chat/prompts.ts
@@ -1,6 +1,8 @@
+import { basename } from 'node:path'
 import type { SkillMetadata } from '../skills/types.js'
 import type { AgentDefinition } from '../agents/types.js'
 import { computeEffectiveTools } from '../tools/tool-policy.js'
+import { getPlatformShell } from '../utils/platform.js'
 
 // ============================================================================
 // Base Prompt (shared by all agents)
@@ -27,7 +29,8 @@ Today's date is ${new Date().toISOString().split('T')[0]!.replace(/-/g, '/')}
 
 ## ENVIRONMENT
 Working directory: ${workdir}
-Platform: ${process.platform} (${process.arch})${modelLine}
+Platform: ${process.platform} (${process.arch})
+Shell (run_command): ${basename(getPlatformShell().command)}${modelLine}
 
 ## CORE BEHAVIOR
 Help user complete tasks safely and efficiently.

--- a/src/server/db/settings.ts
+++ b/src/server/db/settings.ts
@@ -27,6 +27,7 @@ export const SETTINGS_KEYS = {
   SEARCH_SEARXNG_URL: 'search.searxngUrl',
   SEARCH_SEARXNG_API_KEY: 'search.searxngApiKey',
   TOOLS_USE_RTK: 'tools.useRtk',
+  TOOLS_SHELL: 'tools.shell',
 } as const
 
 export const SETTINGS_DEFAULTS: Record<string, string> = {
@@ -54,6 +55,7 @@ export const SETTINGS_DEFAULTS: Record<string, string> = {
     ],
   }),
   [SETTINGS_KEYS.TOOLS_USE_RTK]: 'false',
+  [SETTINGS_KEYS.TOOLS_SHELL]: 'cmd',
 }
 
 export type SettingsKey = (typeof SETTINGS_KEYS)[keyof typeof SETTINGS_KEYS]

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1102,6 +1102,12 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
     }
   })
 
+  // Shells available for the tools.shell setting (Windows only; empty elsewhere)
+  app.get('/api/tools/shells', async (_req, res) => {
+    const { listAvailableShells } = await import('./utils/platform.js')
+    res.json({ shells: listAvailableShells() })
+  })
+
   // Config endpoint
   app.get('/api/config', async (_req, res) => {
     const llmClient = getLLMClient()

--- a/src/server/utils/platform.test.ts
+++ b/src/server/utils/platform.test.ts
@@ -1,5 +1,22 @@
-import { describe, expect, it } from 'vitest'
-import { getPathSeparator, isWindowsPath, isAbsolutePath } from './platform.js'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { getPathSeparator, isWindowsPath, isAbsolutePath, getPlatformShell, listAvailableShells } from './platform.js'
+
+vi.mock('../db/settings.js', () => ({
+  getSetting: vi.fn(() => null),
+  SETTINGS_KEYS: { TOOLS_SHELL: 'tools.shell' },
+}))
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>()
+  return { ...actual, existsSync: vi.fn(() => false) }
+})
+
+import { getSetting } from '../db/settings.js'
+import { existsSync } from 'node:fs'
+
+function mockPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true })
+}
 
 describe('getPathSeparator', () => {
   it('returns ; on windows', () => {
@@ -23,6 +40,85 @@ describe('isWindowsPath', () => {
   it('returns false for relative paths', () => {
     expect(isWindowsPath('relative/path')).toBe(false)
     expect(isWindowsPath('file.txt')).toBe(false)
+  })
+})
+
+describe('getPlatformShell (win32 shell setting)', () => {
+  const realPlatform = process.platform
+
+  beforeEach(() => {
+    mockPlatform('win32')
+    vi.mocked(getSetting).mockReturnValue(null)
+    vi.mocked(existsSync).mockReturnValue(false)
+  })
+
+  afterEach(() => {
+    mockPlatform(realPlatform)
+    vi.clearAllMocks()
+  })
+
+  it('defaults to cmd.exe when no setting', () => {
+    expect(getPlatformShell()).toEqual({ command: 'cmd.exe', args: ['/c'] })
+  })
+
+  it('uses cmd.exe when setting is cmd', () => {
+    vi.mocked(getSetting).mockReturnValue('cmd')
+    expect(getPlatformShell()).toEqual({ command: 'cmd.exe', args: ['/c'] })
+  })
+
+  it('uses powershell when setting is powershell', () => {
+    vi.mocked(getSetting).mockReturnValue('powershell')
+    expect(getPlatformShell()).toEqual({ command: 'powershell.exe', args: ['-NoProfile', '-Command'] })
+  })
+
+  it('uses Git Bash when setting is gitbash and bash.exe is found', () => {
+    vi.mocked(getSetting).mockReturnValue('gitbash')
+    vi.mocked(existsSync).mockImplementation((p) => String(p).endsWith('bash.exe'))
+    const shell = getPlatformShell()
+    expect(shell.command.endsWith('bash.exe')).toBe(true)
+    expect(shell.args).toEqual(['-c'])
+  })
+
+  it('falls back to cmd.exe when setting is gitbash but bash.exe is missing', () => {
+    vi.mocked(getSetting).mockReturnValue('gitbash')
+    expect(getPlatformShell()).toEqual({ command: 'cmd.exe', args: ['/c'] })
+  })
+
+  it('ignores the setting on non-Windows platforms', () => {
+    mockPlatform('linux')
+    vi.mocked(getSetting).mockReturnValue('powershell')
+    const shell = getPlatformShell()
+    expect(shell.command).not.toBe('powershell.exe')
+    expect(shell.args[shell.args.length - 1]).toBe('-c')
+  })
+})
+
+describe('listAvailableShells', () => {
+  const realPlatform = process.platform
+
+  afterEach(() => {
+    mockPlatform(realPlatform)
+    vi.clearAllMocks()
+  })
+
+  it('returns empty list on non-Windows', () => {
+    mockPlatform('linux')
+    expect(listAvailableShells()).toEqual([])
+  })
+
+  it('lists cmd and powershell as always available on Windows', () => {
+    mockPlatform('win32')
+    vi.mocked(existsSync).mockReturnValue(false)
+    const shells = listAvailableShells()
+    expect(shells.find((s) => s.id === 'cmd')?.available).toBe(true)
+    expect(shells.find((s) => s.id === 'powershell')?.available).toBe(true)
+    expect(shells.find((s) => s.id === 'gitbash')?.available).toBe(false)
+  })
+
+  it('marks gitbash available when bash.exe is found', () => {
+    mockPlatform('win32')
+    vi.mocked(existsSync).mockImplementation((p) => String(p).endsWith('bash.exe'))
+    expect(listAvailableShells().find((s) => s.id === 'gitbash')?.available).toBe(true)
   })
 })
 

--- a/src/server/utils/platform.ts
+++ b/src/server/utils/platform.ts
@@ -1,8 +1,63 @@
 import os from 'node:os'
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { getSetting, SETTINGS_KEYS } from '../db/settings.js'
 
-export function getPlatformShell(): { command: string; args: string[] } {
+export interface ShellConfig {
+  command: string
+  args: string[]
+}
+
+export interface ShellOption {
+  id: string
+  label: string
+  available: boolean
+}
+
+/**
+ * Locate Git Bash on Windows (bundled with Git for Windows).
+ * Checks the standard install locations for bash.exe.
+ */
+export function findGitBash(): string | null {
+  const candidates = [
+    process.env['ProgramFiles'] && join(process.env['ProgramFiles'], 'Git', 'bin', 'bash.exe'),
+    process.env['ProgramFiles(x86)'] && join(process.env['ProgramFiles(x86)'], 'Git', 'bin', 'bash.exe'),
+    process.env['LocalAppData'] && join(process.env['LocalAppData'], 'Programs', 'Git', 'bin', 'bash.exe'),
+  ].filter((p): p is string => !!p)
+  return candidates.find((p) => existsSync(p)) ?? null
+}
+
+const CMD_SHELL: ShellConfig = { command: 'cmd.exe', args: ['/c'] }
+
+const WINDOWS_SHELLS: Record<string, () => ShellConfig | null> = {
+  cmd: () => CMD_SHELL,
+  powershell: () => ({ command: 'powershell.exe', args: ['-NoProfile', '-Command'] }),
+  gitbash: () => {
+    const bash = findGitBash()
+    return bash ? { command: bash, args: ['-c'] } : null
+  },
+}
+
+/**
+ * Shells the user can pick from in Settings > Tools (Windows only).
+ * Empty on other platforms, where the user's login shell is used.
+ */
+export function listAvailableShells(): ShellOption[] {
+  if (process.platform !== 'win32') {
+    return []
+  }
+  return [
+    { id: 'cmd', label: 'cmd.exe', available: true },
+    { id: 'powershell', label: 'PowerShell', available: true },
+    { id: 'gitbash', label: 'Git Bash', available: findGitBash() !== null },
+  ]
+}
+
+export function getPlatformShell(): ShellConfig {
   if (process.platform === 'win32') {
-    return { command: 'cmd.exe', args: ['/c'] }
+    const choice = getSetting(SETTINGS_KEYS.TOOLS_SHELL) ?? 'cmd'
+    // Unknown value or Git Bash not installed anymore: fall back to cmd.exe
+    return WINDOWS_SHELLS[choice]?.() ?? CMD_SHELL
   }
 
   const userShell = os.userInfo().shell

--- a/web/src/components/settings/tabs/ToolsTab.tsx
+++ b/web/src/components/settings/tabs/ToolsTab.tsx
@@ -162,6 +162,19 @@ export function ToolsTab() {
       .catch(() => setRtkStatus('unavailable'))
   }, [])
 
+  // ── Shell selection (Windows only; empty list elsewhere) ──
+  const [shells, setShells] = useState<{ id: string; label: string; available: boolean }[]>([])
+
+  useEffect(() => {
+    getSetting(SETTINGS_KEYS.TOOLS_SHELL)
+    authFetch('/api/tools/shells')
+      .then((r) => r.json())
+      .then((data) => setShells(data.shells ?? []))
+      .catch(() => setShells([]))
+  }, [getSetting])
+
+  const currentShell = settings[SETTINGS_KEYS.TOOLS_SHELL] || 'cmd'
+
   // ── MCP state ──
   const [servers, setServers] = useState<McpServerState[]>([])
   const [loading, setLoading] = useState(true)
@@ -427,6 +440,44 @@ export function ToolsTab() {
           )}
         </div>
       </div>
+
+      {shells.length > 0 && (
+        <>
+          <hr className="border-border" />
+
+          {/* ── Shell Section (Windows) ── */}
+          <div>
+            <h3 className="text-sm font-medium text-text-primary mb-3">Shell</h3>
+            <p className="text-sm text-text-muted mb-3">
+              Shell used to run agent commands and integrated terminals. Git Bash gives the agent a Unix-like toolset
+              (grep, sed, ls…) and usually works better than cmd.exe.
+            </p>
+            <div className="flex gap-2">
+              {shells.map((shell) => (
+                <button
+                  key={shell.id}
+                  onClick={() => setSetting(SETTINGS_KEYS.TOOLS_SHELL, shell.id)}
+                  disabled={!shell.available}
+                  title={shell.available ? undefined : 'Not found on this machine'}
+                  className={`px-3 py-1.5 rounded text-sm border transition-colors ${
+                    currentShell === shell.id
+                      ? 'bg-accent-primary/10 border-accent-primary text-accent-primary'
+                      : shell.available
+                        ? 'border-border text-text-muted hover:text-text-primary'
+                        : 'border-border text-text-muted opacity-50 cursor-not-allowed'
+                  }`}
+                >
+                  {shell.label}
+                  {!shell.available && ' (not found)'}
+                </button>
+              ))}
+            </div>
+            <p className="text-xs text-text-muted mt-2">
+              Applies to new commands and newly opened terminals. Running terminals keep their current shell.
+            </p>
+          </div>
+        </>
+      )}
 
       <hr className="border-border" />
 

--- a/web/src/stores/settings.ts
+++ b/web/src/stores/settings.ts
@@ -26,6 +26,7 @@ export const SETTINGS_KEYS = {
   SEARCH_SEARXNG_URL: 'search.searxngUrl',
   SEARCH_SEARXNG_API_KEY: 'search.searxngApiKey',
   TOOLS_USE_RTK: 'tools.useRtk',
+  TOOLS_SHELL: 'tools.shell',
 } as const
 
 interface SettingsState {


### PR DESCRIPTION
### Problem
- The agent shell is hardcoded to `cmd.exe` on Windows via `getPlatformShell()`
  (`src/server/utils/platform.ts`).
- `cmd.exe` has a limited toolset — no `grep`, `sed`, `ls` — and hostile quoting,
  which noticeably degrades what the model can do compared to Unix hosts.
- Users with Git for Windows installed already have a far more capable shell available.

### Solution
Adds a **shell picker in Settings > Tools** (Windows only):

- New `tools.shell` setting: `cmd` (default) | `powershell` | `gitbash`.
  Default behavior is unchanged.
- `findGitBash()` detects `bash.exe` in standard Git for Windows locations
  (Program Files, Program Files (x86), LocalAppData\Programs). If Git Bash is
  selected but later uninstalled, falls back silently to `cmd.exe`.
- `GET /api/tools/shells` returns selectable shells with availability (empty list
  on non-Windows, which also hides the UI section).
- Everything that spawns a shell already routes through `getPlatformShell()`
  (run_command, background processes, integrated terminals, dev server), so the
  setting applies everywhere via a single change point.
- The system prompt now states the active shell (`Shell (run_command): bash.exe`)
  so the model emits the right syntax.
- Non-Windows platforms are untouched (setting ignored, login shell as before).

### Validation
**Test protocol (Windows 11, Node 24):**
1. `npm i` + build, start openfox.
2. Settings > Tools → new "Shell" section shows `cmd.exe` / `PowerShell` /
   `Git Bash` (Git Bash greyed out "(not found)" if Git for Windows is absent).
3. Default (`cmd.exe`): run `ver` via run_command → works as before.
4. **Git Bash**, new message: `grep -rn "getPlatformShell" src | head -5` → works;
   system prompt shows `Shell (run_command): bash.exe`.
5. **PowerShell**, new message: `Get-ChildItem | Select-Object -First 3` → works.
6. New integrated terminal after each switch → uses the selected shell. Already-open
   terminals keep their shell (documented in the UI hint).
7. Uninstall/rename `bash.exe` with `gitbash` still selected → falls back to
   `cmd.exe`, no crash.
8. Linux/macOS: no Shell section; behavior unchanged.

**Unit tests:** `npx vitest run src/server/utils/platform.test.ts` (16 tests:
selection, fallback, non-Windows no-op). Note: the full suite has pre-existing
failures on Windows hosts (tests hardcode `/tmp`, `ps`, symlinks) — identical on a
clean `main` checkout.

**Interaction with #74 (path extraction on Windows):**
No git conflict (disjoint files), but a behavioral note. #74 makes
`extractAbsolutePathsFromCommand` skip `/token` arguments on `win32` because under
`cmd.exe` they are switches (`dir /s`). Once this PR