### PR TITLE
feat: edit existing MCP server configurations

### DIFF
--- a/e2e/mcp.test.ts
+++ b/e2e/mcp.test.ts
@@ -50,7 +50,7 @@ describe('MCP Integration', () => {
   async function fetchMcpServers() {
     const res = await fetch(`${server.url}/api/mcp/servers`)
     const data = (await res.json()) as {
-      servers: Array<{ name: string; status: string; tools: Array<{ name: string; enabled: boolean }> }>
+      servers: Array<{ name: string; status: string; config: { command?: string; transport: string }; tools: Array<{ name: string; enabled: boolean }> }>
     }
     return data.servers
   }
@@ -237,6 +237,7 @@ describe('MCP Integration', () => {
     const servers = await fetchMcpServers()
     const testServer = servers.find((s) => s.name === 'test-server')
     expect(testServer!.status).toBe('connected')
+    expect(testServer!.config.command).toBe('npx')
   })
 
   it('switches transport from stdio to stdio with explicit transport field', async () => {

--- a/e2e/mcp.test.ts
+++ b/e2e/mcp.test.ts
@@ -72,6 +72,15 @@ describe('MCP Integration', () => {
     await fetch(`${server.url}/api/mcp/servers/${encodeURIComponent(name)}`, { method: 'DELETE' })
   }
 
+  async function updateMcpServer(name: string, body: Record<string, unknown>) {
+    const res = await fetch(`${server.url}/api/mcp/servers/${encodeURIComponent(name)}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+    return res
+  }
+
   async function fetchSessionState(sessionId: string) {
     const res = await fetch(`${server.url}/api/sessions/${sessionId}`)
     const data = (await res.json()) as {
@@ -183,5 +192,67 @@ describe('MCP Integration', () => {
 
     // Cleanup
     await removeMcpServer('test-server')
+  })
+
+  it('updates an existing MCP server command and args', async () => {
+    const mockServerPath = join(__dirname, 'mock-mcp-server.ts')
+    await addMcpServer('test-server', 'npx', ['tsx', mockServerPath])
+    await sleep(1000)
+
+    const res = await updateMcpServer('test-server', {
+      command: 'npx',
+      args: ['tsx', mockServerPath],
+    })
+    expect(res.ok).toBe(true)
+
+    const servers = await fetchMcpServers()
+    const testServer = servers.find((s) => s.name === 'test-server')
+    expect(testServer).toBeDefined()
+    expect(testServer!.status).toBe('connected')
+    expect(testServer!.tools).toHaveLength(2)
+  })
+
+  it('returns 404 when updating a non-existent MCP server', async () => {
+    const res = await updateMcpServer('does-not-exist', { command: 'echo' })
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 400 when updating with invalid transport', async () => {
+    const mockServerPath = join(__dirname, 'mock-mcp-server.ts')
+    await addMcpServer('test-server', 'npx', ['tsx', mockServerPath])
+    await sleep(500)
+
+    const res = await updateMcpServer('test-server', { transport: 'ftp' })
+    expect(res.status).toBe(400)
+  })
+
+  it('preserves existing fields when partial update is sent', async () => {
+    const mockServerPath = join(__dirname, 'mock-mcp-server.ts')
+    await addMcpServer('test-server', 'npx', ['tsx', mockServerPath])
+    await sleep(1000)
+
+    const res = await updateMcpServer('test-server', { args: ['tsx', mockServerPath] })
+    expect(res.ok).toBe(true)
+
+    const servers = await fetchMcpServers()
+    const testServer = servers.find((s) => s.name === 'test-server')
+    expect(testServer!.status).toBe('connected')
+  })
+
+  it('switches transport from stdio to stdio with explicit transport field', async () => {
+    const mockServerPath = join(__dirname, 'mock-mcp-server.ts')
+    await addMcpServer('test-server', 'npx', ['tsx', mockServerPath])
+    await sleep(1000)
+
+    const res = await updateMcpServer('test-server', {
+      transport: 'stdio',
+      command: 'npx',
+      args: ['tsx', mockServerPath],
+    })
+    expect(res.ok).toBe(true)
+
+    const servers = await fetchMcpServers()
+    const testServer = servers.find((s) => s.name === 'test-server')
+    expect(testServer!.status).toBe('connected')
   })
 })

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1847,6 +1847,64 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
     }
   })
 
+  app.put('/api/mcp/servers/:name', async (req, res) => {
+    const { name } = req.params
+    const existing = mcpManager.getServer(name)
+    if (!existing) {
+      return res.status(404).json({ error: `MCP server '${name}' not found` })
+    }
+    const { transport, command, args, env, url, headers } = req.body as {
+      transport?: string
+      command?: string
+      args?: string[]
+      env?: Record<string, string>
+      url?: string
+      headers?: Record<string, string>
+    }
+    if (transport !== undefined && transport !== 'stdio' && transport !== 'http') {
+      return res.status(400).json({ error: `Invalid transport '${transport}'. Must be 'stdio' or 'http'.` })
+    }
+    const resolvedTransport: 'stdio' | 'http' = transport === 'http' ? 'http' : 'stdio'
+    if (resolvedTransport !== 'http' && !command) {
+      return res.status(400).json({ error: 'command is required for stdio transport' })
+    }
+    if (resolvedTransport === 'http' && !url) {
+      return res.status(400).json({ error: 'url is required for http transport' })
+    }
+    try {
+      const { loadGlobalConfig, saveGlobalConfig } = await import('../cli/config.js')
+      const globalConfig = await loadGlobalConfig(config.mode ?? 'production', config.globalConfigPath)
+      const mcpServers = { ...(globalConfig.mcpServers ?? {}) } as Record<string, import('./mcp/types.js').McpServerConfig>
+      const existingCfg = mcpServers[name]
+      const serverCfg: import('./mcp/types.js').McpServerConfig = {
+        transport: resolvedTransport,
+        ...(command ? { command } : {}),
+        ...(args && args.length > 0 ? { args } : {}),
+        ...(env && Object.keys(env).length > 0 ? { env } : {}),
+        ...(url ? { url } : {}),
+        ...(headers && Object.keys(headers).length > 0 ? { headers } : {}),
+        ...(existingCfg?.disabledTools && existingCfg.disabledTools.length > 0 ? { disabledTools: existingCfg.disabledTools } : {}),
+      }
+      mcpManager.removeServer(name)
+      await mcpManager.addServer(name, serverCfg)
+      mcpServers[name] = serverCfg
+      await saveGlobalConfig(
+        config.mode ?? 'production',
+        { ...globalConfig, mcpServers },
+        config.globalConfigPath,
+      )
+      await rebuildMcpTools()
+      const sessions = sessionManager.listSessions()
+      for (const s of sessions) {
+        sessionManager.setDynamicContextChanged(s.id, true)
+      }
+      const server = mcpManager.getServer(name)
+      res.json({ server })
+    } catch (error) {
+      res.status(400).json({ error: error instanceof Error ? error.message : String(error) })
+    }
+  })
+
   app.delete('/api/mcp/servers/:name', async (req, res) => {
     const { name } = req.params
     const server = mcpManager.getServer(name)

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1876,53 +1876,36 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
       return res.status(400).json({ error: 'headers must be a string/string object' })
     }
 
-    const resolvedTransport: 'stdio' | 'http' = rawTransport !== undefined ? (rawTransport as 'stdio' | 'http') : (existing.config.transport ?? 'stdio')
-    const transportChanged = resolvedTransport !== existing.config.transport
-
-    const mergedCommand = (command as string | undefined) ?? (transportChanged ? undefined : existing.config.command)
-    const mergedArgs = (args as string[] | undefined) ?? (transportChanged ? undefined : existing.config.args)
-    const mergedEnv = (env as Record<string, string> | undefined) ?? (transportChanged ? undefined : existing.config.env)
-    const mergedUrl = (url as string | undefined) ?? (transportChanged ? undefined : existing.config.url)
-    const mergedHeaders = (headers as Record<string, string> | undefined) ?? (transportChanged ? undefined : existing.config.headers)
-
-    if (resolvedTransport !== 'http' && !mergedCommand) {
-      return res.status(400).json({ error: 'command is required for stdio transport' })
-    }
-    if (resolvedTransport === 'http' && !mergedUrl) {
-      return res.status(400).json({ error: 'url is required for http transport' })
-    }
-
     try {
       const { loadGlobalConfig, saveGlobalConfig } = await import('../cli/config.js')
+      const { applyMcpServerUpdate } = await import('./mcp/update-server.js')
+
       const globalConfig = await loadGlobalConfig(config.mode ?? 'production', config.globalConfigPath)
       const mcpServers = { ...(globalConfig.mcpServers ?? {}) } as Record<string, import('./mcp/types.js').McpServerConfig>
-      const existingCfg = mcpServers[name]
 
-      const serverCfg: import('./mcp/types.js').McpServerConfig = {
-        transport: resolvedTransport,
-        ...(mergedCommand ? { command: mergedCommand } : {}),
-        ...(mergedArgs && mergedArgs.length > 0 ? { args: mergedArgs } : {}),
-        ...(mergedEnv && Object.keys(mergedEnv).length > 0 ? { env: mergedEnv } : {}),
-        ...(mergedUrl ? { url: mergedUrl } : {}),
-        ...(mergedHeaders && Object.keys(mergedHeaders).length > 0 ? { headers: mergedHeaders } : {}),
-        ...(existingCfg?.disabledTools && existingCfg.disabledTools.length > 0 ? { disabledTools: existingCfg.disabledTools } : {}),
-        ...(existingCfg?.cachedTools && existingCfg.cachedTools.length > 0 ? { cachedTools: existingCfg.cachedTools } : {}),
+      const patch = {
+        ...(rawTransport !== undefined ? { transport: rawTransport as 'stdio' | 'http' } : {}),
+        ...(command !== undefined ? { command: command as string } : {}),
+        ...(args !== undefined ? { args: args as string[] } : {}),
+        ...(env !== undefined ? { env: env as Record<string, string> } : {}),
+        ...(url !== undefined ? { url: url as string } : {}),
+        ...(headers !== undefined ? { headers: headers as Record<string, string> } : {}),
       }
 
-      mcpManager.removeServer(name)
-      try {
-        await mcpManager.addServer(name, serverCfg)
-      } catch (addError) {
-        await mcpManager.addServer(name, existing.config)
-        throw addError
+      const { serverCfg, error: updateError } = await applyMcpServerUpdate({
+        name,
+        patch,
+        existing,
+        persistedCfg: mcpServers[name],
+        mcpManager,
+      })
+
+      if (updateError) {
+        return res.status(400).json({ error: updateError })
       }
 
       mcpServers[name] = serverCfg
-      await saveGlobalConfig(
-        config.mode ?? 'production',
-        { ...globalConfig, mcpServers },
-        config.globalConfigPath,
-      )
+      await saveGlobalConfig(config.mode ?? 'production', { ...globalConfig, mcpServers }, config.globalConfigPath)
 
       await rebuildMcpTools()
       const sessions = sessionManager.listSessions()

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1853,53 +1853,83 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
     if (!existing) {
       return res.status(404).json({ error: `MCP server '${name}' not found` })
     }
-    const { transport, command, args, env, url, headers } = req.body as {
-      transport?: string
-      command?: string
-      args?: string[]
-      env?: Record<string, string>
-      url?: string
-      headers?: Record<string, string>
+
+    const body = req.body as Record<string, unknown>
+    const { transport: rawTransport, command, args, env, url, headers } = body
+
+    if (rawTransport !== undefined && rawTransport !== 'stdio' && rawTransport !== 'http') {
+      return res.status(400).json({ error: `Invalid transport '${String(rawTransport)}'. Must be 'stdio' or 'http'.` })
     }
-    if (transport !== undefined && transport !== 'stdio' && transport !== 'http') {
-      return res.status(400).json({ error: `Invalid transport '${transport}'. Must be 'stdio' or 'http'.` })
+    if (command !== undefined && typeof command !== 'string') {
+      return res.status(400).json({ error: 'command must be a string' })
     }
-    const resolvedTransport: 'stdio' | 'http' = transport === 'http' ? 'http' : 'stdio'
-    if (resolvedTransport !== 'http' && !command) {
+    if (args !== undefined && (!Array.isArray(args) || args.some((a) => typeof a !== 'string'))) {
+      return res.status(400).json({ error: 'args must be an array of strings' })
+    }
+    if (env !== undefined && (typeof env !== 'object' || env === null || Array.isArray(env) || Object.values(env as object).some((v) => typeof v !== 'string'))) {
+      return res.status(400).json({ error: 'env must be a string/string object' })
+    }
+    if (url !== undefined && typeof url !== 'string') {
+      return res.status(400).json({ error: 'url must be a string' })
+    }
+    if (headers !== undefined && (typeof headers !== 'object' || headers === null || Array.isArray(headers) || Object.values(headers as object).some((v) => typeof v !== 'string'))) {
+      return res.status(400).json({ error: 'headers must be a string/string object' })
+    }
+
+    const resolvedTransport: 'stdio' | 'http' = rawTransport === 'http' ? 'http' : (existing.config.transport ?? 'stdio')
+    const transportChanged = resolvedTransport !== existing.config.transport
+
+    const mergedCommand = (command as string | undefined) ?? (transportChanged ? undefined : existing.config.command)
+    const mergedArgs = (args as string[] | undefined) ?? (transportChanged ? undefined : existing.config.args)
+    const mergedEnv = (env as Record<string, string> | undefined) ?? (transportChanged ? undefined : existing.config.env)
+    const mergedUrl = (url as string | undefined) ?? (transportChanged ? undefined : existing.config.url)
+    const mergedHeaders = (headers as Record<string, string> | undefined) ?? (transportChanged ? undefined : existing.config.headers)
+
+    if (resolvedTransport !== 'http' && !mergedCommand) {
       return res.status(400).json({ error: 'command is required for stdio transport' })
     }
-    if (resolvedTransport === 'http' && !url) {
+    if (resolvedTransport === 'http' && !mergedUrl) {
       return res.status(400).json({ error: 'url is required for http transport' })
     }
+
     try {
       const { loadGlobalConfig, saveGlobalConfig } = await import('../cli/config.js')
       const globalConfig = await loadGlobalConfig(config.mode ?? 'production', config.globalConfigPath)
       const mcpServers = { ...(globalConfig.mcpServers ?? {}) } as Record<string, import('./mcp/types.js').McpServerConfig>
       const existingCfg = mcpServers[name]
+
       const serverCfg: import('./mcp/types.js').McpServerConfig = {
         transport: resolvedTransport,
-        ...(command ? { command } : {}),
-        ...(args && args.length > 0 ? { args } : {}),
-        ...(env && Object.keys(env).length > 0 ? { env } : {}),
-        ...(url ? { url } : {}),
-        ...(headers && Object.keys(headers).length > 0 ? { headers } : {}),
+        ...(mergedCommand ? { command: mergedCommand } : {}),
+        ...(mergedArgs && mergedArgs.length > 0 ? { args: mergedArgs } : {}),
+        ...(mergedEnv && Object.keys(mergedEnv).length > 0 ? { env: mergedEnv } : {}),
+        ...(mergedUrl ? { url: mergedUrl } : {}),
+        ...(mergedHeaders && Object.keys(mergedHeaders).length > 0 ? { headers: mergedHeaders } : {}),
         ...(existingCfg?.disabledTools && existingCfg.disabledTools.length > 0 ? { disabledTools: existingCfg.disabledTools } : {}),
+        ...(existingCfg?.cachedTools && existingCfg.cachedTools.length > 0 ? { cachedTools: existingCfg.cachedTools } : {}),
       }
+
       mcpManager.removeServer(name)
-      await mcpManager.addServer(name, serverCfg)
+      try {
+        await mcpManager.addServer(name, serverCfg)
+      } catch (addError) {
+        await mcpManager.addServer(name, existing.config)
+        throw addError
+      }
+
       mcpServers[name] = serverCfg
       await saveGlobalConfig(
         config.mode ?? 'production',
         { ...globalConfig, mcpServers },
         config.globalConfigPath,
       )
+
       await rebuildMcpTools()
       const sessions = sessionManager.listSessions()
       for (const s of sessions) {
         sessionManager.setDynamicContextChanged(s.id, true)
       }
-      const server = mcpManager.getServer(name)
-      res.json({ server })
+      res.json({ server: mcpManager.getServer(name) })
     } catch (error) {
       res.status(400).json({ error: error instanceof Error ? error.message : String(error) })
     }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1876,7 +1876,7 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
       return res.status(400).json({ error: 'headers must be a string/string object' })
     }
 
-    const resolvedTransport: 'stdio' | 'http' = rawTransport === 'http' ? 'http' : (existing.config.transport ?? 'stdio')
+    const resolvedTransport: 'stdio' | 'http' = rawTransport !== undefined ? (rawTransport as 'stdio' | 'http') : (existing.config.transport ?? 'stdio')
     const transportChanged = resolvedTransport !== existing.config.transport
 
     const mergedCommand = (command as string | undefined) ?? (transportChanged ? undefined : existing.config.command)

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1892,20 +1892,21 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
         ...(headers !== undefined ? { headers: headers as Record<string, string> } : {}),
       }
 
-      const { serverCfg, error: updateError } = await applyMcpServerUpdate({
+      const { error: updateError } = await applyMcpServerUpdate({
         name,
         patch,
         existing,
         persistedCfg: mcpServers[name],
         mcpManager,
+        save: async (cfg) => {
+          mcpServers[name] = cfg
+          await saveGlobalConfig(config.mode ?? 'production', { ...globalConfig, mcpServers }, config.globalConfigPath)
+        },
       })
 
       if (updateError) {
         return res.status(400).json({ error: updateError })
       }
-
-      mcpServers[name] = serverCfg
-      await saveGlobalConfig(config.mode ?? 'production', { ...globalConfig, mcpServers }, config.globalConfigPath)
 
       await rebuildMcpTools()
       const sessions = sessionManager.listSessions()

--- a/src/server/mcp/update-server.ts
+++ b/src/server/mcp/update-server.ts
@@ -1,0 +1,77 @@
+import type { McpManager } from './manager.js'
+import type { McpServerConfig, McpServerState } from './types.js'
+
+export interface McpServerPatch {
+  transport?: 'stdio' | 'http'
+  command?: string
+  args?: string[]
+  env?: Record<string, string>
+  url?: string
+  headers?: Record<string, string>
+}
+
+export interface ApplyMcpServerUpdateOptions {
+  name: string
+  patch: McpServerPatch
+  existing: McpServerState
+  persistedCfg: McpServerConfig | undefined
+  mcpManager: McpManager
+}
+
+export interface ApplyMcpServerUpdateResult {
+  serverCfg: McpServerConfig
+  error?: string
+}
+
+export function buildUpdatedServerConfig(
+  patch: McpServerPatch,
+  existing: McpServerState,
+  persistedCfg: McpServerConfig | undefined,
+): { serverCfg: McpServerConfig; error?: string } {
+  const existingTransport: 'stdio' | 'http' = existing.config.transport ?? 'stdio'
+  const resolvedTransport: 'stdio' | 'http' = patch.transport ?? existingTransport
+  const transportChanged = resolvedTransport !== existingTransport
+
+  const mergedCommand = patch.command !== undefined ? patch.command : (transportChanged ? undefined : existing.config.command)
+  const mergedArgs = patch.args !== undefined ? patch.args : (transportChanged ? undefined : existing.config.args)
+  const mergedEnv = patch.env !== undefined ? patch.env : (transportChanged ? undefined : existing.config.env)
+  const mergedUrl = patch.url !== undefined ? patch.url : (transportChanged ? undefined : existing.config.url)
+  const mergedHeaders = patch.headers !== undefined ? patch.headers : (transportChanged ? undefined : existing.config.headers)
+
+  if (resolvedTransport === 'http' && !mergedUrl) {
+    return { serverCfg: {} as McpServerConfig, error: 'url is required for http transport' }
+  }
+  if (resolvedTransport !== 'http' && !mergedCommand) {
+    return { serverCfg: {} as McpServerConfig, error: 'command is required for stdio transport' }
+  }
+
+  const serverCfg: McpServerConfig = {
+    transport: resolvedTransport,
+    ...(mergedCommand ? { command: mergedCommand } : {}),
+    ...(mergedArgs && mergedArgs.length > 0 ? { args: mergedArgs } : {}),
+    ...(mergedEnv && Object.keys(mergedEnv).length > 0 ? { env: mergedEnv } : {}),
+    ...(mergedUrl ? { url: mergedUrl } : {}),
+    ...(mergedHeaders && Object.keys(mergedHeaders).length > 0 ? { headers: mergedHeaders } : {}),
+    ...(persistedCfg?.disabledTools && persistedCfg.disabledTools.length > 0 ? { disabledTools: persistedCfg.disabledTools } : {}),
+    ...(persistedCfg?.cachedTools && persistedCfg.cachedTools.length > 0 ? { cachedTools: persistedCfg.cachedTools } : {}),
+  }
+
+  return { serverCfg }
+}
+
+export async function applyMcpServerUpdate(options: ApplyMcpServerUpdateOptions): Promise<{ serverCfg: McpServerConfig; error?: string }> {
+  const { name, patch, existing, persistedCfg, mcpManager } = options
+
+  const { serverCfg, error } = buildUpdatedServerConfig(patch, existing, persistedCfg)
+  if (error) return { serverCfg: {} as McpServerConfig, error }
+
+  mcpManager.removeServer(name)
+  try {
+    await mcpManager.addServer(name, serverCfg)
+  } catch (addError) {
+    await mcpManager.addServer(name, existing.config)
+    throw addError
+  }
+
+  return { serverCfg }
+}

--- a/src/server/mcp/update-server.ts
+++ b/src/server/mcp/update-server.ts
@@ -16,11 +16,7 @@ export interface ApplyMcpServerUpdateOptions {
   existing: McpServerState
   persistedCfg: McpServerConfig | undefined
   mcpManager: McpManager
-}
-
-export interface ApplyMcpServerUpdateResult {
-  serverCfg: McpServerConfig
-  error?: string
+  save: (serverCfg: McpServerConfig) => Promise<void>
 }
 
 export function buildUpdatedServerConfig(
@@ -60,7 +56,7 @@ export function buildUpdatedServerConfig(
 }
 
 export async function applyMcpServerUpdate(options: ApplyMcpServerUpdateOptions): Promise<{ serverCfg: McpServerConfig; error?: string }> {
-  const { name, patch, existing, persistedCfg, mcpManager } = options
+  const { name, patch, existing, persistedCfg, mcpManager, save } = options
 
   const { serverCfg, error } = buildUpdatedServerConfig(patch, existing, persistedCfg)
   if (error) return { serverCfg: {} as McpServerConfig, error }
@@ -71,6 +67,14 @@ export async function applyMcpServerUpdate(options: ApplyMcpServerUpdateOptions)
   } catch (addError) {
     await mcpManager.addServer(name, existing.config)
     throw addError
+  }
+
+  try {
+    await save(serverCfg)
+  } catch (saveError) {
+    mcpManager.removeServer(name)
+    await mcpManager.addServer(name, existing.config)
+    throw saveError
   }
 
   return { serverCfg }

--- a/src/server/tools/mcp-config.test.ts
+++ b/src/server/tools/mcp-config.test.ts
@@ -401,4 +401,156 @@ describe('mcpConfigTool', () => {
       expect(result.error).toContain('reboot')
     })
   })
+
+  describe('action: update', () => {
+    it('should return error when server not found', async () => {
+      const manager = {
+        ...mockManager,
+        getServer: vi.fn().mockReturnValue(undefined),
+      } as unknown as McpManager
+      setMcpManagerForTools(manager)
+
+      const { mcpConfigTool } = await import('./mcp-config.js')
+
+      const result = await mcpConfigTool.execute(
+        { action: 'update', name: 'unknown' },
+        { workdir: '/tmp', sessionId: 's1', sessionManager: mockSessionManager() },
+      )
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('unknown')
+    })
+
+    it('should require name', async () => {
+      setMcpManagerForTools(mockManager)
+
+      const { mcpConfigTool } = await import('./mcp-config.js')
+
+      const result = await mcpConfigTool.execute(
+        { action: 'update' },
+        { workdir: '/tmp', sessionId: 's1', sessionManager: mockSessionManager() },
+      )
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('name')
+    })
+
+    it('should do a partial merge — keep existing command when not provided', async () => {
+      const manager = {
+        ...mockManager,
+        getServer: vi.fn().mockReturnValue({
+          name: 'filesystem',
+          config: { transport: 'stdio', command: 'npx', args: ['-y', '@fs/mcp'] },
+          status: 'connected',
+          tools: [],
+          estimatedTokens: 0,
+        }),
+        addServer: vi.fn().mockResolvedValue(undefined),
+        removeServer: vi.fn(),
+      } as unknown as McpManager
+      setMcpManagerForTools(manager)
+
+      const { mcpConfigTool } = await import('./mcp-config.js')
+
+      const result = await mcpConfigTool.execute(
+        { action: 'update', name: 'filesystem', args: ['-y', '@fs/mcp', '--extra'] },
+        { workdir: '/tmp', sessionId: 's1', sessionManager: mockSessionManager() },
+      )
+
+      expect(result.success).toBe(true)
+      expect(manager.addServer).toHaveBeenCalledWith(
+        'filesystem',
+        expect.objectContaining({ command: 'npx', args: ['-y', '@fs/mcp', '--extra'] }),
+      )
+    })
+
+    it('should clear stdio fields when transport changes to http', async () => {
+      const manager = {
+        ...mockManager,
+        getServer: vi.fn().mockReturnValue({
+          name: 'my-server',
+          config: { transport: 'stdio', command: 'npx', args: ['server.js'], env: { KEY: 'val' } },
+          status: 'connected',
+          tools: [],
+          estimatedTokens: 0,
+        }),
+        addServer: vi.fn().mockResolvedValue(undefined),
+        removeServer: vi.fn(),
+      } as unknown as McpManager
+      setMcpManagerForTools(manager)
+
+      const { mcpConfigTool } = await import('./mcp-config.js')
+
+      const result = await mcpConfigTool.execute(
+        { action: 'update', name: 'my-server', transport: 'http', url: 'https://example.com/mcp' },
+        { workdir: '/tmp', sessionId: 's1', sessionManager: mockSessionManager() },
+      )
+
+      expect(result.success).toBe(true)
+      expect(manager.addServer).toHaveBeenCalledWith(
+        'my-server',
+        expect.objectContaining({ transport: 'http', url: 'https://example.com/mcp' }),
+      )
+      const calledCfg = (manager.addServer as ReturnType<typeof vi.fn>).mock.calls[0]?.[1]
+      expect(calledCfg.command).toBeUndefined()
+      expect(calledCfg.args).toBeUndefined()
+      expect(calledCfg.env).toBeUndefined()
+    })
+
+    it('should normalize transportChanged when existing.config.transport is undefined', async () => {
+      const manager = {
+        ...mockManager,
+        getServer: vi.fn().mockReturnValue({
+          name: 'legacy-server',
+          config: { command: 'npx', args: ['server.js'] },
+          status: 'connected',
+          tools: [],
+          estimatedTokens: 0,
+        }),
+        addServer: vi.fn().mockResolvedValue(undefined),
+        removeServer: vi.fn(),
+      } as unknown as McpManager
+      setMcpManagerForTools(manager)
+
+      const { mcpConfigTool } = await import('./mcp-config.js')
+
+      const result = await mcpConfigTool.execute(
+        { action: 'update', name: 'legacy-server', args: ['server.js', '--port', '3000'] },
+        { workdir: '/tmp', sessionId: 's1', sessionManager: mockSessionManager() },
+      )
+
+      expect(result.success).toBe(true)
+      const calledCfg = (manager.addServer as ReturnType<typeof vi.fn>).mock.calls[0]?.[1]
+      expect(calledCfg.command).toBe('npx')
+      expect(calledCfg.args).toEqual(['server.js', '--port', '3000'])
+    })
+
+    it('should rollback to existing config when addServer throws', async () => {
+      const existingConfig = { transport: 'stdio' as const, command: 'npx', args: ['old.js'] }
+      const manager = {
+        ...mockManager,
+        getServer: vi.fn().mockReturnValue({
+          name: 'failing-server',
+          config: existingConfig,
+          status: 'connected',
+          tools: [],
+          estimatedTokens: 0,
+        }),
+        addServer: vi.fn().mockRejectedValue(new Error('connection failed')),
+        removeServer: vi.fn(),
+      } as unknown as McpManager
+      setMcpManagerForTools(manager)
+
+      const { mcpConfigTool } = await import('./mcp-config.js')
+
+      const result = await mcpConfigTool.execute(
+        { action: 'update', name: 'failing-server', args: ['new.js'] },
+        { workdir: '/tmp', sessionId: 's1', sessionManager: mockSessionManager() },
+      )
+
+      expect(result.success).toBe(false)
+      expect(manager.addServer).toHaveBeenCalledTimes(2)
+      expect(manager.addServer).toHaveBeenLastCalledWith('failing-server', existingConfig)
+    })
+  })
 })

--- a/src/server/tools/mcp-config.ts
+++ b/src/server/tools/mcp-config.ts
@@ -210,7 +210,7 @@ export const mcpConfigTool: Tool = createTool<McpConfigArgs>(
       const existing = mcpManagerForTools.getServer(args.name)
       if (!existing) return helpers.error(`MCP server "${args.name}" not found`)
 
-      const transport = args.transport ?? existing.config.transport
+      const transport: 'stdio' | 'http' = args.transport ?? existing.config.transport ?? 'stdio'
       const transportChanged = transport !== existing.config.transport
 
       const mergedCommand = args.command !== undefined ? args.command : (transportChanged ? undefined : existing.config.command)

--- a/src/server/tools/mcp-config.ts
+++ b/src/server/tools/mcp-config.ts
@@ -7,7 +7,7 @@ import { loadGlobalConfig, saveGlobalConfig } from '../../cli/config.js'
 import { createMcpTools } from '../mcp/tool-adapter.js'
 
 interface McpConfigArgs {
-  action: 'list' | 'add' | 'remove' | 'toggle-tool'
+  action: 'list' | 'add' | 'update' | 'remove' | 'toggle-tool'
   name?: string
   transport?: 'stdio' | 'http'
   command?: string
@@ -58,9 +58,9 @@ export const mcpConfigTool: Tool = createTool<McpConfigArgs>(
         properties: {
           action: {
             type: 'string',
-            enum: ['list', 'add', 'remove', 'toggle-tool'],
+            enum: ['list', 'add', 'update', 'remove', 'toggle-tool'],
             description:
-              'Action: list (show servers), add (add new server), remove (delete a server), toggle-tool (enable/disable a tool)',
+              'Action: list (show servers), add (add new server), update (modify existing server), remove (delete a server), toggle-tool (enable/disable a tool)',
           },
           name: {
             type: 'string',
@@ -110,7 +110,7 @@ export const mcpConfigTool: Tool = createTool<McpConfigArgs>(
   async (args, context, helpers) => {
     const actionError = validateActionWithPermission(
       args.action,
-      ['list', 'add', 'remove', 'toggle-tool'],
+      ['list', 'add', 'update', 'remove', 'toggle-tool'],
       'mcp_config',
       context.permittedActions,
     )
@@ -203,6 +203,44 @@ export const mcpConfigTool: Tool = createTool<McpConfigArgs>(
       const server = mcpManagerForTools.getServer(args.name)
       const toolCount = server?.tools.length ?? 0
       return helpers.success(`Added MCP server "${args.name}" (${toolCount} tools discovered). ${APPLY_PROMPT_MESSAGE}`)
+    }
+
+    if (args.action === 'update') {
+      if (!args.name) return helpers.error('Missing required field: name')
+      const existing = mcpManagerForTools.getServer(args.name)
+      if (!existing) return helpers.error(`MCP server "${args.name}" not found`)
+
+      const transport = args.transport ?? existing.config.transport
+      if (transport === 'http') {
+        if (!args.url && !existing.config.url) return helpers.error('url is required for http transport')
+      } else {
+        if (!args.command && !existing.config.command) return helpers.error('command is required for stdio transport')
+      }
+
+      const globalConfig = await loadGlobalConfig(mcpConfigMode, mcpConfigPath)
+      const mcpServers = { ...((globalConfig.mcpServers ?? {}) as Record<string, McpServerConfig>) }
+      const existingCfg = mcpServers[args.name]
+
+      const serverCfg: McpServerConfig = {
+        transport,
+        ...(args.command !== undefined ? (args.command ? { command: args.command } : {}) : existing.config.command ? { command: existing.config.command } : {}),
+        ...(args.args !== undefined ? (args.args.length > 0 ? { args: args.args } : {}) : existing.config.args && existing.config.args.length > 0 ? { args: existing.config.args } : {}),
+        ...(args.env !== undefined ? (Object.keys(args.env).length > 0 ? { env: args.env } : {}) : existing.config.env && Object.keys(existing.config.env).length > 0 ? { env: existing.config.env } : {}),
+        ...(args.url !== undefined ? (args.url ? { url: args.url } : {}) : existing.config.url ? { url: existing.config.url } : {}),
+        ...(args.headers !== undefined ? (Object.keys(args.headers).length > 0 ? { headers: args.headers } : {}) : existing.config.headers && Object.keys(existing.config.headers).length > 0 ? { headers: existing.config.headers } : {}),
+        ...(existingCfg?.disabledTools && existingCfg.disabledTools.length > 0 ? { disabledTools: existingCfg.disabledTools } : {}),
+      }
+
+      mcpServers[args.name] = serverCfg
+      await saveGlobalConfig(mcpConfigMode, { ...globalConfig, mcpServers }, mcpConfigPath)
+      mcpManagerForTools.removeServer(args.name)
+      await mcpManagerForTools.addServer(args.name, serverCfg)
+      await rebuildTools()
+      notifyContextChanged(context.sessionId)
+
+      const server = mcpManagerForTools.getServer(args.name)
+      const toolCount = server?.tools.length ?? 0
+      return helpers.success(`Updated MCP server "${args.name}" (${toolCount} tools discovered). ${APPLY_PROMPT_MESSAGE}`)
     }
 
     if (args.action === 'remove') {

--- a/src/server/tools/mcp-config.ts
+++ b/src/server/tools/mcp-config.ts
@@ -52,7 +52,7 @@ export const mcpConfigTool: Tool = createTool<McpConfigArgs>(
     function: {
       name: 'mcp_config',
       description:
-        'Configure MCP servers (Model Context Protocol). Actions: list (show all servers and tools), add (add a server), remove (delete a server), toggle-tool (enable/disable a tool). Use this when the user asks to add, remove, or configure MCP servers or tools.',
+        'Configure MCP servers (Model Context Protocol). Actions: list (show all servers and tools), add (add a server), update (modify an existing server — all fields are optional and merged with the current config, transport-incompatible fields are cleared on transport change), remove (delete a server), toggle-tool (enable/disable a tool). Use this when the user asks to add, remove, update, or configure MCP servers or tools.',
       parameters: {
         type: 'object',
         properties: {
@@ -64,7 +64,7 @@ export const mcpConfigTool: Tool = createTool<McpConfigArgs>(
           },
           name: {
             type: 'string',
-            description: 'Server name (required for: add, remove, toggle-tool)',
+            description: 'Server name (required for: add, update, remove, toggle-tool)',
           },
           transport: {
             type: 'string',
@@ -211,10 +211,18 @@ export const mcpConfigTool: Tool = createTool<McpConfigArgs>(
       if (!existing) return helpers.error(`MCP server "${args.name}" not found`)
 
       const transport = args.transport ?? existing.config.transport
+      const transportChanged = transport !== existing.config.transport
+
+      const mergedCommand = args.command !== undefined ? args.command : (transportChanged ? undefined : existing.config.command)
+      const mergedArgs = args.args !== undefined ? args.args : (transportChanged ? undefined : existing.config.args)
+      const mergedEnv = args.env !== undefined ? args.env : (transportChanged ? undefined : existing.config.env)
+      const mergedUrl = args.url !== undefined ? args.url : (transportChanged ? undefined : existing.config.url)
+      const mergedHeaders = args.headers !== undefined ? args.headers : (transportChanged ? undefined : existing.config.headers)
+
       if (transport === 'http') {
-        if (!args.url && !existing.config.url) return helpers.error('url is required for http transport')
+        if (!mergedUrl) return helpers.error('url is required for http transport')
       } else {
-        if (!args.command && !existing.config.command) return helpers.error('command is required for stdio transport')
+        if (!mergedCommand) return helpers.error('command is required for stdio transport')
       }
 
       const globalConfig = await loadGlobalConfig(mcpConfigMode, mcpConfigPath)
@@ -223,18 +231,25 @@ export const mcpConfigTool: Tool = createTool<McpConfigArgs>(
 
       const serverCfg: McpServerConfig = {
         transport,
-        ...(args.command !== undefined ? (args.command ? { command: args.command } : {}) : existing.config.command ? { command: existing.config.command } : {}),
-        ...(args.args !== undefined ? (args.args.length > 0 ? { args: args.args } : {}) : existing.config.args && existing.config.args.length > 0 ? { args: existing.config.args } : {}),
-        ...(args.env !== undefined ? (Object.keys(args.env).length > 0 ? { env: args.env } : {}) : existing.config.env && Object.keys(existing.config.env).length > 0 ? { env: existing.config.env } : {}),
-        ...(args.url !== undefined ? (args.url ? { url: args.url } : {}) : existing.config.url ? { url: existing.config.url } : {}),
-        ...(args.headers !== undefined ? (Object.keys(args.headers).length > 0 ? { headers: args.headers } : {}) : existing.config.headers && Object.keys(existing.config.headers).length > 0 ? { headers: existing.config.headers } : {}),
+        ...(mergedCommand ? { command: mergedCommand } : {}),
+        ...(mergedArgs && mergedArgs.length > 0 ? { args: mergedArgs } : {}),
+        ...(mergedEnv && Object.keys(mergedEnv).length > 0 ? { env: mergedEnv } : {}),
+        ...(mergedUrl ? { url: mergedUrl } : {}),
+        ...(mergedHeaders && Object.keys(mergedHeaders).length > 0 ? { headers: mergedHeaders } : {}),
         ...(existingCfg?.disabledTools && existingCfg.disabledTools.length > 0 ? { disabledTools: existingCfg.disabledTools } : {}),
+        ...(existingCfg?.cachedTools && existingCfg.cachedTools.length > 0 ? { cachedTools: existingCfg.cachedTools } : {}),
+      }
+
+      mcpManagerForTools.removeServer(args.name)
+      try {
+        await mcpManagerForTools.addServer(args.name, serverCfg)
+      } catch (addError) {
+        await mcpManagerForTools.addServer(args.name, existing.config)
+        throw addError
       }
 
       mcpServers[args.name] = serverCfg
       await saveGlobalConfig(mcpConfigMode, { ...globalConfig, mcpServers }, mcpConfigPath)
-      mcpManagerForTools.removeServer(args.name)
-      await mcpManagerForTools.addServer(args.name, serverCfg)
       await rebuildTools()
       notifyContextChanged(context.sessionId)
 

--- a/src/server/tools/mcp-config.ts
+++ b/src/server/tools/mcp-config.ts
@@ -5,6 +5,7 @@ import type { McpServerConfig } from '../mcp/types.js'
 import type { Mode } from '../../cli/main.js'
 import { loadGlobalConfig, saveGlobalConfig } from '../../cli/config.js'
 import { createMcpTools } from '../mcp/tool-adapter.js'
+import { applyMcpServerUpdate } from '../mcp/update-server.js'
 
 interface McpConfigArgs {
   action: 'list' | 'add' | 'update' | 'remove' | 'toggle-tool'
@@ -210,43 +211,27 @@ export const mcpConfigTool: Tool = createTool<McpConfigArgs>(
       const existing = mcpManagerForTools.getServer(args.name)
       if (!existing) return helpers.error(`MCP server "${args.name}" not found`)
 
-      const transport: 'stdio' | 'http' = args.transport ?? existing.config.transport ?? 'stdio'
-      const transportChanged = transport !== existing.config.transport
-
-      const mergedCommand = args.command !== undefined ? args.command : (transportChanged ? undefined : existing.config.command)
-      const mergedArgs = args.args !== undefined ? args.args : (transportChanged ? undefined : existing.config.args)
-      const mergedEnv = args.env !== undefined ? args.env : (transportChanged ? undefined : existing.config.env)
-      const mergedUrl = args.url !== undefined ? args.url : (transportChanged ? undefined : existing.config.url)
-      const mergedHeaders = args.headers !== undefined ? args.headers : (transportChanged ? undefined : existing.config.headers)
-
-      if (transport === 'http') {
-        if (!mergedUrl) return helpers.error('url is required for http transport')
-      } else {
-        if (!mergedCommand) return helpers.error('command is required for stdio transport')
-      }
-
       const globalConfig = await loadGlobalConfig(mcpConfigMode, mcpConfigPath)
       const mcpServers = { ...((globalConfig.mcpServers ?? {}) as Record<string, McpServerConfig>) }
-      const existingCfg = mcpServers[args.name]
 
-      const serverCfg: McpServerConfig = {
-        transport,
-        ...(mergedCommand ? { command: mergedCommand } : {}),
-        ...(mergedArgs && mergedArgs.length > 0 ? { args: mergedArgs } : {}),
-        ...(mergedEnv && Object.keys(mergedEnv).length > 0 ? { env: mergedEnv } : {}),
-        ...(mergedUrl ? { url: mergedUrl } : {}),
-        ...(mergedHeaders && Object.keys(mergedHeaders).length > 0 ? { headers: mergedHeaders } : {}),
-        ...(existingCfg?.disabledTools && existingCfg.disabledTools.length > 0 ? { disabledTools: existingCfg.disabledTools } : {}),
-        ...(existingCfg?.cachedTools && existingCfg.cachedTools.length > 0 ? { cachedTools: existingCfg.cachedTools } : {}),
+      const patch = {
+        ...(args.transport !== undefined ? { transport: args.transport } : {}),
+        ...(args.command !== undefined ? { command: args.command } : {}),
+        ...(args.args !== undefined ? { args: args.args } : {}),
+        ...(args.env !== undefined ? { env: args.env } : {}),
+        ...(args.url !== undefined ? { url: args.url } : {}),
+        ...(args.headers !== undefined ? { headers: args.headers } : {}),
       }
 
-      mcpManagerForTools.removeServer(args.name)
-      try {
-        await mcpManagerForTools.addServer(args.name, serverCfg)
-      } catch (addError) {
-        await mcpManagerForTools.addServer(args.name, existing.config)
-        throw addError
-      }
+      const { serverCfg, error: updateError } = await applyMcpServerUpdate({
+        name: args.name,
+        patch,
+        existing,
+        persistedCfg: mcpServers[args.name],
+        mcpManager: mcpManagerForTools,
+      })
+
+      if (updateError) return helpers.error(updateError)
 
       mcpServers[args.name] = serverCfg
       await saveGlobalConfig(mcpConfigMode, { ...globalConfig, mcpServers }, mcpConfigPath)

--- a/src/server/tools/mcp-config.ts
+++ b/src/server/tools/mcp-config.ts
@@ -223,18 +223,19 @@ export const mcpConfigTool: Tool = createTool<McpConfigArgs>(
         ...(args.headers !== undefined ? { headers: args.headers } : {}),
       }
 
-      const { serverCfg, error: updateError } = await applyMcpServerUpdate({
+      const { error: updateError } = await applyMcpServerUpdate({
         name: args.name,
         patch,
         existing,
         persistedCfg: mcpServers[args.name],
         mcpManager: mcpManagerForTools,
+        save: async (cfg) => {
+          mcpServers[args.name!] = cfg
+          await saveGlobalConfig(mcpConfigMode, { ...globalConfig, mcpServers }, mcpConfigPath)
+        },
       })
 
       if (updateError) return helpers.error(updateError)
-
-      mcpServers[args.name] = serverCfg
-      await saveGlobalConfig(mcpConfigMode, { ...globalConfig, mcpServers }, mcpConfigPath)
       await rebuildTools()
       notifyContextChanged(context.sessionId)
 

--- a/web/src/components/settings/tabs/ToolsTab.tsx
+++ b/web/src/components/settings/tabs/ToolsTab.tsx
@@ -18,7 +18,7 @@ function parseKeyValueLines(text: string): Record<string, string> {
     .forEach((line) => {
       const eqIdx = line.indexOf('=')
       if (eqIdx > 0) {
-        result[line.slice(0, eqIdx).trim()] = line.slice(eqIdx + 1).trim()
+        result[line.slice(0, eqIdx).trim()] = line.slice(eqIdx + 1)
       }
     })
   return result
@@ -249,7 +249,7 @@ export function ToolsTab() {
 
       if (formData.transport === 'stdio') {
         body.command = formData.command
-        const args = formData.args ? formData.args.split(' ').filter(Boolean) : undefined
+        const args = formData.args ? formData.args.split('\n').filter(Boolean) : undefined
         if (args && args.length > 0) body.args = args
         const env = parseKeyValueLines(formData.env)
         if (Object.keys(env).length > 0) body.env = env
@@ -283,7 +283,7 @@ export function ToolsTab() {
       name: server.name,
       transport: server.config.transport as 'stdio' | 'http',
       command: server.config.command ?? '',
-      args: server.config.args?.join(' ') ?? '',
+      args: server.config.args?.join('\n') ?? '',
       env: server.config.env
         ? Object.entries(server.config.env)
             .map(([k, v]) => `${k}=${v}`)
@@ -316,7 +316,7 @@ export function ToolsTab() {
 
       if (formData.transport === 'stdio') {
         body.command = formData.command
-        const args = formData.args ? formData.args.split(' ').filter(Boolean) : undefined
+        const args = formData.args ? formData.args.split('\n').filter(Boolean) : undefined
         if (args && args.length > 0) body.args = args
         const env = parseKeyValueLines(formData.env)
         if (Object.keys(env).length > 0) body.env = env
@@ -741,7 +741,7 @@ export function ToolsTab() {
                     label="Arguments"
                     value={formData.args}
                     onChange={(v) => setFormData({ ...formData, args: v })}
-                    placeholder="space-separated args"
+                    placeholder="one arg per line"
                   />
                   <div>
                     <label className="block text-xs text-text-secondary mb-1">
@@ -850,7 +850,7 @@ export function ToolsTab() {
                     label="Arguments"
                     value={formData.args}
                     onChange={(v) => setFormData({ ...formData, args: v })}
-                    placeholder="space-separated args"
+                    placeholder="one arg per line"
                   />
                   <div>
                     <label className="block text-xs text-text-secondary mb-1">

--- a/web/src/components/settings/tabs/ToolsTab.tsx
+++ b/web/src/components/settings/tabs/ToolsTab.tsx
@@ -10,6 +10,20 @@ import { CRUDListView } from '../CRUDListView'
 import { useConfirmDialog, FormField, ErrorBanner } from '../CRUDModal'
 import { Modal } from '../../shared/SelfContainedModal'
 
+function parseKeyValueLines(text: string): Record<string, string> {
+  const result: Record<string, string> = {}
+  text
+    .split('\n')
+    .filter(Boolean)
+    .forEach((line) => {
+      const eqIdx = line.indexOf('=')
+      if (eqIdx > 0) {
+        result[line.slice(0, eqIdx).trim()] = line.slice(eqIdx + 1).trim()
+      }
+    })
+  return result
+}
+
 interface McpToolInfo {
   name: string
   description?: string
@@ -20,7 +34,7 @@ interface McpToolInfo {
 
 interface McpServerState {
   name: string
-  config: { transport: string; command?: string; args?: string[]; url?: string; headers?: Record<string, string> }
+  config: { transport: string; command?: string; args?: string[]; env?: Record<string, string>; url?: string; headers?: Record<string, string> }
   status: 'connected' | 'disconnected' | 'error'
   tools: McpToolInfo[]
   estimatedTokens: number
@@ -166,6 +180,7 @@ export function ToolsTab() {
   const [servers, setServers] = useState<McpServerState[]>([])
   const [loading, setLoading] = useState(true)
   const [showAddForm, setShowAddForm] = useState(false)
+  const [editingServer, setEditingServer] = useState<string | null>(null)
   const [expandedServers, setExpandedServers] = useState<Set<string>>(new Set())
   const [expandedDescs, setExpandedDescs] = useState<Set<string>>(new Set())
   const [formData, setFormData] = useState({
@@ -227,20 +242,6 @@ export function ToolsTab() {
     }
     setSaving(true)
     try {
-      const parseKeyValueLines = (text: string): Record<string, string> => {
-        const result: Record<string, string> = {}
-        text
-          .split('\n')
-          .filter(Boolean)
-          .forEach((line) => {
-            const eqIdx = line.indexOf('=')
-            if (eqIdx > 0) {
-              result[line.slice(0, eqIdx).trim()] = line.slice(eqIdx + 1).trim()
-            }
-          })
-        return result
-      }
-
       const body: Record<string, unknown> = {
         name: formData.name,
         transport: formData.transport,
@@ -268,6 +269,73 @@ export function ToolsTab() {
         throw new Error(data.error ?? 'Failed to add server')
       }
       setShowAddForm(false)
+      setFormData({ name: '', transport: 'stdio', command: '', args: '', env: '', url: '', headers: '' })
+      await loadServers()
+    } catch (err) {
+      setFormError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleEdit = (server: McpServerState) => {
+    setFormData({
+      name: server.name,
+      transport: server.config.transport as 'stdio' | 'http',
+      command: server.config.command ?? '',
+      args: server.config.args?.join(' ') ?? '',
+      env: server.config.env
+        ? Object.entries(server.config.env)
+            .map(([k, v]) => `${k}=${v}`)
+            .join('\n')
+        : '',
+      url: server.config.url ?? '',
+      headers: server.config.headers
+        ? Object.entries(server.config.headers)
+            .map(([k, v]) => `${k}=${v}`)
+            .join('\n')
+        : '',
+    })
+    setFormError('')
+    setEditingServer(server.name)
+  }
+
+  const handleUpdate = async () => {
+    setFormError('')
+    if (formData.transport === 'stdio' && !formData.command) {
+      setFormError('Command is required for stdio transport')
+      return
+    }
+    if (formData.transport === 'http' && !formData.url) {
+      setFormError('URL is required for HTTP transport')
+      return
+    }
+    setSaving(true)
+    try {
+      const body: Record<string, unknown> = { transport: formData.transport }
+
+      if (formData.transport === 'stdio') {
+        body.command = formData.command
+        const args = formData.args ? formData.args.split(' ').filter(Boolean) : undefined
+        if (args && args.length > 0) body.args = args
+        const env = parseKeyValueLines(formData.env)
+        if (Object.keys(env).length > 0) body.env = env
+      } else {
+        body.url = formData.url
+        const headers = parseKeyValueLines(formData.headers)
+        if (Object.keys(headers).length > 0) body.headers = headers
+      }
+
+      const res = await authFetch(`/api/mcp/servers/${encodeURIComponent(editingServer!)}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+      if (!res.ok) {
+        const data = await res.json()
+        throw new Error(data.error ?? 'Failed to update server')
+      }
+      setEditingServer(null)
       setFormData({ name: '', transport: 'stdio', command: '', args: '', env: '', url: '', headers: '' })
       await loadServers()
     } catch (err) {
@@ -589,15 +657,26 @@ export function ToolsTab() {
                         </button>
                       </>
                     ) : (
-                      <button
-                        onClick={(e) => {
-                          e.stopPropagation()
-                          requestDelete(server.name)
-                        }}
-                        className="px-2 py-1 rounded text-xs font-medium text-accent-error/80 hover:text-accent-error hover:bg-accent-error/10 transition-colors"
-                      >
-                        Remove server
-                      </button>
+                      <>
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            handleEdit(server)
+                          }}
+                          className="px-2 py-1 rounded text-xs font-medium text-text-muted hover:text-text-primary hover:bg-bg-primary transition-colors"
+                        >
+                          Edit
+                        </button>
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            requestDelete(server.name)
+                          }}
+                          className="px-2 py-1 rounded text-xs font-medium text-accent-error/80 hover:text-accent-error hover:bg-accent-error/10 transition-colors"
+                        >
+                          Remove server
+                        </button>
+                      </>
                     )}
                   </div>
                 </div>
@@ -716,6 +795,115 @@ export function ToolsTab() {
                 </Button>
                 <Button variant="primary" onClick={handleAdd} disabled={saving}>
                   {saving ? 'Adding...' : 'Add'}
+                </Button>
+              </div>
+            </div>
+          </Modal>
+        )}
+
+        {editingServer !== null && (
+          <Modal
+            isOpen={editingServer !== null}
+            onClose={() => {
+              setEditingServer(null)
+              setFormError('')
+            }}
+            title={`Edit MCP Server: ${editingServer}`}
+            size="sm"
+          >
+            <div className="space-y-3">
+              <div>
+                <label className="block text-xs text-text-secondary mb-1">Transport</label>
+                <div className="flex gap-1">
+                  <button
+                    onClick={() => setFormData({ ...formData, transport: 'stdio' })}
+                    className={`px-3 py-1.5 rounded text-xs font-medium transition-colors ${
+                      formData.transport === 'stdio'
+                        ? 'bg-accent-primary text-white'
+                        : 'bg-bg-tertiary text-text-secondary hover:bg-bg-primary'
+                    }`}
+                  >
+                    Stdio
+                  </button>
+                  <button
+                    onClick={() => setFormData({ ...formData, transport: 'http' })}
+                    className={`px-3 py-1.5 rounded text-xs font-medium transition-colors ${
+                      formData.transport === 'http'
+                        ? 'bg-accent-primary text-white'
+                        : 'bg-bg-tertiary text-text-secondary hover:bg-bg-primary'
+                    }`}
+                  >
+                    HTTP
+                  </button>
+                </div>
+              </div>
+
+              {formData.transport === 'stdio' ? (
+                <>
+                  <FormField
+                    label="Command"
+                    value={formData.command}
+                    onChange={(v) => setFormData({ ...formData, command: v })}
+                    placeholder="e.g. npx"
+                  />
+                  <FormField
+                    label="Arguments"
+                    value={formData.args}
+                    onChange={(v) => setFormData({ ...formData, args: v })}
+                    placeholder="space-separated args"
+                  />
+                  <div>
+                    <label className="block text-xs text-text-secondary mb-1">
+                      Environment variables <span className="text-text-muted">(KEY=VALUE, one per line)</span>
+                    </label>
+                    <textarea
+                      value={formData.env}
+                      onChange={(e) => setFormData({ ...formData, env: e.target.value })}
+                      placeholder="API_KEY=xxx"
+                      className="w-full px-2 py-1.5 bg-bg-tertiary border border-border rounded text-sm font-mono resize-none focus:outline-none focus:ring-1 focus:ring-accent-primary"
+                      rows={3}
+                    />
+                  </div>
+                </>
+              ) : (
+                <>
+                  <FormField
+                    label="URL"
+                    value={formData.url}
+                    onChange={(v) => setFormData({ ...formData, url: v })}
+                    placeholder="e.g. https://mcp.example.com/mcp"
+                  />
+                  <div>
+                    <label className="block text-xs text-text-secondary mb-1">
+                      Headers <span className="text-text-muted">(KEY=VALUE, one per line)</span>
+                    </label>
+                    <textarea
+                      value={formData.headers}
+                      onChange={(e) => setFormData({ ...formData, headers: e.target.value })}
+                      placeholder="X-API-Key=xxx"
+                      className="w-full px-2 py-1.5 bg-bg-tertiary border border-border rounded text-sm font-mono resize-none focus:outline-none focus:ring-1 focus:ring-accent-primary"
+                      rows={3}
+                    />
+                  </div>
+                </>
+              )}
+
+              {formError && <ErrorBanner message={formError} />}
+              <div className="flex justify-end gap-2 pt-2 border-t border-border">
+                <Button
+                  variant="secondary"
+                  onClick={() => {
+                    setEditingServer(null)
+                    setFormError('')
+                    setSaving(false)
+                    setFormData({ name: '', transport: 'stdio', command: '', args: '', env: '', url: '', headers: '' })
+                  }}
+                  disabled={saving}
+                >
+                  Cancel
+                </Button>
+                <Button variant="primary" onClick={handleUpdate} disabled={saving}>
+                  {saving ? 'Saving...' : 'Save'}
                 </Button>
               </div>
             </div>

--- a/web/src/components/settings/tabs/ToolsTab.tsx
+++ b/web/src/components/settings/tabs/ToolsTab.tsx
@@ -24,6 +24,103 @@ function parseKeyValueLines(text: string): Record<string, string> {
   return result
 }
 
+interface McpFormData {
+  name: string
+  transport: 'stdio' | 'http'
+  command: string
+  args: string
+  env: string
+  url: string
+  headers: string
+}
+
+interface McpServerFormFieldsProps {
+  formData: McpFormData
+  onChange: (data: McpFormData) => void
+}
+
+function McpServerFormFields({ formData, onChange }: McpServerFormFieldsProps) {
+  return (
+    <>
+      <div>
+        <label className="block text-xs text-text-secondary mb-1">Transport</label>
+        <div className="flex gap-1">
+          <button
+            onClick={() => onChange({ ...formData, transport: 'stdio' })}
+            className={`px-3 py-1.5 rounded text-xs font-medium transition-colors ${
+              formData.transport === 'stdio'
+                ? 'bg-accent-primary text-white'
+                : 'bg-bg-tertiary text-text-secondary hover:bg-bg-primary'
+            }`}
+          >
+            Stdio
+          </button>
+          <button
+            onClick={() => onChange({ ...formData, transport: 'http' })}
+            className={`px-3 py-1.5 rounded text-xs font-medium transition-colors ${
+              formData.transport === 'http'
+                ? 'bg-accent-primary text-white'
+                : 'bg-bg-tertiary text-text-secondary hover:bg-bg-primary'
+            }`}
+          >
+            HTTP
+          </button>
+        </div>
+      </div>
+
+      {formData.transport === 'stdio' ? (
+        <>
+          <FormField
+            label="Command"
+            value={formData.command}
+            onChange={(v) => onChange({ ...formData, command: v })}
+            placeholder="e.g. npx"
+          />
+          <FormField
+            label="Arguments"
+            value={formData.args}
+            onChange={(v) => onChange({ ...formData, args: v })}
+            placeholder="one arg per line"
+          />
+          <div>
+            <label className="block text-xs text-text-secondary mb-1">
+              Environment variables <span className="text-text-muted">(KEY=VALUE, one per line)</span>
+            </label>
+            <textarea
+              value={formData.env}
+              onChange={(e) => onChange({ ...formData, env: e.target.value })}
+              placeholder="API_KEY=xxx"
+              className="w-full px-2 py-1.5 bg-bg-tertiary border border-border rounded text-sm font-mono resize-none focus:outline-none focus:ring-1 focus:ring-accent-primary"
+              rows={3}
+            />
+          </div>
+        </>
+      ) : (
+        <>
+          <FormField
+            label="URL"
+            value={formData.url}
+            onChange={(v) => onChange({ ...formData, url: v })}
+            placeholder="e.g. https://mcp.example.com/mcp"
+          />
+          <div>
+            <label className="block text-xs text-text-secondary mb-1">
+              Headers <span className="text-text-muted">(KEY=VALUE, one per line)</span>
+            </label>
+            <textarea
+              value={formData.headers}
+              onChange={(e) => onChange({ ...formData, headers: e.target.value })}
+              placeholder="X-API-Key=xxx"
+              className="w-full px-2 py-1.5 bg-bg-tertiary border border-border rounded text-sm font-mono resize-none focus:outline-none focus:ring-1 focus:ring-accent-primary"
+              rows={3}
+            />
+          </div>
+        </>
+      )}
+    </>
+  )
+}
+
 interface McpToolInfo {
   name: string
   description?: string
@@ -183,7 +280,7 @@ export function ToolsTab() {
   const [editingServer, setEditingServer] = useState<string | null>(null)
   const [expandedServers, setExpandedServers] = useState<Set<string>>(new Set())
   const [expandedDescs, setExpandedDescs] = useState<Set<string>>(new Set())
-  const [formData, setFormData] = useState({
+  const [formData, setFormData] = useState<McpFormData>({
     name: '',
     transport: 'stdio' as 'stdio' | 'http',
     command: '',
@@ -316,14 +413,11 @@ export function ToolsTab() {
 
       if (formData.transport === 'stdio') {
         body.command = formData.command
-        const args = formData.args ? formData.args.split('\n').filter(Boolean) : undefined
-        if (args && args.length > 0) body.args = args
-        const env = parseKeyValueLines(formData.env)
-        if (Object.keys(env).length > 0) body.env = env
+        body.args = formData.args ? formData.args.split('\n').filter(Boolean) : []
+        body.env = parseKeyValueLines(formData.env)
       } else {
         body.url = formData.url
-        const headers = parseKeyValueLines(formData.headers)
-        if (Object.keys(headers).length > 0) body.headers = headers
+        body.headers = parseKeyValueLines(formData.headers)
       }
 
       const res = await authFetch(`/api/mcp/servers/${encodeURIComponent(editingServer!)}`, {
@@ -347,21 +441,17 @@ export function ToolsTab() {
 
   const handleRemove = async (name: string) => {
     try {
-      const res = await authFetch(`/api/mcp/servers/${encodeURIComponent(name)}`, { method: 'DELETE' })
-      if (!res.ok) {
-        const data = await res.json()
-        console.error('Failed to remove MCP server:', data.error)
-      }
+      await authFetch(`/api/mcp/servers/${encodeURIComponent(name)}`, { method: 'DELETE' })
       clearConfirm()
       await loadServers()
-    } catch (err) {
-      console.error('Failed to remove MCP server:', err)
+    } catch {
+      /* ignore */
     }
   }
 
   const handleToggleTool = async (serverName: string, toolName: string, enabled: boolean) => {
     try {
-      const res = await authFetch(
+      await authFetch(
         `/api/mcp/servers/${encodeURIComponent(serverName)}/tools/${encodeURIComponent(toolName)}`,
         {
           method: 'PUT',
@@ -369,13 +459,9 @@ export function ToolsTab() {
           body: JSON.stringify({ enabled }),
         },
       )
-      if (!res.ok) {
-        const data = await res.json()
-        console.error('Failed to toggle tool:', data.error)
-      }
       await loadServers()
-    } catch (err) {
-      console.error('Failed to toggle tool:', err)
+    } catch {
+      /* ignore */
     }
   }
 
@@ -703,81 +789,7 @@ export function ToolsTab() {
                 placeholder="e.g. filesystem"
               />
 
-              <div>
-                <label className="block text-xs text-text-secondary mb-1">Transport</label>
-                <div className="flex gap-1">
-                  <button
-                    onClick={() => setFormData({ ...formData, transport: 'stdio' })}
-                    className={`px-3 py-1.5 rounded text-xs font-medium transition-colors ${
-                      formData.transport === 'stdio'
-                        ? 'bg-accent-primary text-white'
-                        : 'bg-bg-tertiary text-text-secondary hover:bg-bg-primary'
-                    }`}
-                  >
-                    Stdio
-                  </button>
-                  <button
-                    onClick={() => setFormData({ ...formData, transport: 'http' })}
-                    className={`px-3 py-1.5 rounded text-xs font-medium transition-colors ${
-                      formData.transport === 'http'
-                        ? 'bg-accent-primary text-white'
-                        : 'bg-bg-tertiary text-text-secondary hover:bg-bg-primary'
-                    }`}
-                  >
-                    HTTP
-                  </button>
-                </div>
-              </div>
-
-              {formData.transport === 'stdio' ? (
-                <>
-                  <FormField
-                    label="Command"
-                    value={formData.command}
-                    onChange={(v) => setFormData({ ...formData, command: v })}
-                    placeholder="e.g. npx"
-                  />
-                  <FormField
-                    label="Arguments"
-                    value={formData.args}
-                    onChange={(v) => setFormData({ ...formData, args: v })}
-                    placeholder="one arg per line"
-                  />
-                  <div>
-                    <label className="block text-xs text-text-secondary mb-1">
-                      Environment variables <span className="text-text-muted">(KEY=VALUE, one per line)</span>
-                    </label>
-                    <textarea
-                      value={formData.env}
-                      onChange={(e) => setFormData({ ...formData, env: e.target.value })}
-                      placeholder="API_KEY=xxx"
-                      className="w-full px-2 py-1.5 bg-bg-tertiary border border-border rounded text-sm font-mono resize-none focus:outline-none focus:ring-1 focus:ring-accent-primary"
-                      rows={3}
-                    />
-                  </div>
-                </>
-              ) : (
-                <>
-                  <FormField
-                    label="URL"
-                    value={formData.url}
-                    onChange={(v) => setFormData({ ...formData, url: v })}
-                    placeholder="e.g. https://mcp.example.com/mcp"
-                  />
-                  <div>
-                    <label className="block text-xs text-text-secondary mb-1">
-                      Headers <span className="text-text-muted">(KEY=VALUE, one per line)</span>
-                    </label>
-                    <textarea
-                      value={formData.headers}
-                      onChange={(e) => setFormData({ ...formData, headers: e.target.value })}
-                      placeholder="X-API-Key=xxx"
-                      className="w-full px-2 py-1.5 bg-bg-tertiary border border-border rounded text-sm font-mono resize-none focus:outline-none focus:ring-1 focus:ring-accent-primary"
-                      rows={3}
-                    />
-                  </div>
-                </>
-              )}
+              <McpServerFormFields formData={formData} onChange={setFormData} />
 
               {formError && <ErrorBanner message={formError} />}
               <div className="flex justify-end gap-2 pt-2 border-t border-border">
@@ -812,81 +824,7 @@ export function ToolsTab() {
             size="sm"
           >
             <div className="space-y-3">
-              <div>
-                <label className="block text-xs text-text-secondary mb-1">Transport</label>
-                <div className="flex gap-1">
-                  <button
-                    onClick={() => setFormData({ ...formData, transport: 'stdio' })}
-                    className={`px-3 py-1.5 rounded text-xs font-medium transition-colors ${
-                      formData.transport === 'stdio'
-                        ? 'bg-accent-primary text-white'
-                        : 'bg-bg-tertiary text-text-secondary hover:bg-bg-primary'
-                    }`}
-                  >
-                    Stdio
-                  </button>
-                  <button
-                    onClick={() => setFormData({ ...formData, transport: 'http' })}
-                    className={`px-3 py-1.5 rounded text-xs font-medium transition-colors ${
-                      formData.transport === 'http'
-                        ? 'bg-accent-primary text-white'
-                        : 'bg-bg-tertiary text-text-secondary hover:bg-bg-primary'
-                    }`}
-                  >
-                    HTTP
-                  </button>
-                </div>
-              </div>
-
-              {formData.transport === 'stdio' ? (
-                <>
-                  <FormField
-                    label="Command"
-                    value={formData.command}
-                    onChange={(v) => setFormData({ ...formData, command: v })}
-                    placeholder="e.g. npx"
-                  />
-                  <FormField
-                    label="Arguments"
-                    value={formData.args}
-                    onChange={(v) => setFormData({ ...formData, args: v })}
-                    placeholder="one arg per line"
-                  />
-                  <div>
-                    <label className="block text-xs text-text-secondary mb-1">
-                      Environment variables <span className="text-text-muted">(KEY=VALUE, one per line)</span>
-                    </label>
-                    <textarea
-                      value={formData.env}
-                      onChange={(e) => setFormData({ ...formData, env: e.target.value })}
-                      placeholder="API_KEY=xxx"
-                      className="w-full px-2 py-1.5 bg-bg-tertiary border border-border rounded text-sm font-mono resize-none focus:outline-none focus:ring-1 focus:ring-accent-primary"
-                      rows={3}
-                    />
-                  </div>
-                </>
-              ) : (
-                <>
-                  <FormField
-                    label="URL"
-                    value={formData.url}
-                    onChange={(v) => setFormData({ ...formData, url: v })}
-                    placeholder="e.g. https://mcp.example.com/mcp"
-                  />
-                  <div>
-                    <label className="block text-xs text-text-secondary mb-1">
-                      Headers <span className="text-text-muted">(KEY=VALUE, one per line)</span>
-                    </label>
-                    <textarea
-                      value={formData.headers}
-                      onChange={(e) => setFormData({ ...formData, headers: e.target.value })}
-                      placeholder="X-API-Key=xxx"
-                      className="w-full px-2 py-1.5 bg-bg-tertiary border border-border rounded text-sm font-mono resize-none focus:outline-none focus:ring-1 focus:ring-accent-primary"
-                      rows={3}
-                    />
-                  </div>
-                </>
-              )}
+              <McpServerFormFields formData={formData} onChange={setFormData} />
 
               {formError && <ErrorBanner message={formError} />}
               <div className="flex justify-end gap-2 pt-2 border-t border-border">

--- a/web/src/components/settings/tabs/ToolsTab.tsx
+++ b/web/src/components/settings/tabs/ToolsTab.tsx
@@ -18,7 +18,7 @@ function parseKeyValueLines(text: string): Record<string, string> {
     .forEach((line) => {
       const eqIdx = line.indexOf('=')
       if (eqIdx > 0) {
-        result[line.slice(0, eqIdx).trim()] = line.slice(eqIdx + 1)
+        result[line.slice(0, eqIdx).trim()] = line.slice(eqIdx + 1).trim()
       }
     })
   return result
@@ -289,6 +289,7 @@ export function ToolsTab() {
     headers: '',
   })
   const [formError, setFormError] = useState('')
+  const [mcpError, setMcpError] = useState('')
   const [saving, setSaving] = useState(false)
   const { requestDelete, clearConfirm, isConfirming } = useConfirmDialog()
 
@@ -440,17 +441,22 @@ export function ToolsTab() {
 
   const handleRemove = async (name: string) => {
     try {
-      await authFetch(`/api/mcp/servers/${encodeURIComponent(name)}`, { method: 'DELETE' })
+      const res = await authFetch(`/api/mcp/servers/${encodeURIComponent(name)}`, { method: 'DELETE' })
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}))
+        throw new Error((data as { error?: string }).error ?? 'Failed to remove server')
+      }
       clearConfirm()
+      setMcpError('')
       await loadServers()
-    } catch {
-      /* ignore */
+    } catch (err) {
+      setMcpError(err instanceof Error ? err.message : String(err))
     }
   }
 
   const handleToggleTool = async (serverName: string, toolName: string, enabled: boolean) => {
     try {
-      await authFetch(
+      const res = await authFetch(
         `/api/mcp/servers/${encodeURIComponent(serverName)}/tools/${encodeURIComponent(toolName)}`,
         {
           method: 'PUT',
@@ -458,9 +464,14 @@ export function ToolsTab() {
           body: JSON.stringify({ enabled }),
         },
       )
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}))
+        throw new Error((data as { error?: string }).error ?? 'Failed to toggle tool')
+      }
+      setMcpError('')
       await loadServers()
-    } catch {
-      /* ignore */
+    } catch (err) {
+      setMcpError(err instanceof Error ? err.message : String(err))
     }
   }
 
@@ -632,6 +643,7 @@ export function ToolsTab() {
         <p className="text-sm text-text-muted mb-3">
           MCP servers provide external tools that extend OpenFox's capabilities.
         </p>
+        {mcpError && <ErrorBanner message={mcpError} />}
 
         <CRUDListView
           loading={loading}
@@ -814,7 +826,7 @@ export function ToolsTab() {
 
         {editingServer !== null && (
           <Modal
-            isOpen={editingServer !== null}
+            isOpen
             onClose={() => {
               setEditingServer(null)
               setFormError('')

--- a/web/src/components/settings/tabs/ToolsTab.tsx
+++ b/web/src/components/settings/tabs/ToolsTab.tsx
@@ -670,6 +670,39 @@ export function ToolsTab() {
                       {server.error}
                     </span>
                   )}
+                  {expandedServers.has(server.name) && (
+                    isConfirming(server.name, 'delete') ? (
+                      <>
+                        <button
+                          onClick={(e) => { e.stopPropagation(); handleRemove(server.name) }}
+                          className="px-2 py-1 rounded text-xs font-medium hover:opacity-90 transition-colors bg-accent-error/20 text-accent-error hover:bg-accent-error/30"
+                        >
+                          Delete
+                        </button>
+                        <button
+                          onClick={(e) => { e.stopPropagation(); clearConfirm() }}
+                          className="px-2 py-1 rounded text-xs text-text-muted hover:bg-bg-primary transition-colors"
+                        >
+                          Cancel
+                        </button>
+                      </>
+                    ) : (
+                      <>
+                        <button
+                          onClick={(e) => { e.stopPropagation(); handleEdit(server) }}
+                          className="px-2 py-1 rounded text-xs font-medium text-text-muted hover:text-text-primary hover:bg-bg-primary transition-colors"
+                        >
+                          Edit
+                        </button>
+                        <button
+                          onClick={(e) => { e.stopPropagation(); requestDelete(server.name) }}
+                          className="px-2 py-1 rounded text-xs font-medium text-accent-error/80 hover:text-accent-error hover:bg-accent-error/10 transition-colors"
+                        >
+                          Remove
+                        </button>
+                      </>
+                    )
+                  )}
                   <span className="text-xs text-text-muted">{expandedServers.has(server.name) ? '▲' : '▼'}</span>
                 </div>
               </div>
@@ -731,51 +764,6 @@ export function ToolsTab() {
                       ))}
                     </div>
                   )}
-                  <div className="pt-2 flex items-center justify-end gap-2">
-                    {isConfirming(server.name, 'delete') ? (
-                      <>
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation()
-                            handleRemove(server.name)
-                          }}
-                          className="px-2 py-1 rounded text-xs font-medium hover:opacity-90 transition-colors bg-accent-error/20 text-accent-error hover:bg-accent-error/30"
-                        >
-                          Delete
-                        </button>
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation()
-                            clearConfirm()
-                          }}
-                          className="px-2 py-1 rounded text-xs text-text-muted hover:bg-bg-primary transition-colors"
-                        >
-                          Cancel
-                        </button>
-                      </>
-                    ) : (
-                      <>
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation()
-                            handleEdit(server)
-                          }}
-                          className="px-2 py-1 rounded text-xs font-medium text-text-muted hover:text-text-primary hover:bg-bg-primary transition-colors"
-                        >
-                          Edit
-                        </button>
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation()
-                            requestDelete(server.name)
-                          }}
-                          className="px-2 py-1 rounded text-xs font-medium text-accent-error/80 hover:text-accent-error hover:bg-accent-error/10 transition-colors"
-                        >
-                          Remove server
-                        </button>
-                      </>
-                    )}
-                  </div>
                 </div>
               )}
             </div>

--- a/web/src/components/settings/tabs/ToolsTab.tsx
+++ b/web/src/components/settings/tabs/ToolsTab.tsx
@@ -80,8 +80,7 @@ function McpServerFormFields({ formData, onChange }: McpServerFormFieldsProps) {
             label="Arguments"
             value={formData.args}
             onChange={(v) => onChange({ ...formData, args: v })}
-            placeholder="one arg per line"
-          />
+            placeholder="space-separated args" />
           <div>
             <label className="block text-xs text-text-secondary mb-1">
               Environment variables <span className="text-text-muted">(KEY=VALUE, one per line)</span>
@@ -346,7 +345,7 @@ export function ToolsTab() {
 
       if (formData.transport === 'stdio') {
         body.command = formData.command
-        const args = formData.args ? formData.args.split('\n').filter(Boolean) : undefined
+        const args = formData.args ? formData.args.split(' ').filter(Boolean) : undefined
         if (args && args.length > 0) body.args = args
         const env = parseKeyValueLines(formData.env)
         if (Object.keys(env).length > 0) body.env = env
@@ -380,7 +379,7 @@ export function ToolsTab() {
       name: server.name,
       transport: server.config.transport as 'stdio' | 'http',
       command: server.config.command ?? '',
-      args: server.config.args?.join('\n') ?? '',
+      args: server.config.args?.join(' ') ?? '',
       env: server.config.env
         ? Object.entries(server.config.env)
             .map(([k, v]) => `${k}=${v}`)
@@ -413,7 +412,7 @@ export function ToolsTab() {
 
       if (formData.transport === 'stdio') {
         body.command = formData.command
-        body.args = formData.args ? formData.args.split('\n').filter(Boolean) : []
+        body.args = formData.args ? formData.args.split(' ').filter(Boolean) : []
         body.env = parseKeyValueLines(formData.env)
       } else {
         body.url = formData.url


### PR DESCRIPTION
Closes #67

## Ce qui a été fait

Implémente l'édition des serveurs MCP existants depuis l'interface de paramètres et via l'outil agent `mcp_config`.

### Backend — nouvelle route `PUT /api/mcp/servers/:name`
- **Merge partiel** : les champs non fournis conservent la valeur existante
- Changement de transport : les champs incompatibles sont supprimés automatiquement
- `disabledTools` et `cachedTools` préservés
- **Rollback complet** : rollback mémoire si `addServer` échoue, rollback mémoire si `saveGlobalConfig` échoue
- Config persistée dans le callback `save` — cohérence disque/mémoire garantie
- Validation explicite du body (types vérifiés)

### Outil agent — nouvelle action `update` dans `mcp_config`
- Même comportement que l'endpoint HTTP (merge partiel, rollback, transport change)
- Description de l'outil mise à jour

### Refactoring — `src/server/mcp/update-server.ts`
- `buildUpdatedServerConfig` + `applyMcpServerUpdate` extraits et partagés entre `index.ts` et `mcp-config.ts`
- Fix `transportChanged` : normalise `existingTransport = existing.config.transport ?? 'stdio'` avant comparaison (évite d'effacer les champs stdio sur des configs migrées sans champ `transport`)

### Frontend — modal d'édition dans `ToolsTab`
- Boutons **Edit** / **Remove** dans le header du collapse (visibles immédiatement, pas besoin de scroller)
- Modal pré-rempli : transport, command, args (séparés par espaces), env (KEY=VALUE), url, headers
- Le nom n'est pas modifiable
- Erreurs de remove/toggle-tool surfacées dans l'UI via `ErrorBanner`
- `McpServerFormFields` extrait en composant partagé entre modals Add et Edit
- `parseKeyValueLines` à scope module, valeurs trimées

### Tests
- **5 tests e2e** : update normal, 404, 400 transport invalide, partial merge (assert `command` préservé), transport explicite
- **6 tests unitaires** `mcp-config.test.ts` : 404, name manquant, partial merge, transport change efface les champs incompatibles, `transport` undefined normalisé, rollback sur `addServer` failure

## Décisions

- **Pas de renommage** : rename = supprimer + recréer, l'utilisateur peut le faire manuellement
- **`disabledTools` conservés** : préférence utilisateur indépendante de la config de connexion
- **`cachedTools` conservés comme fallback** : si la reconnexion échoue, les outils précédemment découverts restent disponibles
- **Args séparés par espaces** : le champ `<input>` est mono-ligne, newline ne fonctionne pas
