### PR TITLE
feat: support multiline acceptance criteria paste

### DIFF
--- a/web/src/components/plan/CriteriaEditor.test.tsx
+++ b/web/src/components/plan/CriteriaEditor.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment happy-dom
+import '@testing-library/jest-dom/vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { CriteriaEditor } from './CriteriaEditor'
+import { authFetch } from '../../lib/api'
+
+vi.mock('../../lib/api', () => ({
+  authFetch: vi.fn(() => Promise.resolve(new Response(null, { status: 200 }))),
+}))
+
+vi.mock('../../stores/agents', () => ({
+  useAgentsStore: vi.fn(
+    (selector: (state: { defaults: unknown[]; userItems: unknown[]; projectItems: unknown[] }) => unknown) =>
+      selector({ defaults: [], userItems: [], projectItems: [] }),
+  ),
+  getAgentColor: vi.fn(() => '#000000'),
+}))
+
+vi.mock('../../stores/workflows', () => ({
+  useWorkflowsStore: vi.fn((selector: (state: { defaults: unknown[]; userItems: unknown[] }) => unknown) =>
+    selector({ defaults: [], userItems: [] }),
+  ),
+}))
+
+const mockedAuthFetch = vi.mocked(authFetch)
+
+function openAddInput() {
+  fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+  return screen.getByPlaceholderText('New criterion...')
+}
+
+describe('CriteriaEditor', () => {
+  afterEach(cleanup)
+
+  beforeEach(() => {
+    mockedAuthFetch.mockClear()
+  })
+
+  it('creates one pending criterion per non-empty pasted line in one request', () => {
+    render(<CriteriaEditor entries={[]} sessionId="session-1" />)
+    const input = openAddInput()
+
+    fireEvent.paste(input, {
+      clipboardData: {
+        getData: () => ' First criterion \r\n\r\nSecond criterion\n Third criterion ',
+      },
+    })
+
+    expect(screen.getByText('[0] First criterion')).toBeInTheDocument()
+    expect(screen.getByText('[1] Second criterion')).toBeInTheDocument()
+    expect(screen.getByText('[2] Third criterion')).toBeInTheDocument()
+    expect(input).toHaveValue('')
+    expect(mockedAuthFetch).toHaveBeenCalledTimes(1)
+    expect(mockedAuthFetch).toHaveBeenCalledWith('/api/sessions/session-1/criteria', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        criteria: [
+          { id: '0', description: 'First criterion', status: 'pending' },
+          { id: '1', description: 'Second criterion', status: 'pending' },
+          { id: '2', description: 'Third criterion', status: 'pending' },
+        ],
+      }),
+    })
+  })
+
+  it('keeps a single-line paste as normal input without creating a criterion', () => {
+    render(<CriteriaEditor entries={[]} sessionId="session-1" />)
+    const input = openAddInput()
+
+    fireEvent.paste(input, {
+      clipboardData: {
+        getData: () => 'Single criterion',
+      },
+    })
+
+    expect(mockedAuthFetch).not.toHaveBeenCalled()
+    expect(screen.queryByText('[0] Single criterion')).not.toBeInTheDocument()
+  })
+
+  it('keeps the existing Enter-to-add behavior', () => {
+    render(<CriteriaEditor entries={[]} sessionId="session-1" />)
+    const input = openAddInput()
+
+    fireEvent.change(input, { target: { value: 'Added with Enter' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    expect(screen.getByText('[0] Added with Enter')).toBeInTheDocument()
+    expect(mockedAuthFetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('allocates pasted IDs after the greatest existing numeric ID', () => {
+    render(
+      <CriteriaEditor
+        sessionId="session-1"
+        entries={[
+          { id: '0', description: 'Existing zero', status: 'pending' },
+          { id: '2', description: 'Existing two', status: 'pending' },
+          { id: 'custom', description: 'Existing custom', status: 'pending' },
+        ]}
+      />,
+    )
+    const input = openAddInput()
+
+    fireEvent.paste(input, {
+      clipboardData: {
+        getData: () => 'New one\nNew two',
+      },
+    })
+
+    expect(screen.getByText('[3] New one')).toBeInTheDocument()
+    expect(screen.getByText('[4] New two')).toBeInTheDocument()
+  })
+})

--- a/web/src/components/plan/CriteriaEditor.tsx
+++ b/web/src/components/plan/CriteriaEditor.tsx
@@ -85,15 +85,42 @@ export function CriteriaEditor({ entries, sessionId }: CriteriaEditorProps) {
     [sessionId],
   )
 
+  const addCriteria = useCallback(
+    (descriptions: string[]) => {
+      const cleaned = descriptions.map((description) => description.trim()).filter(Boolean)
+      if (cleaned.length === 0) return
+
+      const numericIds = criteria
+        .map((criterion) => Number(criterion.id))
+        .filter((id) => Number.isInteger(id) && id >= 0)
+      const firstId = Math.max(-1, ...numericIds) + 1
+      const added = cleaned.map((description, index) => ({
+        id: String(firstId + index),
+        description,
+        status: 'pending',
+      }))
+
+      syncToServer([...criteria, ...added])
+      setNewDescription('')
+      addInputRef.current?.focus()
+    },
+    [criteria, syncToServer],
+  )
+
   const handleAdd = useCallback(() => {
-    const desc = newDescription.trim()
-    if (!desc) return
-    const nextId = String(criteria.length)
-    const next = [...criteria, { id: nextId, description: desc, status: 'pending' }]
-    syncToServer(next)
-    setNewDescription('')
-    addInputRef.current?.focus()
-  }, [criteria, newDescription, syncToServer])
+    addCriteria([newDescription])
+  }, [addCriteria, newDescription])
+
+  const handleAddPaste = useCallback(
+    (e: React.ClipboardEvent<HTMLInputElement>) => {
+      const lines = e.clipboardData.getData('text/plain').split(/\r\n|\r|\n/)
+      if (lines.length < 2) return
+
+      e.preventDefault()
+      addCriteria(lines)
+    },
+    [addCriteria],
+  )
 
   const handleCancelAdd = useCallback(() => {
     setAdding(false)
@@ -228,6 +255,7 @@ export function CriteriaEditor({ entries, sessionId }: CriteriaEditorProps) {
               value={newDescription}
               onChange={(e) => setNewDescription(e.target.value)}
               onKeyDown={handleAddKeyDown}
+              onPaste={handleAddPaste}
               placeholder="New criterion..."
               className="flex-1 bg-bg-tertiary text-text-primary text-xs px-1.5 py-0.5 rounded border border-border focus:outline-none focus:border-accent-primary placeholder-text-muted"
             />


### PR DESCRIPTION
## Summary

- add multiline paste support to the Acceptance Criteria editor
- create one pending criterion per non-empty pasted line
- trim whitespace and persist the batch with one request
- preserve normal single-line paste and Enter-to-add behavior
- generate numeric IDs after the greatest existing numeric ID to avoid collisions
- add focused unit tests

Closes #81

## Context

Some models occasionally complete planning without populating acceptance criteria through `session_metadata`. Users then need a quick manual fallback. Multiline paste makes it possible to copy criteria from model output, notes, or another planning tool without adding each item individually.

## Tests

- `npx vitest run web/src/components/plan/CriteriaEditor.test.tsx --reporter=dot`
- `npm run typecheck:web`
- `npx eslint web/src/components/plan/CriteriaEditor.tsx web/src/components/plan/CriteriaEditor.test.tsx`
- repository pre-push checks: lint, duplicate, typecheck, test