### PR TITLE
feat: add plugin management UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "dist",
     "!dist/**/*.map",
     "dist/**/*.md",
-    "package.json"
+    "package.json",
+    "plugins-registry.json"
   ],
   "scripts": {
     "dev": "OPENFOX_DEV=true tsx watch src/cli/dev.ts --no-browser",

--- a/plugins-registry.json
+++ b/plugins-registry.json
@@ -1,0 +1,14 @@
+[
+  {
+    "name": "openfox-chatgpt",
+    "displayName": "ChatGPT",
+    "description": "Authenticate with a ChatGPT Plus or Pro account via browser-based OAuth.",
+    "githubUrl": "https://github.com/arthurlacoste/openfox-chatgpt"
+  },
+  {
+    "name": "openfox-github-copilot",
+    "displayName": "Github Copilot",
+    "description": "Authenticate with a Github copilot account via browser-based OAuth.",
+    "githubUrl": "https://github.com/JamesDAdams/openfox-github-copilot"
+  }
+]

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,9 +1,13 @@
 import express from 'express'
 import cors from 'cors'
 import { createServer as createHttpServer } from 'node:http'
-import { fileURLToPath } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 import { dirname, resolve, join } from 'node:path'
-import { readFile } from 'node:fs/promises'
+import { readFile, readdir, rm, rename } from 'node:fs/promises'
+import { platform } from 'node:os'
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+const execFileP = promisify(execFile)
 import { createServer as createViteServer, type ViteDevServer } from 'vite'
 
 import type { Config, ModelConfig, ProviderBackend } from '../shared/types.js'
@@ -42,7 +46,9 @@ import { createAutoUpdateRoutes } from './routes/auto-update.js'
 import { createProviderAuthRoutes } from './routes/provider-auth.js'
 import { devServerManager } from './dev-server/manager.js'
 import { getGlobalConfigDir } from '../cli/paths.js'
+import type { ProviderPluginRegistry } from '../provider/index.js'
 import { ProviderRegistry, loadProviderPlugins } from './providers/plugins/index.js'
+import type { ProviderPluginDiagnostic } from './providers/plugins/index.js'
 import { logger, setLogLevel } from './utils/logger.js'
 import { VERSION } from '../constants.js'
 import {
@@ -1578,6 +1584,203 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
     }
   })
 
