### PR TITLE
fix(providers): local provider toggle not saved when unchecked

### DIFF
--- a/web/src/components/shared/ProviderModal.tsx
+++ b/web/src/components/shared/ProviderModal.tsx
@@ -814,7 +814,7 @@ export function ProviderModal({
       url: formUrl,
       backend: (formBackend || 'unknown') as Backend,
       apiKey: formApiKey || undefined,
-      isLocal: formIsLocal || undefined,
+      isLocal: formIsLocal,
       thinkingField: thinkingField || undefined,
       authAdapter: formAuthAdapter,
       transportAdapter: formTransportAdapter,


### PR DESCRIPTION
Fixes #71

## Problem

Unchecking "This is a local provider" in the provider modal did not save.

The culprit: `isLocal: formIsLocal || undefined` — when the checkbox is unchecked, `formIsLocal` is `false`, and `false || undefined` evaluates to `undefined`. The server skips any field that is `undefined`, so the update was silently ignored.

## Fix

Change `isLocal: formIsLocal || undefined` to `isLocal: formIsLocal` so the boolean is passed as-is, and `false` is correctly persisted.