### PR TITLE
fix: handle empty tool call arguments gracefully

### DIFF
--- a/src/server/chat/execute-tools.test.ts
+++ b/src/server/chat/execute-tools.test.ts
@@ -264,22 +264,6 @@ describe('executeTools', () => {
     expect(result.stepDoneCalled).toBe(false)
   })
 
-  it('handles step_done with empty string arguments', async () => {
-    const append = vi.fn()
-    mockToolRegistry.execute = vi.fn().mockResolvedValue({
-      success: true,
-      output: 'Step completion signal recorded.',
-      durationMs: 0,
-      truncated: false,
-    })
-
-    const toolCalls: ToolCall[] = [{ id: 'call-1', name: 'step_done', arguments: {} }]
-
-    const result = await executeTools('msg-1', toolCalls, makeCtx(), append)
-
-    expect(result.stepDoneCalled).toBe(true)
-  })
-
   it('detects return_value tool and includes it in result', async () => {
     const append = vi.fn()
     mockToolRegistry.execute = vi.fn().mockResolvedValue({

--- a/src/server/chat/execute-tools.test.ts
+++ b/src/server/chat/execute-tools.test.ts
@@ -264,6 +264,24 @@ describe('executeTools', () => {
     expect(result.stepDoneCalled).toBe(false)
   })
 
+  it('sets stepDoneCalled when step_done has a parseError', async () => {
+    const append = vi.fn()
+    mockToolRegistry.execute = vi.fn().mockResolvedValue({
+      success: true,
+      output: 'Step completion signal recorded.',
+      durationMs: 0,
+      truncated: false,
+    })
+
+    const toolCalls: ToolCall[] = [
+      { id: 'call-1', name: 'step_done', arguments: {}, parseError: 'Unexpected end of JSON input', rawArguments: '{' },
+    ]
+
+    const result = await executeTools('msg-1', toolCalls, makeCtx(), append)
+
+    expect(result.stepDoneCalled).toBe(true)
+  })
+
   it('detects return_value tool and includes it in result', async () => {
     const append = vi.fn()
     mockToolRegistry.execute = vi.fn().mockResolvedValue({

--- a/src/server/chat/execute-tools.test.ts
+++ b/src/server/chat/execute-tools.test.ts
@@ -264,6 +264,22 @@ describe('executeTools', () => {
     expect(result.stepDoneCalled).toBe(false)
   })
 
+  it('handles step_done with empty string arguments', async () => {
+    const append = vi.fn()
+    mockToolRegistry.execute = vi.fn().mockResolvedValue({
+      success: true,
+      output: 'Step completion signal recorded.',
+      durationMs: 0,
+      truncated: false,
+    })
+
+    const toolCalls: ToolCall[] = [{ id: 'call-1', name: 'step_done', arguments: {} }]
+
+    const result = await executeTools('msg-1', toolCalls, makeCtx(), append)
+
+    expect(result.stepDoneCalled).toBe(true)
+  })
+
   it('detects return_value tool and includes it in result', async () => {
     const append = vi.fn()
     mockToolRegistry.execute = vi.fn().mockResolvedValue({

--- a/src/server/chat/execute-tools.ts
+++ b/src/server/chat/execute-tools.ts
@@ -125,18 +125,23 @@ export async function executeTools(
     }
 
     if (toolCall.parseError) {
-      const toolResult: ToolResult = {
-        success: false,
-        error: `Failed to parse tool call arguments: ${toolCall.parseError}. Please ensure your JSON function call arguments are valid.`,
-        durationMs: 0,
-        truncated: false,
-      }
-      append(createToolResultEvent(assistantMsgId, toolCall.id, toolResult))
-      return {
-        toolCall,
-        toolResult,
-        content: `Error: ${toolResult.error}`,
-        index,
+      if (toolCall.name === 'step_done') {
+        const { parseError: _pe, rawArguments: _ra, ...rest } = toolCall
+        toolCall = { ...rest, arguments: {} }
+      } else {
+        const toolResult: ToolResult = {
+          success: false,
+          error: `Failed to parse tool call arguments: ${toolCall.parseError}. Please ensure your JSON function call arguments are valid.`,
+          durationMs: 0,
+          truncated: false,
+        }
+        append(createToolResultEvent(assistantMsgId, toolCall.id, toolResult))
+        return {
+          toolCall,
+          toolResult,
+          content: `Error: ${toolResult.error}`,
+          index,
+        }
       }
     }
 

--- a/src/server/llm/client-pure.ts
+++ b/src/server/llm/client-pure.ts
@@ -23,6 +23,25 @@ export interface ModelParams {
   maxTokens?: number
 }
 
+export function parseToolArguments(
+  raw: string | null | undefined,
+  _meta: { id?: string; name?: string },
+): { arguments: Record<string, unknown>; parseError?: string } {
+  const input = raw?.trim() ? raw : '{}'
+  try {
+    const parsed = JSON.parse(input) as unknown
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return { arguments: {}, parseError: 'Tool arguments must be a JSON object' }
+    }
+    return { arguments: parsed as Record<string, unknown> }
+  } catch (error) {
+    return {
+      arguments: {},
+      parseError: error instanceof Error ? error.message : 'Invalid JSON',
+    }
+  }
+}
+
 export function buildModelParams(params: {
   temperature?: number
   topP?: number

--- a/src/server/llm/client.test.ts
+++ b/src/server/llm/client.test.ts
@@ -197,6 +197,65 @@ describe('llm client', () => {
     })
   })
 
+  it('handles tool calls with empty arguments string', async () => {
+    httpClientCreateStreamMock.mockReturnValueOnce(
+      (async function* () {
+        yield createChunk({
+          choices: [
+            {
+              delta: {
+                tool_calls: [{ index: 0, id: 'call-1', function: { name: 'step_done', arguments: '' } }],
+              },
+              finish_reason: 'tool_calls',
+            },
+          ],
+          usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+        })
+      })(),
+    )
+
+    const client = createLLMClient(createConfig(), 'vllm')
+    const events = [] as Array<Record<string, unknown>>
+
+    for await (const event of client.stream({
+      messages: [{ role: 'user', content: 'hello' }],
+    })) {
+      events.push(event as Record<string, unknown>)
+    }
+
+    const doneEvent = events.find((e) => e['type'] === 'done') as Record<string, unknown> | undefined
+    const response = doneEvent?.['response'] as Record<string, unknown> | undefined
+    const toolCalls = response?.['toolCalls'] as Array<Record<string, unknown>> | undefined
+
+    expect(toolCalls).toHaveLength(1)
+    expect(toolCalls?.[0]).toMatchObject({
+      id: 'call-1',
+      name: 'step_done',
+      arguments: {},
+    })
+    expect(toolCalls?.[0]).not.toHaveProperty('parseError')
+  })
+
+  it('handles tool calls with empty arguments string in complete path', async () => {
+    httpClientCreateMock.mockResolvedValueOnce({
+      id: 'resp-1',
+      choices: [{ finish_reason: 'tool_calls', message: { content: null, tool_calls: [{ id: 'call-1', type: 'function', function: { name: 'step_done', arguments: '' } }] } }],
+      usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+    })
+
+    const client = createLLMClient(createConfig(), 'vllm')
+    const result = await client.complete({
+      messages: [{ role: 'user', content: 'hello' }],
+    })
+
+    expect(result.toolCalls).toHaveLength(1)
+    expect(result.toolCalls?.[0]).toMatchObject({
+      id: 'call-1',
+      name: 'step_done',
+      arguments: {},
+    })
+  })
+
   it('streams reasoning, text, and tool calls and emits a done event with parsed tool calls', async () => {
     httpClientCreateStreamMock.mockReturnValueOnce(
       (async function* () {

--- a/src/server/llm/client.ts
+++ b/src/server/llm/client.ts
@@ -122,7 +122,7 @@ export function createLLMClient(config: Config, initialBackend: Backend = 'unkno
         const toolCalls = message.tool_calls?.map((tc) => ({
           id: tc.id,
           name: tc.function.name,
-          arguments: JSON.parse(tc.function.arguments) as Record<string, unknown>,
+          arguments: JSON.parse(tc.function.arguments || '{}') as Record<string, unknown>,
         }))
 
         return {
@@ -305,7 +305,7 @@ export function createLLMClient(config: Config, initialBackend: Backend = 'unkno
             parsedToolCalls.push({
               id: tc.id,
               name: tc.name,
-              arguments: JSON.parse(tc.arguments) as Record<string, unknown>,
+              arguments: JSON.parse(tc.arguments || '{}') as Record<string, unknown>,
             })
           } catch (error) {
             logger.warn('Failed to parse tool call arguments', { name: tc.name, arguments: tc.arguments })

--- a/src/server/llm/client.ts
+++ b/src/server/llm/client.ts
@@ -17,6 +17,7 @@ import {
   buildStreamingCreateParams,
   mapFinishReason,
   getThinking,
+  parseToolArguments,
 } from './client-pure.js'
 import { OpenAIHttpClient } from './http-client.js'
 
@@ -119,11 +120,10 @@ export function createLLMClient(config: Config, initialBackend: Backend = 'unkno
         const content = message.content ?? ''
         const thinkingContent = getThinking(message as Record<string, string | null>, thinkingField) ?? ''
 
-        const toolCalls = message.tool_calls?.map((tc) => ({
-          id: tc.id,
-          name: tc.function.name,
-          arguments: JSON.parse(tc.function.arguments || '{}') as Record<string, unknown>,
-        }))
+        const toolCalls = message.tool_calls?.map((tc) => {
+          const { arguments: args, parseError } = parseToolArguments(tc.function.arguments, { id: tc.id, name: tc.function.name })
+          return { id: tc.id, name: tc.function.name, arguments: args, ...(parseError ? { parseError } : {}) }
+        })
 
         return {
           id: httpResponse.id,
@@ -301,21 +301,21 @@ export function createLLMClient(config: Config, initialBackend: Backend = 'unkno
         // Parse tool calls
         const parsedToolCalls: ToolCall[] = []
         for (const [, tc] of toolCalls) {
-          try {
+          const { arguments: args, parseError } = parseToolArguments(tc.arguments, { id: tc.id, name: tc.name })
+          if (parseError) {
+            logger.warn('Failed to parse tool call arguments', { name: tc.name, arguments: tc.arguments, parseError })
             parsedToolCalls.push({
               id: tc.id,
               name: tc.name,
-              arguments: JSON.parse(tc.arguments || '{}') as Record<string, unknown>,
-            })
-          } catch (error) {
-            logger.warn('Failed to parse tool call arguments', { name: tc.name, arguments: tc.arguments })
-            // Include the failed tool call with error metadata so the LLM can retry
-            parsedToolCalls.push({
-              id: tc.id,
-              name: tc.name,
-              arguments: {},
-              parseError: error instanceof Error ? error.message : 'Unknown JSON parse error',
+              arguments: args,
+              parseError,
               rawArguments: tc.arguments,
+            })
+          } else {
+            parsedToolCalls.push({
+              id: tc.id,
+              name: tc.name,
+              arguments: args,
             })
           }
         }


### PR DESCRIPTION
Certains LLMs generent une chaine vide ou du JSON invalide comme arguments pour un tool call sans parametres (comme step_done). JSON.parse("") ou JSON.parse("{") echouait, bloquant le workflow.

## Root cause

JSON.parse etait appele directement sur les arguments sans protection. Les modeles qui streamt les tool calls produisent parfois des fragments incomplets ("", "{", "{invalide") cassant le parsing.

## Fix

Deux couches de protection :

### 1. parseToolArguments helper (client-pure.ts)
Utilise par les deux chemins (stream + complete).
- raw?.trim() ? raw : "{}" → rattrape les chaines vides, null, undefined
- try/catch → rattrape tout JSON invalide, retourne parseError
- Validation du type : verifie que le resultat est bien un objet

### 2. Safety net step_done (execute-tools.ts)
Si step_done arrive avec un parseError (ex: arguments tronques "{"), on l execute avec {} quand meme pour ne pas bloquer le workflow.

## Fichiers modifies

- src/server/llm/client-pure.ts : nouveau helper parseToolArguments
- src/server/llm/client.ts : utilise le helper dans les deux paths
- src/server/chat/execute-tools.ts : safety net pour step_done avec parseError
- src/server/chat/execute-tools.test.ts : test pour step_done avec parseError
- src/server/llm/client.test.ts : tests arguments vides (stream + complete)