+  // ponytail: cached per-server-instance, 5min TTL for rarely-changing registry
+  let registryCache: { data: unknown; ts: number } | null = null
+  app.get('/api/plugins/registry', async (_req, res) => {
+    try {
+      const now = Date.now()
+      if (registryCache && now - registryCache.ts < 300_000) {
+        return res.json({ plugins: registryCache.data })
+      }
+      const moduleDir = dirname(fileURLToPath(import.meta.url))
+      const registryPath = resolve(moduleDir, '../../plugins-registry.json')
+      const data = JSON.parse(await readFile(registryPath, 'utf8'))
+      registryCache = { data, ts: now }
+      res.json({ plugins: data })
+    } catch (err) {
+      logger.error('Failed to load plugin registry', { error: String(err) })
+      res.json({ plugins: [] })
+    }
+  })
+  app.post('/api/plugins/install', async (req, res) => {
+    const { githubUrl } = req.body as { githubUrl?: string }
+    if (!githubUrl || typeof githubUrl !== 'string') {
+      return res.status(400).json({ error: 'githubUrl is required' })
+    }
+
+    const parsed = githubUrl.match(/github\.com\/([^/]+)\/([^/]+?)(?:\/|$)/)
+    if (!parsed) {
+      return res.status(400).json({ error: 'Invalid GitHub URL' })
+    }
+
+    const repoName = parsed[2]!.replace(/\.git$/, '')
+    if (!/^[a-zA-Z0-9_-]+$/.test(repoName)) {
+      return res.status(400).json({ error: 'Invalid repository name' })
+    }
+
+    const pluginsDir = join(getGlobalConfigDir(config.mode ?? 'production'), 'plugins')
+    const targetDir = join(pluginsDir, repoName)
+
+    // Atomic install: clone to temp dir then mv over target.
+    // This ensures a clone failure never destroys an existing install.
+    const tmpDir = join(pluginsDir, `.${repoName}-tmp-${Date.now()}`)
+    try {
+      await execFileP('mkdir', ['-p', pluginsDir], { timeout: 5000 })
+    } catch {
+      return res.status(500).json({ error: 'Failed to create plugins directory' })
+    }
+
+    let gitOk = false
+    try {
+      const { stdout } = await execFileP('git', ['--version'], { timeout: 5000 })
+      gitOk = stdout.includes('git version')
+    } catch {
+      // fall through
+    }
+    if (!gitOk) {
+      return res.status(500).json({ error: 'git is not installed or not found in PATH' })
+    }
+
+    try {
+      const cloneUrl = githubUrl.replace(/\/$/, '') + '.git'
+      await execFileP('git', ['clone', '--depth', '1', cloneUrl, tmpDir], { timeout: 60000 })
+      await rm(targetDir, { recursive: true, force: true })
+      await rename(tmpDir, targetDir)
+      let loaded = false
+      let loadError: string | undefined
+      try {
+        await execFileP('npm', ['install', '--no-audit', '--no-fund'], { cwd: targetDir, timeout: 120000 })
+        await execFileP('npm', ['run', 'build'], { cwd: targetDir, timeout: 120000 })
+      } catch (err) {
+        loadError = 'Failed to install/build plugin dependencies'
+        logger.error('Plugin build failed', { repoName, error: String(err) })
+      }
+
+      if (!loadError) {
+        try {
+          const manifest = JSON.parse(await readFile(join(targetDir, 'package.json'), 'utf8'))
+          const pluginEntry = manifest.openfox?.plugin as string | undefined
+          const apiVersion = manifest.openfox?.apiVersion as number | undefined
+
+          if (!pluginEntry || !manifest.name) {
+            loadError = 'Plugin package.json is missing openfox.plugin or name field'
+          } else if (apiVersion !== 1) {
+            loadError = `Unsupported plugin API version: ${String(apiVersion)}`
+          } else {
+            const mod = (await import(pathToFileURL(join(targetDir, pluginEntry)).href)) as {
+              register?: (registry: ProviderPluginRegistry) => void | Promise<void>
+            }
+            if (typeof mod.register !== 'function') {
+              loadError = 'Plugin does not export register(registry)'
+            } else {
+              const diagnostic: ProviderPluginDiagnostic = {
+                packageName: manifest.name,
+                version: manifest.version,
+                source: targetDir,
+                loaded: false,
+                authAdapters: [],
+                transportAdapters: [],
+                presets: [],
+              }
+              const trackingRegistry: ProviderPluginRegistry = {
+                runtime: providerAdapters.runtime,
+                registerAuth(adapter) {
+                  providerAdapters.registerAuth(adapter)
+                  diagnostic.authAdapters.push(adapter.id)
+                },
+                registerTransport(adapter) {
+                  providerAdapters.registerTransport(adapter)
+                  diagnostic.transportAdapters.push(adapter.id)
+                },
+                registerPreset(preset) {
+                  providerAdapters.registerPreset(preset)
+                  diagnostic.presets.push(preset.id)
+                },
+              }
+              await mod.register(trackingRegistry)
+              diagnostic.loaded = true
+              pluginDiagnostics.push(diagnostic)
+              loaded = true
+              // Re-resolve providers that use preset default configs
+              config.providers = providerAdapters.resolveProviders(config.providers ?? [])
+            }
+          }
+        } catch (err) {
+          loadError = err instanceof Error ? err.message : 'Failed to load plugin'
+          logger.error('Plugin runtime load failed', { repoName, error: loadError })
+        }
+      }
+
+      res.json({ success: true, loaded, loadError, path: targetDir })
+    } catch (err) {
+      await rm(tmpDir, { recursive: true, force: true })
+      const msg = err instanceof Error ? err.message : 'Clone failed'
+      logger.error('Plugin install failed', { githubUrl, error: msg })
+      res.status(500).json({ error: msg })
+    }
+  })
+  app.get('/api/plugins/installed', async (_req, res) => {
+    const pluginsDir = join(getGlobalConfigDir(config.mode ?? 'production'), 'plugins')
+    try {
+      const entries = await readdir(pluginsDir, { withFileTypes: true })
+      const installed: { name: string; version: string | null }[] = []
+      for (const entry of entries) {
+        if (!entry.isDirectory()) continue
+        const pkgPath = join(pluginsDir, entry.name, 'package.json')
+        let version: string | null = null
+        try {
+          const pkg = JSON.parse(await readFile(pkgPath, 'utf8'))
+          version = (pkg.version as string) ?? null
+        } catch {
+          // ignore if package.json not found or invalid
+        }
+        installed.push({ name: entry.name, version })
+      }
+      res.json({ installed })
+    } catch {
+      res.json({ installed: [] })
+    }
+  })
+  app.get('/api/plugins/open-folder', async (_req, res) => {
+    const pluginsDir = join(getGlobalConfigDir(config.mode ?? 'production'), 'plugins')
+    try {
+      await execFileP('mkdir', ['-p', pluginsDir], { timeout: 5000 })
+      const cmd = platform() === 'darwin' ? 'open' : platform() === 'win32' ? 'explorer' : 'xdg-open'
+      await execFileP(cmd, [pluginsDir], { timeout: 5000 })
+      res.json({ success: true })
+    } catch (err) {
+      res.status(500).json({ error: err instanceof Error ? err.message : 'Failed to open folder' })
+    }
+  })
+  app.get('/api/plugins/:name/open-folder', async (req, res) => {
+    const name = req.params.name as string
+    if (!/^[a-zA-Z0-9_-]+$/.test(name)) return res.status(400).json({ error: 'Invalid plugin name' })
+    const targetDir = join(getGlobalConfigDir(config.mode ?? 'production'), 'plugins', name)
+    try {
+      const cmd = platform() === 'darwin' ? 'open' : platform() === 'win32' ? 'explorer' : 'xdg-open'
+      await execFileP(cmd, [targetDir], { timeout: 5000 })
+      res.json({ success: true })
+    } catch (err) {
+      res.status(500).json({ error: err instanceof Error ? err.message : 'Failed to open folder' })
+    }
+  })
+  app.delete('/api/plugins/:name', async (req, res) => {
+    const name = req.params.name as string
+    if (!/^[a-zA-Z0-9_-]+$/.test(name)) {
+      return res.status(400).json({ error: 'Invalid plugin name' })
+    }
+    const targetDir = join(getGlobalConfigDir(config.mode ?? 'production'), 'plugins', name)
+    try {
+      await rm(targetDir, { recursive: true, force: true })
+      // Clean up stale diagnostics entry
+      for (let i = pluginDiagnostics.length - 1; i >= 0; i--) {
+        if (pluginDiagnostics[i]!.source === targetDir) pluginDiagnostics.splice(i, 1)
+      }
+      res.json({ success: true })
+    } catch (err) {
+      res.status(500).json({ error: err instanceof Error ? err.message : 'Failed to remove plugin' })
+    }
+  })
   app.get('/api/plugins', (_req, res) => res.json({ plugins: pluginDiagnostics }))
   app.get('/api/provider-presets', (_req, res) => res.json({ presets: providerAdapters.getPresets() }))
   app.get('/api/provider-adapters', (_req, res) =>

--- a/src/server/providers/plugins/registry.test.ts
+++ b/src/server/providers/plugins/registry.test.ts
@@ -43,7 +43,7 @@ describe('ProviderRegistry', () => {
     expect(value.getPresets()).toHaveLength(1)
   })
 
-  it('rejects duplicate IDs', () => {
+  it('overwrites on duplicate auth adapter', () => {
     const value = registry()
     const adapter = {
       id: 'auth',
@@ -56,7 +56,8 @@ describe('ProviderRegistry', () => {
       logout: async () => undefined,
     }
     value.registerAuth(adapter)
-    expect(() => value.registerAuth(adapter)).toThrow('already registered')
+    value.registerAuth(adapter)
+    expect(value.listAuthAdapters()).toHaveLength(1)
   })
 
   it('lists registered auth and transport adapters', () => {
@@ -118,7 +119,7 @@ describe('ProviderRegistry', () => {
     expect(value.getPresets()[0]!.id).toBe('preset-1')
   })
 
-  it('rejects duplicate preset IDs', () => {
+  it('overwrites on duplicate preset registration', () => {
     const value = registry()
     const preset = {
       id: 'dup',
@@ -128,7 +129,8 @@ describe('ProviderRegistry', () => {
       defaults: { url: 'https://example.test', backend: 'openai' },
     }
     value.registerPreset(preset)
-    expect(() => value.registerPreset(preset)).toThrow('already registered')
+    value.registerPreset(preset)
+    expect(value.getPresets()).toHaveLength(1)
   })
 
   it('rejects empty ID strings', () => {

--- a/src/server/providers/plugins/registry.ts
+++ b/src/server/providers/plugins/registry.ts
@@ -72,7 +72,9 @@ export class ProviderRegistry implements ProviderPluginRegistry {
 
   private register<T>(map: Map<string, T>, id: string, value: T, kind: string): void {
     if (!id.trim()) throw new Error(`Provider ${kind} id cannot be empty`)
-    if (map.has(id)) throw new Error(`Provider ${kind} already registered: ${id}`)
+    if (map.has(id)) {
+      map.delete(id)
+    }
     map.set(id, value)
   }
 }

--- a/src/server/tools/pdf-utils.ts
+++ b/src/server/tools/pdf-utils.ts
@@ -1,4 +1,5 @@
 import { OUTPUT_LIMITS } from './types.js'
+// @ts-expect-error pdfjs-dist exports getDocument but TypeScript types can't resolve it for this legacy path
 import { getDocument } from 'pdfjs-dist/legacy/build/pdf.mjs'
 
 const PDF_HEADER = Buffer.from('%PDF')
@@ -67,7 +68,8 @@ export async function extractPdfText(buffer: Buffer): Promise<PdfResult> {
       const page = await doc.getPage(i)
       try {
         const content = await page.getTextContent()
-        const pageText = content.items.map((item) => ('str' in item ? item.str : '')).join(' ')
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const pageText = content.items.map((item: any) => ('str' in item ? item.str : '')).join(' ')
         pages.push(`[Page ${i}/${pageCount}]\n${pageText}`)
       } finally {
         page.cleanup()

--- a/web/src/components/settings/GlobalSettingsModal.tsx
+++ b/web/src/components/settings/GlobalSettingsModal.tsx
@@ -7,6 +7,7 @@ import { DisplayTab } from './tabs/DisplayTab'
 import { AdvancedTab } from './tabs/AdvancedTab'
 import { KeybindingsTab } from './tabs/KeybindingsTab'
 import { ToolsTab } from './tabs/ToolsTab'
+import { PluginsTab } from './tabs/PluginsTab'
 import { wsClient } from '../../lib/ws'
 
 interface GlobalSettingsModalProps {
@@ -14,7 +15,7 @@ interface GlobalSettingsModalProps {
   onClose: () => void
 }
 
-type Tab = 'instructions' | 'skills' | 'notifications' | 'display' | 'keybindings' | 'advanced' | 'tools'
+type Tab = 'instructions' | 'skills' | 'plugins' | 'notifications' | 'display' | 'keybindings' | 'advanced' | 'tools'
 
 export function GlobalSettingsModal({ isOpen, onClose }: GlobalSettingsModalProps) {
   const [activeTab, setActiveTab] = useState<Tab>('instructions')
@@ -40,6 +41,7 @@ export function GlobalSettingsModal({ isOpen, onClose }: GlobalSettingsModalProp
           />
           <TabButton label="Tools" active={activeTab === 'tools'} onClick={() => setActiveTab('tools')} />
           <TabButton label="Skills" active={activeTab === 'skills'} onClick={() => setActiveTab('skills')} />
+          <TabButton label="Plugins" active={activeTab === 'plugins'} onClick={() => setActiveTab('plugins')} />
           <TabButton
             label="Notifications"
             active={activeTab === 'notifications'}
@@ -57,6 +59,11 @@ export function GlobalSettingsModal({ isOpen, onClose }: GlobalSettingsModalProp
         {/* Tab content */}
         {activeTab === 'instructions' && <InstructionsTab isOpen={isOpen} />}
         {activeTab === 'skills' && <SkillsContent isOpen={isOpen} />}
+        {activeTab === 'plugins' && (
+          <div className="max-h-[60vh] overflow-y-auto">
+            <PluginsTab />
+          </div>
+        )}
         {activeTab === 'notifications' && (
           <div className="max-h-[60vh] overflow-y-auto">
             <NotificationSettings />

--- a/web/src/components/settings/tabs/PluginsTab.tsx
+++ b/web/src/components/settings/tabs/PluginsTab.tsx
@@ -1,0 +1,423 @@
+import { useState, useEffect, useCallback } from 'react'
+import { authFetch } from '../../../lib/api'
+import { Button } from '../../shared/Button'
+
+const STORAGE_KEY = 'openfox_user_plugins'
+
+interface RegistryPlugin {
+  name: string
+  displayName: string
+  description: string
+  githubUrl: string
+}
+
+interface PluginWithVersion extends RegistryPlugin {
+  latestVersion: string | null
+  versionLoading: boolean
+}
+
+type InstallState = 'idle' | 'installing' | 'installed' | 'error'
+
+function parseGithubRepo(url: string): { owner: string; repo: string } | null {
+  const m = url.match(/github\.com\/([^/]+)\/([^/]+?)(?:\/|$)/)
+  if (!m) return null
+  return { owner: m[1]!, repo: m[2]!.replace(/\.git$/, '') }
+}
+
+async function fetchLatestVersion(githubUrl: string): Promise<string | null> {
+  const parsed = parseGithubRepo(githubUrl)
+  if (!parsed) return null
+  try {
+    const res = await fetch(`https://api.github.com/repos/${parsed.owner}/${parsed.repo}/releases/latest`, {
+      signal: AbortSignal.timeout(5000),
+    })
+    if (!res.ok) return null
+    const data = await res.json()
+    return (data.tag_name as string) ?? null
+  } catch {
+    return null
+  }
+}
+
+function loadUserPlugins(): RegistryPlugin[] {
+  try {
+    return JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '[]')
+  } catch {
+    return []
+  }
+}
+
+function saveUserPlugins(plugins: RegistryPlugin[]) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(plugins))
+}
+
+function AddPluginForm({ onAdd }: { onAdd: (p: RegistryPlugin) => void }) {
+  const [name, setName] = useState('')
+  const [githubUrl, setGithubUrl] = useState('')
+  const [added, setAdded] = useState(false)
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!name.trim() || !githubUrl.trim()) return
+    onAdd({
+      name: name.trim(),
+      displayName: name.trim(),
+      description: 'User-added plugin',
+      githubUrl: githubUrl.trim(),
+    })
+    setName('')
+    setGithubUrl('')
+    setAdded(true)
+    setTimeout(() => setAdded(false), 2000)
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex gap-2 items-end">
+      <div className="flex-1">
+        <label className="text-xs text-text-muted block mb-1">Name</label>
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="my-plugin"
+          className="w-full px-2 py-1 text-sm text-text-primary bg-bg-tertiary border border-border rounded"
+        />
+      </div>
+      <div className="flex-[2]">
+        <label className="text-xs text-text-muted block mb-1">GitHub URL</label>
+        <input
+          type="text"
+          value={githubUrl}
+          onChange={(e) => setGithubUrl(e.target.value)}
+          placeholder="https://github.com/user/repo"
+          className="w-full px-2 py-1 text-sm text-text-primary bg-bg-tertiary border border-border rounded"
+        />
+      </div>
+      <Button type="submit" variant="primary" size="sm">
+        {added ? 'Added' : 'Add'}
+      </Button>
+    </form>
+  )
+}
+
+function PluginCard({
+  plugin,
+  initiallyInstalled,
+  installedVersion,
+  onRemove,
+  onOpenFolder,
+}: {
+  plugin: PluginWithVersion
+  initiallyInstalled: boolean
+  installedVersion: string | null
+  onRemove: (name: string) => void
+  onOpenFolder: (name: string) => void
+}) {
+  const [installState, setInstallState] = useState<InstallState>(initiallyInstalled ? 'installed' : 'idle')
+  const [updating, setUpdating] = useState(false)
+  const [errorMsg, setErrorMsg] = useState('')
+  const [localVersion, setLocalVersion] = useState<string | null>(installedVersion)
+
+  useEffect(() => {
+    setLocalVersion(installedVersion)
+  }, [installedVersion])
+
+  const doInstall = useCallback(async () => {
+    const res = await authFetch('/api/plugins/install', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ githubUrl: plugin.githubUrl }),
+    })
+    const data = await res.json()
+    if (res.ok) {
+      setInstallState('installed')
+      if (plugin.latestVersion) setLocalVersion(plugin.latestVersion)
+      if (!data.loaded) setErrorMsg(data.loadError ?? 'Plugin installed but failed to load')
+    } else {
+      throw new Error(data.error ?? 'Install failed')
+    }
+  }, [plugin.githubUrl, plugin.name])
+
+  const handleInstall = async () => {
+    setInstallState('installing')
+    setErrorMsg('')
+    try {
+      await doInstall()
+    } catch (e) {
+      setInstallState('error')
+      setErrorMsg(e instanceof Error ? e.message : 'Connection error')
+    }
+  }
+
+  const handleRemove = async () => {
+    if (!window.confirm(`Remove "${plugin.displayName}"?`)) return
+    try {
+      const res = await authFetch(`/api/plugins/${plugin.name}`, { method: 'DELETE' })
+      if (res.ok) {
+        setInstallState('idle')
+        onRemove(plugin.name)
+      }
+    } catch {
+      // ignore
+    }
+  }
+
+  const handleUpdate = async () => {
+    setUpdating(true)
+    setErrorMsg('')
+    try {
+      await doInstall()
+    } catch (e) {
+      setErrorMsg(e instanceof Error ? e.message : 'Update failed')
+    }
+    setUpdating(false)
+  }
+
+  const displayVersion = localVersion ?? installedVersion
+  const hasUpdate =
+    plugin.latestVersion && displayVersion && displayVersion !== 'unknown' && plugin.latestVersion !== displayVersion
+  const buttonLabel =
+    installState === 'installing'
+      ? 'Installing…'
+      : updating
+        ? 'Updating…'
+        : installState === 'installed'
+          ? 'Installed ✓'
+          : 'Install'
+  const disabled = installState === 'installing' || installState === 'installed' || updating
+
+  return (
+    <div className="border border-border rounded-lg p-4">
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <h3 className="text-sm font-medium text-text-primary">{plugin.displayName}</h3>
+            <span className="text-xs text-text-muted">({plugin.name})</span>
+          </div>
+          <p className="text-xs text-text-muted mt-1">{plugin.description}</p>
+          <div className="flex items-center gap-3 mt-2 text-xs">
+            {plugin.githubUrl && (
+              <a
+                href={plugin.githubUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="text-accent-primary hover:underline"
+              >
+                GitHub
+              </a>
+            )}
+            {plugin.versionLoading ? (
+              <span className="text-text-muted">Loading version…</span>
+            ) : plugin.latestVersion ? (
+              <span className="text-text-muted">v{plugin.latestVersion}</span>
+            ) : null}
+            {displayVersion && displayVersion !== 'unknown' && (
+              <span className="text-text-muted">installed: v{displayVersion}</span>
+            )}
+          </div>
+          {installState === 'error' && errorMsg && <p className="text-xs text-accent-error mt-1">{errorMsg}</p>}
+        </div>
+        <div className="flex flex-col items-end gap-1">
+          <div className="flex gap-1">
+            {plugin.githubUrl && (
+              <Button
+                variant={installState === 'installed' ? 'secondary' : 'primary'}
+                size="sm"
+                onClick={handleInstall}
+                disabled={disabled}
+              >
+                {buttonLabel}
+              </Button>
+            )}
+            {hasUpdate && (
+              <Button variant="primary" size="sm" onClick={handleUpdate}>
+                Update
+              </Button>
+            )}
+            {installState === 'installed' && (
+              <Button variant="danger" size="sm" onClick={handleRemove}>
+                Remove
+              </Button>
+            )}
+          </div>
+          {installState === 'installed' && (
+            <button onClick={() => onOpenFolder(plugin.name)} className="text-xs text-accent-primary hover:underline">
+              Open folder
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export function PluginsTab() {
+  const [registryPlugins, setRegistryPlugins] = useState<PluginWithVersion[]>([])
+  const [userPlugins, setUserPlugins] = useState<PluginWithVersion[]>([])
+  const [installedVersions, setInstalledVersions] = useState<Record<string, string | null>>({})
+  const [loading, setLoading] = useState(true)
+  const [fetchError, setFetchError] = useState('')
+  const [duplicateWarning, setDuplicateWarning] = useState('')
+
+  useEffect(() => {
+    let cancelled = false
+    Promise.all([
+      authFetch('/api/plugins/registry').then((r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`)
+        return r.json()
+      }),
+      authFetch('/api/plugins/installed').then((r) => {
+        if (!r.ok) return { installed: [] }
+        return r.json()
+      }),
+    ])
+      .then(([registryData, installedData]) => {
+        if (cancelled) return
+        const versions: Record<string, string | null> = {}
+        const installedList = installedData.installed as { name: string; version: string | null }[]
+        for (const p of installedList) {
+          versions[p.name] = p.version
+        }
+        setInstalledVersions(versions)
+
+        const items = (registryData.plugins as RegistryPlugin[]).map((p) => ({
+          ...p,
+          latestVersion: null,
+          versionLoading: true,
+        }))
+        setRegistryPlugins(items)
+        items.forEach((p) => {
+          fetchLatestVersion(p.githubUrl).then((v) => {
+            if (!cancelled)
+              setRegistryPlugins((prev) =>
+                prev.map((x) => (x.name === p.name ? { ...x, latestVersion: v, versionLoading: false } : x)),
+              )
+          })
+        })
+
+        // Auto-discover plugins on disk not in registry or user list
+        const known = new Set(items.map((p) => p.name))
+        const userSaved = loadUserPlugins()
+        const discovered: PluginWithVersion[] = []
+        for (const p of installedList) {
+          if (!known.has(p.name) && !userSaved.some((u) => u.name === p.name)) {
+            discovered.push({
+              name: p.name,
+              displayName: p.name,
+              description: 'Found on disk',
+              githubUrl: '',
+              latestVersion: null,
+              versionLoading: false,
+            })
+          }
+        }
+        if (discovered.length > 0) setUserPlugins((prev) => [...prev, ...discovered])
+      })
+      .catch((err) => {
+        if (!cancelled) setFetchError(err instanceof Error ? err.message : 'Failed to load plugins')
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+
+    const saved = loadUserPlugins()
+    if (saved.length > 0) {
+      setUserPlugins(saved.map((p) => ({ ...p, latestVersion: null, versionLoading: true })))
+      saved.forEach((p) => {
+        fetchLatestVersion(p.githubUrl).then((v) => {
+          if (!cancelled)
+            setUserPlugins((prev) =>
+              prev.map((x) => (x.name === p.name ? { ...x, latestVersion: v, versionLoading: false } : x)),
+            )
+        })
+      })
+    }
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const handleOpenFolder = async (name?: string) => {
+    try {
+      if (name) await authFetch(`/api/plugins/${name}/open-folder`)
+      else await authFetch('/api/plugins/open-folder')
+    } catch {
+      // ignore
+    }
+  }
+
+  const handleRemovePlugin = useCallback((name: string) => {
+    setInstalledVersions((prev) => {
+      const n = { ...prev }
+      delete n[name]
+      return n
+    })
+    const saved = loadUserPlugins()
+    const filtered = saved.filter((p) => p.name !== name)
+    if (filtered.length !== saved.length) saveUserPlugins(filtered)
+    setUserPlugins((prev) => prev.filter((p) => p.name !== name))
+  }, [])
+
+  const handleAddUserPlugin = useCallback(
+    (p: RegistryPlugin) => {
+      const registryNames = new Set(registryPlugins.map((x) => x.name))
+      if (registryNames.has(p.name)) {
+        setDuplicateWarning(`"${p.displayName}" is already listed in the registry and won't be added again.`)
+        return
+      }
+      const saved = loadUserPlugins()
+      saveUserPlugins([...saved, p])
+      setUserPlugins((prev) => [...prev, { ...p, latestVersion: null, versionLoading: true }])
+      fetchLatestVersion(p.githubUrl).then((v) => {
+        setUserPlugins((prev) =>
+          prev.map((x) => (x.name === p.name ? { ...x, latestVersion: v, versionLoading: false } : x)),
+        )
+      })
+    },
+    [registryPlugins],
+  )
+
+  const seen = new Set<string>()
+  const allPlugins = [...registryPlugins, ...userPlugins].filter((p) => {
+    if (seen.has(p.name)) return false
+    seen.add(p.name)
+    return true
+  })
+
+  if (loading) return <div className="text-sm text-text-muted">Loading plugins...</div>
+
+  return (
+    <div className="space-y-4">
+      {fetchError && (
+        <div className="text-sm text-accent-error bg-accent-error/10 border border-accent-error/30 rounded-lg p-3">
+          Failed to load plugin registry: {fetchError}
+        </div>
+      )}
+      {duplicateWarning && (
+        <div className="text-sm text-accent-warning bg-accent-warning/10 border border-accent-warning/30 rounded-lg p-3 flex justify-between items-center">
+          <span>{duplicateWarning}</span>
+          <button onClick={() => setDuplicateWarning('')} className="text-text-muted hover:text-text-primary ml-2">
+            &times;
+          </button>
+        </div>
+      )}
+      <div className="border border-border rounded-lg p-4">
+        <h3 className="text-sm font-medium text-text-primary mb-3">Add Plugin</h3>
+        <AddPluginForm onAdd={handleAddUserPlugin} />
+      </div>
+
+      {allPlugins.length === 0 && !fetchError && <div className="text-sm text-text-muted">No plugins found.</div>}
+
+      {allPlugins.map((plugin) => (
+        <PluginCard
+          key={plugin.name}
+          plugin={plugin}
+          initiallyInstalled={plugin.name in installedVersions}
+          installedVersion={installedVersions[plugin.name] ?? null}
+          onRemove={handleRemovePlugin}
+          onOpenFolder={handleOpenFolder}
+        />
+      ))}
+    </div>
+  )
+}


### PR DESCRIPTION
Hi,

I added this code to show the plugin list in the settings and give the possibility to install, uninstall, or update plugins directly from the UI.

For this, we have a `plugins-registry.json` file which stores the official list of plugins (users can still install plugins that are not in this list).