### PR TITLE
Add per-agent model selection with ordered fallback cascades

### DIFF
--- a/src/server/agents/model-cascade.test.ts
+++ b/src/server/agents/model-cascade.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AgentDefinition } from './types.js'
+import type { LLMClientWithModel } from '../llm/client.js'
+
+const createRuntimeModelClient = vi.fn()
+vi.mock('../provider-manager.js', () => ({ createRuntimeModelClient }))
+
+const { resolveAgentLLMClient } = await import('./model-cascade.js')
+
+function client(model: string): LLMClientWithModel {
+  return {
+    getModel: () => model,
+    setModel: vi.fn(),
+    getProfile: vi.fn() as never,
+    getBackend: () => 'unknown',
+    setBackend: vi.fn(),
+    complete: vi.fn(),
+    async *stream() {},
+  }
+}
+
+function agent(
+  id: string,
+  subagent: boolean,
+  modelCascade?: Array<{ providerId: string; model: string }>,
+): AgentDefinition {
+  return {
+    metadata: {
+      id,
+      name: id,
+      description: '',
+      subagent,
+      allowedTools: [],
+      ...(modelCascade ? { modelCascade } : {}),
+    },
+    prompt: 'Prompt',
+  }
+}
+
+describe('resolveAgentLLMClient', () => {
+  beforeEach(() => createRuntimeModelClient.mockReset())
+
+  it('inherits the session client when no cascade is configured', () => {
+    const inherited = client('session-model')
+    expect(resolveAgentLLMClient(agent('planner', false), inherited)).toBe(inherited)
+    expect(createRuntimeModelClient).not.toHaveBeenCalled()
+  })
+
+  it('isolates top-level and sub-agent cascades', () => {
+    const plannerClient = client('planner-model')
+    const verifierClient = client('verifier-model')
+    createRuntimeModelClient.mockImplementation((providerId: string) =>
+      providerId === 'planner-provider' ? plannerClient : verifierClient,
+    )
+
+    const planner = resolveAgentLLMClient(
+      agent('planner', false, [{ providerId: 'planner-provider', model: 'planner-model' }]),
+      client('session'),
+    )
+    const verifier = resolveAgentLLMClient(
+      agent('verifier', true, [{ providerId: 'verifier-provider', model: 'verifier-model' }]),
+      client('session'),
+    )
+
+    expect(planner.getModel()).toBe('planner-model')
+    expect(verifier.getModel()).toBe('verifier-model')
+    expect(createRuntimeModelClient.mock.calls).toEqual([
+      ['planner-provider', 'planner-model'],
+      ['verifier-provider', 'verifier-model'],
+    ])
+  })
+})

--- a/src/server/agents/model-cascade.ts
+++ b/src/server/agents/model-cascade.ts
@@ -1,0 +1,15 @@
+import type { AgentDefinition } from './types.js'
+import type { LLMClientWithModel } from '../llm/client.js'
+import { createCascadingLLMClient } from '../llm/model-cascade.js'
+import { createRuntimeModelClient } from '../provider-manager.js'
+
+export function resolveAgentLLMClient(agent: AgentDefinition, inherited: LLMClientWithModel): LLMClientWithModel {
+  const refs = agent.metadata.modelCascade
+  if (!refs?.length) return inherited
+  const entries = refs.map((ref) => {
+    const client = createRuntimeModelClient(ref.providerId, ref.model)
+    if (!client) throw new Error(`Configured model not found: ${ref.providerId}/${ref.model}`)
+    return { ...ref, client }
+  })
+  return createCascadingLLMClient(entries)
+}

--- a/src/server/agents/registry.test.ts
+++ b/src/server/agents/registry.test.ts
@@ -154,6 +154,10 @@ describe('CRUD', () => {
         description: 'Test agent',
         subagent: true,
         allowedTools: ['read_file'],
+        modelCascade: [
+          { providerId: 'primary', model: 'model/a' },
+          { providerId: 'fallback', model: 'model-b' },
+        ],
       },
       prompt: 'Do the thing.',
     }
@@ -164,6 +168,10 @@ describe('CRUD', () => {
 
     expect(loaded).toBeDefined()
     expect(loaded!.metadata.name).toBe('My Agent')
+    expect(loaded!.metadata.modelCascade).toEqual([
+      { providerId: 'primary', model: 'model/a' },
+      { providerId: 'fallback', model: 'model-b' },
+    ])
     expect(loaded!.prompt).toBe('Do the thing.')
   })
 
@@ -185,6 +193,19 @@ describe('CRUD', () => {
 
     const agents = await loadAllAgents(tempDir)
     expect(agents.find((a) => a.metadata.id === 'deleteme')).toBeUndefined()
+  })
+
+  it('should delete a user override of a built-in agent and reveal the default', async () => {
+    const defaults = await loadDefaultAgents()
+    const planner = defaults.find((agent) => agent.metadata.id === 'planner')!
+    await saveAgent(tempDir, { ...planner, metadata: { ...planner.metadata, name: 'Overridden Planner' } })
+    expect((await loadAllAgents(tempDir)).find((agent) => agent.metadata.id === 'planner')?.metadata.name).toBe(
+      'Overridden Planner',
+    )
+    expect((await deleteAgent(tempDir, 'planner')).success).toBe(true)
+    expect((await loadAllAgents(tempDir)).find((agent) => agent.metadata.id === 'planner')?.metadata.name).toBe(
+      'Planner',
+    )
   })
 
   it('should not delete built-in default agents', async () => {

--- a/src/server/agents/registry.ts
+++ b/src/server/agents/registry.ts
@@ -56,6 +56,14 @@ function parseAgentFile(raw: string, filename: string): AgentDefinition | undefi
     allowedTools: Array.isArray(meta['allowedTools']) ? meta['allowedTools'].map(String) : [],
     ...(typeof meta['color'] === 'string' ? { color: meta['color'] } : {}),
     ...(Array.isArray(meta['results']) ? { results: meta['results'].map(String) } : {}),
+    ...(Array.isArray(meta['modelCascade'])
+      ? {
+          modelCascade: meta['modelCascade']
+            .filter((entry): entry is Record<string, unknown> => !!entry && typeof entry === 'object')
+            .map((entry) => ({ providerId: String(entry['providerId'] ?? ''), model: String(entry['model'] ?? '') }))
+            .filter((entry) => entry.providerId && entry.model),
+        }
+      : {}),
   }
 
   return { metadata, prompt: content.trim() }
@@ -226,19 +234,17 @@ export async function saveAgent(configDir: string, agent: AgentDefinition): Prom
 }
 
 export async function deleteAgent(configDir: string, agentId: string): Promise<{ success: boolean; reason?: string }> {
-  const isDefault = await isDefaultAgent(agentId)
-  if (isDefault) {
-    return { success: false, reason: 'Cannot delete built-in defaults' }
-  }
   const agentsDir = getAgentsDir(configDir)
   const paths = getAgentFilePaths(agentsDir, agentId)
   for (const filePath of paths) {
-    try {
+    if (await pathExists(filePath)) {
       await unlink(filePath)
       return { success: true }
-    } catch {
-      continue
     }
+  }
+  const isDefault = await isDefaultAgent(agentId)
+  if (isDefault) {
+    return { success: false, reason: 'Cannot delete built-in defaults' }
   }
   return { success: false }
 }

--- a/src/server/agents/types.ts
+++ b/src/server/agents/types.ts
@@ -2,6 +2,11 @@
  * Agent System Types
  */
 
+export interface AgentModelRef {
+  providerId: string
+  model: string
+}
+
 export interface AgentMetadata {
   id: string
   name: string
@@ -10,6 +15,7 @@ export interface AgentMetadata {
   allowedTools: string[]
   color?: string
   results?: string[]
+  modelCascade?: AgentModelRef[]
 }
 
 export interface AgentDefinition {

--- a/src/server/chat/agent-loop.ts
+++ b/src/server/chat/agent-loop.ts
@@ -266,15 +266,18 @@ export async function runTopLevelAgentLoop(
     const contextState = sessionManager.getContextState(sessionId)
     const previousContextTokens = contextState.currentTokens
 
-    const contextWindow = sessionManager.getCurrentModelContext()
+    const contextWindow = llmClient.getContextWindow?.() ?? sessionManager.getCurrentModelContext()
     const availableForOutput = Math.max(256, contextWindow - contextState.currentTokens)
 
+    const clientModelSettings = llmClient.getModelSettings?.()
+    const selectedModelSettings =
+      clientModelSettings === undefined ? sessionManager.getCurrentModelSettings() : (clientModelSettings ?? undefined)
     let modelSettings =
       currentMaxTokensOverride !== undefined
-        ? { ...sessionManager.getCurrentModelSettings(sessionId), maxTokens: currentMaxTokensOverride }
-        : sessionManager.getCurrentModelSettings(sessionId)
+        ? { ...selectedModelSettings, maxTokens: currentMaxTokensOverride }
+        : selectedModelSettings
 
-    if (modelSettings) {
+    if (modelSettings && clientModelSettings !== null) {
       const requestedMaxTokens = modelSettings.maxTokens ?? 16384
       modelSettings = { ...modelSettings, maxTokens: Math.min(requestedMaxTokens, availableForOutput) }
     }
@@ -288,12 +291,23 @@ export async function runTopLevelAgentLoop(
       toolChoice: 'auto',
       signal,
       ...(config.retryPatterns ? { retryPatterns: config.retryPatterns } : {}),
+      messageContext: {
+        ...(currentWindowMessageOptions ?? {}),
+        ...(config.subAgentMetadata
+          ? { subAgentId: config.subAgentMetadata.subAgentId, subAgentType: config.subAgentMetadata.subAgentType }
+          : {}),
+      },
       ...(modelSettings && { modelSettings }),
+      maxTokensLimit: availableForOutput,
     })
 
     const result = await consumeStreamGenerator(streamGen, (event) => {
       append(event)
     })
+    statsIdentity.model = llmClient.getModel()
+    statsIdentity.backend = llmClient.getBackend?.() ?? statsIdentity.backend
+    if (llmClient.getProviderId?.()) statsIdentity.providerId = llmClient.getProviderId()!
+    if (llmClient.getProviderName?.()) statsIdentity.providerName = llmClient.getProviderName()!
 
     // Check if a retry pattern matched mid-stream
     if (result.patternMatch) {
@@ -351,6 +365,7 @@ export async function runTopLevelAgentLoop(
       result.usage.completionTokens,
       previousContextTokens,
       result.modelParams,
+      { ...statsIdentity },
     )
     sessionManager.setCurrentContextSize(sessionId, result.usage.promptTokens, config.subAgentMetadata?.subAgentId)
 
@@ -374,7 +389,7 @@ export async function runTopLevelAgentLoop(
         truncationRetryCount += 1
         const currentMaxTokens = result.modelParams?.maxTokens ?? 16384
         const promptTokens = result.usage.promptTokens
-        const contextWindow = sessionManager.getCurrentModelContext()
+        const contextWindow = llmClient.getContextWindow?.() ?? sessionManager.getCurrentModelContext()
         const newMaxTokens = Math.min(Math.floor(currentMaxTokens * 1.5), contextWindow - promptTokens - 2048)
         currentMaxTokensOverride = newMaxTokens
         // Finalize the truncated assistant message so the frontend properly closes it

--- a/src/server/chat/orchestrator.ts
+++ b/src/server/chat/orchestrator.ts
@@ -33,6 +33,7 @@ import type { RequestContextMessage } from './request-context.js'
 import { buildCachedPrompt, computeDynamicContextHash, getToolFingerprint } from './dynamic-context.js'
 import { runTopLevelAgentLoop } from './agent-loop.js'
 import { loadAllAgentsDefault, findAgentById } from '../agents/registry.js'
+import { resolveAgentLLMClient } from '../agents/model-cascade.js'
 import { getAllInstructions } from '../context/instructions.js'
 import { getEnabledSkillMetadata } from '../skills/registry.js'
 import { getRuntimeConfig } from '../runtime-config.js'
@@ -337,6 +338,7 @@ export async function runAgentTurn(
   const statsIdentity = resolveStatsIdentity(options)
   const allAgents = await loadAllAgentsDefault()
   const agentDef = findAgentById(agentId, allAgents) ?? findAgentById('planner', allAgents)!
+  const agentLLMClient = resolveAgentLLMClient(agentDef, options.llmClient)
 
   if (!options.warmup) {
     injectAgentReminder(options.sessionId, agentDef)
@@ -357,7 +359,7 @@ export async function runAgentTurn(
       ...(await buildRetryPatterns()),
       sessionManager: options.sessionManager,
       sessionId: options.sessionId,
-      llmClient: options.llmClient,
+      llmClient: agentLLMClient,
       statsIdentity,
       signal: options.signal,
       onMessage: options.onMessage,
@@ -394,7 +396,7 @@ export async function runAgentTurn(
         })
       },
       getToolRegistry: () => getToolRegistryForAgent(agentDef),
-      getConversationMessages: buildGetConversationMessages(options.sessionId, options.llmClient, append),
+      getConversationMessages: buildGetConversationMessages(options.sessionId, agentLLMClient, append),
       injectAgentReminder: () => injectAgentReminder(options.sessionId, agentDef),
       ...(options.initialCompacting ? { initialCompacting: true } : {}),
       ...(callbacks?.injectKickoff ? { injectKickoff: callbacks.injectKickoff } : {}),

--- a/src/server/chat/stream-pure.test.ts
+++ b/src/server/chat/stream-pure.test.ts
@@ -99,6 +99,45 @@ describe('stream-pure', () => {
     })
   })
 
+  it('turns cascade fallback attempts into persistent system messages', async () => {
+    const client = createMockClient([
+      {
+        type: 'model_cascade_fallback',
+        fallback: { providerId: 'a', providerName: 'Primary', model: 'first', error: 'busy' },
+      },
+      { type: 'done', response: { ...mockResponse, content: '', toolCalls: [] } },
+    ])
+    const gen = streamLLMPure({
+      messageId: 'msg-fallback',
+      systemPrompt: 'system',
+      llmClient: client,
+      messages: [],
+      messageContext: { contextWindowId: 'window-1', subAgentId: 'sub-1', subAgentType: 'explorer' },
+    })
+    const events: Array<{ type: string; data: unknown }> = []
+    await consumeStreamGenerator(gen, (event) => events.push(event))
+
+    expect(events).toHaveLength(2)
+    expect(events[0]).toMatchObject({
+      type: 'message.start',
+      data: {
+        role: 'system',
+        contextWindowId: 'window-1',
+        subAgentId: 'sub-1',
+        subAgentType: 'explorer',
+        isSystemGenerated: true,
+        messageKind: 'model-fallback',
+      },
+    })
+    expect(JSON.parse((events[0]!.data as { content: string }).content)).toEqual({
+      providerId: 'a',
+      providerName: 'Primary',
+      model: 'first',
+      error: 'busy',
+    })
+    expect(events[1]).toMatchObject({ type: 'message.done' })
+  })
+
   it('streams partial arguments for run_command', async () => {
     const client = createMockClient([
       { type: 'tool_call_delta', index: 0, name: 'run_command' },

--- a/src/server/chat/stream-pure.ts
+++ b/src/server/chat/stream-pure.ts
@@ -54,8 +54,14 @@ export interface PureStreamOptions {
   reasoningEffort?: ReasoningEffort
   /** User-configured model settings (temperature, topP, topK, maxTokens, supportsVision) */
   modelSettings?: ModelParams & { supportsVision?: boolean }
+  maxTokensLimit?: number
   /** Retry patterns to check mid-stream */
   retryPatterns?: RetryPatternConfig[]
+  messageContext?: {
+    contextWindowId?: string
+    subAgentId?: string
+    subAgentType?: string
+  }
 }
 
 export interface PureStreamResult {
@@ -198,6 +204,7 @@ export async function* streamLLMPure(options: PureStreamOptions): AsyncGenerator
     reasoningEffort,
     signal: combinedSignal,
     modelSettings: options.modelSettings,
+    maxTokensLimit: options.maxTokensLimit,
   })
 
   // Track tool call indices we've emitted preparing events for
@@ -214,6 +221,7 @@ export async function* streamLLMPure(options: PureStreamOptions): AsyncGenerator
   let accumulatedContent = ''
   let accumulatedThinking = ''
   let patternMatch: RetryPatternMatch | undefined
+  let streamError: string | undefined
 
   const activePatterns = retryPatterns?.filter((p) => p.active) ?? []
 
@@ -336,14 +344,22 @@ export async function* streamLLMPure(options: PureStreamOptions): AsyncGenerator
           break
         }
 
+        case 'model_cascade_fallback': {
+          const fallbackMessageId = crypto.randomUUID()
+          yield createMessageStartEvent(fallbackMessageId, 'system', JSON.stringify(value.fallback), {
+            ...options.messageContext,
+            isSystemGenerated: true,
+            messageKind: 'model-fallback',
+          })
+          yield createMessageDoneEvent(fallbackMessageId)
+          break
+        }
+
         case 'error':
           // Suppress chat.error when user-initiated abort caused the error —
           // the agent loop handles abort gracefully via signal check + emitPartialDoneEvents.
           if (signal?.aborted) break
-          yield {
-            type: 'chat.error',
-            data: { error: value.error, recoverable: true },
-          }
+          streamError = value.error
           break
       }
 
@@ -364,6 +380,8 @@ export async function* streamLLMPure(options: PureStreamOptions): AsyncGenerator
       throw error
     }
   }
+
+  if (streamError) throw new Error(streamError)
 
   // Pattern match took precedence over normal result
   if (patternMatch) {
@@ -421,7 +439,8 @@ export class TurnMetrics {
   private totalGenTime = 0 // seconds
   private totalToolTime = 0 // seconds
   private llmCalls: Array<
-    Omit<NonNullable<MessageStats['llmCalls']>[number], 'providerId' | 'providerName' | 'backend' | 'model'>
+    Omit<NonNullable<MessageStats['llmCalls']>[number], 'providerId' | 'providerName' | 'backend' | 'model'> &
+      Partial<StatsIdentity>
   > = []
   private modelParams: ModelParams = {}
 
@@ -438,6 +457,7 @@ export class TurnMetrics {
     completionTokens: number,
     previousContextTokens?: number,
     modelParams?: ModelParams,
+    identity?: StatsIdentity,
   ): void {
     const callIndex = this.llmCalls.length + 1
     this.totalPrefillTokens += promptTokens
@@ -456,6 +476,7 @@ export class TurnMetrics {
     this.llmCalls = [
       ...this.llmCalls,
       {
+        ...(identity ?? {}),
         callIndex,
         promptTokens,
         completionTokens,
@@ -497,10 +518,7 @@ export class TurnMetrics {
       totalGenTime: this.totalGenTime,
       totalToolTime: this.totalToolTime,
       totalTime: (performance.now() - this.startTime) / 1000,
-      llmCalls: this.llmCalls.map((call) => ({
-        ...identity,
-        ...call,
-      })),
+      llmCalls: this.llmCalls.map((call) => ({ ...identity, ...call })),
     })
   }
 }
@@ -521,7 +539,14 @@ export function createMessageStartEvent(
     subAgentId?: string
     subAgentType?: string
     isSystemGenerated?: boolean
-    messageKind?: 'correction' | 'auto-prompt' | 'context-reset' | 'task-completed' | 'workflow-started' | 'command'
+    messageKind?:
+      | 'correction'
+      | 'auto-prompt'
+      | 'context-reset'
+      | 'task-completed'
+      | 'workflow-started'
+      | 'command'
+      | 'model-fallback'
     metadata?: { type: string; name: string; color: string }
   },
 ): TurnEvent {

--- a/src/server/chat/stream-utils.ts
+++ b/src/server/chat/stream-utils.ts
@@ -10,8 +10,9 @@ function buildStreamRequestObject(params: {
   modelSettings?:
     | { temperature?: number; topP?: number; topK?: number; maxTokens?: number; supportsVision?: boolean }
     | undefined
+  maxTokensLimit?: number | undefined
 }): LLMCompletionRequest {
-  const { messages, tools, toolChoice, reasoningEffort, signal, modelSettings } = params
+  const { messages, tools, toolChoice, reasoningEffort, signal, modelSettings, maxTokensLimit } = params
   return {
     messages,
     ...(tools && { tools }),
@@ -19,6 +20,7 @@ function buildStreamRequestObject(params: {
     ...(reasoningEffort && { reasoningEffort }),
     ...(signal && { signal }),
     ...(modelSettings && { modelSettings }),
+    ...(maxTokensLimit !== undefined && { maxTokensLimit }),
   }
 }
 

--- a/src/server/db/settings.test.ts
+++ b/src/server/db/settings.test.ts
@@ -1,7 +1,15 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 import { loadConfig } from '../config.js'
 import { closeDatabase, initDatabase } from './index.js'
-import { SETTINGS_KEYS, deleteSetting, getAllSettings, getSetting, setSetting } from './settings.js'
+import {
+  SETTINGS_DEFAULTS,
+  SETTINGS_KEYS,
+  deleteSetting,
+  getAllSettings,
+  getSetting,
+  setSetting,
+  validateSettingValue,
+} from './settings.js'
 
 describe('db settings', () => {
   beforeEach(() => {
@@ -9,6 +17,14 @@ describe('db settings', () => {
     const config = loadConfig()
     config.database.path = ':memory:'
     initDatabase(config)
+  })
+
+  it('defines and validates cascade cooldown settings', () => {
+    expect(SETTINGS_DEFAULTS[SETTINGS_KEYS.MODEL_CASCADE_OVERLOAD_COOLDOWN_MS]).toBe('1200000')
+    expect(SETTINGS_DEFAULTS[SETTINGS_KEYS.MODEL_CASCADE_TRANSIENT_COOLDOWN_MS]).toBe('120000')
+    expect(validateSettingValue(SETTINGS_KEYS.MODEL_CASCADE_OVERLOAD_COOLDOWN_MS, '60000')).toBeNull()
+    expect(validateSettingValue(SETTINGS_KEYS.MODEL_CASCADE_TRANSIENT_COOLDOWN_MS, '-1')).toContain('non-negative')
+    expect(validateSettingValue(SETTINGS_KEYS.MODEL_CASCADE_TRANSIENT_COOLDOWN_MS, 'invalid')).toContain('non-negative')
   })
 
   it('gets, sets, updates, deletes, and lists settings', () => {

--- a/src/server/db/settings.ts
+++ b/src/server/db/settings.ts
@@ -28,6 +28,8 @@ export const SETTINGS_KEYS = {
   SEARCH_SEARXNG_API_KEY: 'search.searxngApiKey',
   TOOLS_USE_RTK: 'tools.useRtk',
   TOOLS_SHELL: 'tools.shell',
+  MODEL_CASCADE_OVERLOAD_COOLDOWN_MS: 'llm.modelCascadeOverloadCooldownMs',
+  MODEL_CASCADE_TRANSIENT_COOLDOWN_MS: 'llm.modelCascadeTransientCooldownMs',
 } as const
 
 export const SETTINGS_DEFAULTS: Record<string, string> = {
@@ -44,6 +46,8 @@ export const SETTINGS_DEFAULTS: Record<string, string> = {
   [SETTINGS_KEYS.LLM_DYNAMIC_SYSTEM_PROMPT]: 'false',
   [SETTINGS_KEYS.CACHE_WARMING]: 'false',
   [SETTINGS_KEYS.RETRY_PATTERNS]: JSON.stringify({ patterns: [], maxRetriesPerTurn: 10 }),
+  [SETTINGS_KEYS.MODEL_CASCADE_OVERLOAD_COOLDOWN_MS]: '1200000',
+  [SETTINGS_KEYS.MODEL_CASCADE_TRANSIENT_COOLDOWN_MS]: '120000',
   [SETTINGS_KEYS.KEYBINDINGS]: JSON.stringify({
     terminalToggle: { type: 'double-press', key: 'Control', threshold: 300 },
     quickAction: { type: 'double-press', key: 'Shift', threshold: 300 },
@@ -59,6 +63,17 @@ export const SETTINGS_DEFAULTS: Record<string, string> = {
 }
 
 export type SettingsKey = (typeof SETTINGS_KEYS)[keyof typeof SETTINGS_KEYS]
+
+export function validateSettingValue(key: string, value: unknown): string | null {
+  if (
+    key !== SETTINGS_KEYS.MODEL_CASCADE_OVERLOAD_COOLDOWN_MS &&
+    key !== SETTINGS_KEYS.MODEL_CASCADE_TRANSIENT_COOLDOWN_MS
+  ) {
+    return null
+  }
+  const duration = Number(value)
+  return Number.isFinite(duration) && duration >= 0 ? null : 'Cooldown must be non-negative'
+}
 
 interface SettingsRow {
   key: string

--- a/src/server/events/apply-events.ts
+++ b/src/server/events/apply-events.ts
@@ -25,7 +25,14 @@ export interface MessageFragment {
   subAgentId?: string
   subAgentType?: string
   isSystemGenerated?: boolean
-  messageKind?: 'correction' | 'auto-prompt' | 'context-reset' | 'task-completed' | 'workflow-started' | 'command'
+  messageKind?:
+    | 'correction'
+    | 'auto-prompt'
+    | 'context-reset'
+    | 'task-completed'
+    | 'workflow-started'
+    | 'command'
+    | 'model-fallback'
   isCompactionSummary?: boolean
   attachments?: unknown[]
   metadata?: unknown

--- a/src/server/events/folding.test.ts
+++ b/src/server/events/folding.test.ts
@@ -20,6 +20,34 @@ const baseEvent = {
 }
 
 describe('apply-events.ts new handlers', () => {
+  it('persists model fallback messages while excluding them from LLM context', () => {
+    const content = JSON.stringify({ providerId: 'a', providerName: 'Primary', model: 'first', error: 'busy' })
+    const events: StoredEvent[] = [
+      {
+        ...baseEvent,
+        type: 'message.start',
+        data: {
+          messageId: 'fallback-1',
+          role: 'system',
+          content,
+          contextWindowId: 'window-1',
+          isSystemGenerated: true,
+          messageKind: 'model-fallback',
+        },
+      },
+      { ...baseEvent, seq: 2, type: 'message.done', data: { messageId: 'fallback-1' } },
+    ]
+
+    expect(buildMessagesFromStoredEvents(events)[0]).toMatchObject({
+      id: 'fallback-1',
+      role: 'system',
+      content,
+      messageKind: 'model-fallback',
+      isStreaming: false,
+    })
+    expect(buildContextMessagesFromStoredEvents(events, 'window-1')).toEqual([])
+  })
+
   describe('tool.output events', () => {
     it('populates streamingOutput on tool calls', () => {
       const events: StoredEvent[] = [

--- a/src/server/events/session.ts
+++ b/src/server/events/session.ts
@@ -246,7 +246,14 @@ export function emitUserMessage(
   options?: {
     contextWindowId?: string
     isSystemGenerated?: boolean
-    messageKind?: 'correction' | 'auto-prompt' | 'context-reset' | 'task-completed' | 'workflow-started' | 'command'
+    messageKind?:
+      | 'correction'
+      | 'auto-prompt'
+      | 'context-reset'
+      | 'task-completed'
+      | 'workflow-started'
+      | 'command'
+      | 'model-fallback'
     isCompactionSummary?: boolean
     tokenCount?: number
     attachments?: Attachment[] // Optional image attachments

--- a/src/server/events/types.ts
+++ b/src/server/events/types.ts
@@ -70,7 +70,14 @@ export type TurnEvent =
         subAgentId?: string
         subAgentType?: string
         isSystemGenerated?: boolean
-        messageKind?: 'correction' | 'auto-prompt' | 'context-reset' | 'task-completed' | 'workflow-started' | 'command'
+        messageKind?:
+          | 'correction'
+          | 'auto-prompt'
+          | 'context-reset'
+          | 'task-completed'
+          | 'workflow-started'
+          | 'command'
+          | 'model-fallback'
         isCompactionSummary?: boolean // True if this is the summary message after compaction
         tokenCount?: number // Known upfront for user messages
         attachments?: Attachment[] // Optional image attachments
@@ -506,7 +513,14 @@ export interface SnapshotMessage {
   subAgentId?: string
   subAgentType?: string
   isSystemGenerated?: boolean
-  messageKind?: 'correction' | 'auto-prompt' | 'context-reset' | 'task-completed' | 'workflow-started' | 'command'
+  messageKind?:
+    | 'correction'
+    | 'auto-prompt'
+    | 'context-reset'
+    | 'task-completed'
+    | 'workflow-started'
+    | 'command'
+    | 'model-fallback'
   contextWindowId?: string
   isCompactionSummary?: boolean
   attachments?: Attachment[] // Optional image attachments

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1092,21 +1092,16 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
     res.json({ key, value })
   })
 
-  app.get('/api/settings/:key', async (req, res) => {
-    const { getSetting, SETTINGS_DEFAULTS } = await import('./db/settings.js')
-    const key = req.params.key
-    const value = getSetting(key) ?? SETTINGS_DEFAULTS[key] ?? null
-    res.json({ key, value })
-  })
-
   app.put('/api/settings/:key', async (req, res) => {
-    const { setSetting } = await import('./db/settings.js')
+    const { setSetting, validateSettingValue } = await import('./db/settings.js')
     const key = req.params.key
     const { value } = req.body
     if (value === undefined) {
       return res.status(400).json({ error: 'value is required' })
     }
-    setSetting(key, value)
+    const validationError = validateSettingValue(key, value)
+    if (validationError) return res.status(400).json({ error: validationError })
+    setSetting(key, String(value))
     res.json({ key, value })
   })
 
@@ -2050,7 +2045,10 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
   const projectDir = config.workdir
   app.use('/api/skills', createSkillRoutes(configDir, projectDir))
   app.use('/api/commands', createCommandRoutes(configDir, projectDir))
-  app.use('/api/agents', createAgentRoutes(configDir, projectDir))
+  app.use(
+    '/api/agents',
+    createAgentRoutes(configDir, projectDir, () => providerManager.getProviders()),
+  )
   app.use('/api/workflows', createWorkflowRoutes(configDir, config, projectDir))
   app.use('/api/dev-server', createDevServerRoutes())
   app.use('/api/workspace', createWorkspaceConfigRoutes())

--- a/src/server/llm/client.test.ts
+++ b/src/server/llm/client.test.ts
@@ -309,7 +309,7 @@ describe('llm client', () => {
         stream: true,
         chat_template_kwargs: { enable_thinking: false },
       }),
-      { signal: undefined },
+      { signal: expect.any(AbortSignal) },
     )
     // Should NOT have reasoning_effort in the params
     const callArgs = httpClientCreateStreamMock.mock.calls[0]?.[0] as Record<string, unknown> | undefined
@@ -453,7 +453,9 @@ describe('llm client', () => {
       events.push(event as Record<string, unknown>)
     }
 
-    expect(events).toEqual([{ type: 'error', error: 'stream failed' }])
+    expect(events).toEqual([
+      { type: 'error', error: 'stream failed', metadata: { kind: 'network', message: 'stream failed' } },
+    ])
   })
 
   it('surfaces error chunks that do not contain choices', async () => {
@@ -583,7 +585,11 @@ describe('llm client', () => {
     expect(events).toEqual([
       { type: 'text_delta', content: 'first chunk' },
       { type: 'text_delta', content: 'second chunk' },
-      { type: 'error', error: expect.stringContaining('idle timeout') },
+      {
+        type: 'error',
+        error: expect.stringContaining('idle timeout'),
+        metadata: { kind: 'timeout', message: expect.stringContaining('idle timeout') },
+      },
     ])
   })
 

--- a/src/server/llm/client.ts
+++ b/src/server/llm/client.ts
@@ -27,6 +27,10 @@ export interface LLMClientWithModel extends LLMClient {
   getProfile(): ModelProfile
   getBackend(): Backend
   setBackend(backend: Backend): void
+  getContextWindow?(): number
+  getModelSettings?(): LLMCompletionRequest['modelSettings'] | null
+  getProviderId?(): string
+  getProviderName?(): string
 }
 
 export function createLLMClient(config: Config, initialBackend: Backend = 'unknown'): LLMClientWithModel {
@@ -140,8 +144,10 @@ export function createLLMClient(config: Config, initialBackend: Backend = 'unkno
         }
       } catch (error: unknown) {
         logger.error('LLM complete error', { error: String(error) })
+        if (error instanceof LLMError) throw error
         throw new LLMError(error instanceof Error ? error.message : 'Unknown LLM error', {
-          originalError: error instanceof Error ? error : undefined,
+          kind: error instanceof DOMException && error.name === 'AbortError' ? 'abort' : 'network',
+          message: error instanceof Error ? error.message : 'Unknown LLM error',
         })
       }
     },
@@ -170,9 +176,11 @@ export function createLLMClient(config: Config, initialBackend: Backend = 'unkno
         })
 
         const { params: streamingParams } = createParams
-        const stream = httpClient.createChatCompletionStream(streamingParams, {
-          signal: request.signal,
-        })
+        const idleTimeoutController = new AbortController()
+        const streamSignal = request.signal
+          ? AbortSignal.any([request.signal, idleTimeoutController.signal])
+          : idleTimeoutController.signal
+        const stream = httpClient.createChatCompletionStream(streamingParams, { signal: streamSignal })
 
         let fullContent = ''
         let fullThinking = ''
@@ -183,7 +191,6 @@ export function createLLMClient(config: Config, initialBackend: Backend = 'unkno
 
         // Idle timeout tracking
         let lastChunkTime = Date.now()
-        const idleTimeoutController = new AbortController()
 
         // Start idle timeout timer
         const idleTimer = setInterval(() => {
@@ -333,9 +340,22 @@ export function createLLMClient(config: Config, initialBackend: Backend = 'unkno
         }
       } catch (error) {
         logger.error('LLM stream error', { error })
+        const metadata =
+          error instanceof LLMError && error.details && typeof error.details === 'object'
+            ? (error.details as import('./types.js').LLMErrorMetadata)
+            : {
+                kind: request.signal?.aborted
+                  ? ('abort' as const)
+                  : (error instanceof DOMException && error.name === 'AbortError') ||
+                      (error instanceof Error && error.message.includes('idle timeout'))
+                    ? ('timeout' as const)
+                    : ('network' as const),
+                message: error instanceof Error ? error.message : 'Unknown LLM error',
+              }
         yield {
           type: 'error',
           error: error instanceof Error ? error.message : 'Unknown LLM error',
+          metadata,
         }
       }
     },

--- a/src/server/llm/http-client.test.ts
+++ b/src/server/llm/http-client.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { LLMError } from '../utils/errors.js'
+import { OpenAIHttpClient } from './http-client.js'
+
+const params = { model: 'test', messages: [], stream: false } as never
+
+describe('OpenAIHttpClient Retry-After', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('parses Retry-After seconds into structured error metadata', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response('busy', { status: 429, headers: { 'Retry-After': '30' } })),
+    )
+    const client = new OpenAIHttpClient({ baseURL: 'http://localhost/v1', apiKey: 'key' })
+    const error = await client.createChatCompletion(params).catch((caught) => caught)
+    expect(error).toBeInstanceOf(LLMError)
+    expect((error as LLMError).details).toMatchObject({ kind: 'overload', status: 429, retryAfterMs: 30_000 })
+  })
+
+  it('ignores invalid Retry-After values so the configured default is used', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response('busy', { status: 503, headers: { 'Retry-After': 'invalid' } })),
+    )
+    const client = new OpenAIHttpClient({ baseURL: 'http://localhost/v1', apiKey: 'key' })
+    const error = await client.createChatCompletion(params).catch((caught) => caught)
+    expect((error as LLMError).details).toMatchObject({ kind: 'overload', status: 503 })
+    expect((error as LLMError).details).not.toHaveProperty('retryAfterMs')
+  })
+})

--- a/src/server/llm/http-client.ts
+++ b/src/server/llm/http-client.ts
@@ -47,7 +47,19 @@ export class OpenAIHttpClient {
 
     if (!response.ok) {
       const errorText = await response.text()
-      throw new LLMError(`HTTP ${response.status}: ${errorText}`)
+      const retryAfter = response.headers.get('retry-after')
+      let retryAfterMs: number | undefined
+      if (retryAfter) {
+        const seconds = Number(retryAfter)
+        const parsed = Number.isFinite(seconds) ? seconds * 1000 : Date.parse(retryAfter) - Date.now()
+        if (Number.isFinite(parsed) && parsed >= 0) retryAfterMs = parsed
+      }
+      throw new LLMError(`HTTP ${response.status}: ${errorText}`, {
+        kind: response.status === 429 || response.status === 503 ? 'overload' : 'http',
+        status: response.status,
+        ...(retryAfterMs !== undefined ? { retryAfterMs } : {}),
+        message: errorText,
+      })
     }
 
     return response
@@ -117,6 +129,11 @@ export class OpenAIHttpClient {
           }
         }
       } finally {
+        try {
+          await reader.cancel()
+        } catch {
+          void 0
+        }
         reader.releaseLock()
       }
     }

--- a/src/server/llm/model-cascade.test.ts
+++ b/src/server/llm/model-cascade.test.ts
@@ -1,0 +1,354 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { LLMClientWithModel } from './client.js'
+import { createCascadingLLMClient, modelCooldownRegistry } from './model-cascade.js'
+
+function client(model: string, events: Array<Record<string, unknown>>, onStream?: () => void): LLMClientWithModel {
+  return {
+    getModel: () => model,
+    setModel: vi.fn(),
+    getProfile: vi.fn() as never,
+    getBackend: () => 'unknown',
+    setBackend: vi.fn(),
+    complete: vi.fn(),
+    async *stream() {
+      onStream?.()
+      for (const event of events) yield event as never
+    },
+  }
+}
+
+async function collect<T>(iterable: AsyncIterable<T>): Promise<T[]> {
+  const result: T[] = []
+  for await (const item of iterable) result.push(item)
+  return result
+}
+
+describe('model cascade', () => {
+  beforeEach(() => modelCooldownRegistry.clear())
+
+  it('falls back before output and keeps priority on the next call', async () => {
+    const first = client('first', [{ type: 'error', error: 'busy', metadata: { kind: 'http', status: 429 } }])
+    const second = client('second', [
+      {
+        type: 'done',
+        response: {
+          id: '2',
+          content: 'ok',
+          finishReason: 'stop',
+          usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+        },
+      },
+    ])
+    const cascade = createCascadingLLMClient([
+      { providerId: 'a', model: 'first', client: first },
+      { providerId: 'b', model: 'second', client: second },
+    ])
+
+    const events = await collect(cascade.stream({ messages: [] }))
+    expect(events).toEqual([
+      {
+        type: 'model_cascade_fallback',
+        fallback: {
+          providerId: 'a',
+          providerName: 'a',
+          model: 'first',
+          error: 'busy',
+        },
+      },
+      expect.objectContaining({ type: 'done' }),
+    ])
+    expect(modelCooldownRegistry.get('a', 'first')?.kind).toBe('cooldown')
+    const secondCall = await collect(cascade.stream({ messages: [] }))
+    expect(secondCall.at(-1)?.type).toBe('done')
+  })
+
+  it('calls models in exact order and restores the first priority after cooldown expiry', async () => {
+    vi.useFakeTimers()
+    const calls: string[] = []
+    let firstFails = true
+    const first = client('first', [], () => calls.push('first'))
+    first.stream = async function* () {
+      calls.push('first')
+      if (firstFails) {
+        yield { type: 'error', error: 'network', metadata: { kind: 'network' } }
+      } else {
+        yield {
+          type: 'done',
+          response: {
+            id: '1',
+            content: 'first',
+            finishReason: 'stop',
+            usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+          },
+        }
+      }
+    }
+    const second = client(
+      'second',
+      [
+        {
+          type: 'done',
+          response: {
+            id: '2',
+            content: 'second',
+            finishReason: 'stop',
+            usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+          },
+        },
+      ],
+      () => calls.push('second'),
+    )
+    const cascade = createCascadingLLMClient([
+      { providerId: 'a', model: 'first', client: first },
+      { providerId: 'b', model: 'second', client: second },
+    ])
+
+    await collect(cascade.stream({ messages: [] }))
+    expect(calls).toEqual(['first', 'second'])
+    calls.length = 0
+    await collect(cascade.stream({ messages: [] }))
+    expect(calls).toEqual(['second'])
+    vi.advanceTimersByTime(120_001)
+    firstFails = false
+    calls.length = 0
+    await collect(cascade.stream({ messages: [] }))
+    expect(calls).toEqual(['first'])
+    vi.useRealTimers()
+  })
+
+  it('classifies 503 as overload and request-specific 400 and other 5xx as transient', () => {
+    vi.useFakeTimers()
+    const now = Date.now()
+    modelCooldownRegistry.mark('a', 'overload', { kind: 'http', status: 503 })
+    modelCooldownRegistry.mark('a', 'bad-request', { kind: 'http', status: 400 })
+    modelCooldownRegistry.mark('a', 'server', { kind: 'http', status: 500 })
+    expect(modelCooldownRegistry.get('a', 'overload')?.until).toBe(now + 1_200_000)
+    expect(modelCooldownRegistry.get('a', 'bad-request')).toMatchObject({
+      kind: 'cooldown',
+      until: now + 120_000,
+    })
+    expect(modelCooldownRegistry.get('a', 'server')?.until).toBe(now + 120_000)
+    vi.useRealTimers()
+  })
+
+  it('preserves each fallback model settings and applies the output limit independently', async () => {
+    const requests: Array<{ modelSettings?: { maxTokens?: number; temperature?: number } }> = []
+    const first = client('first', [])
+    const second = client('second', [])
+    first.getModelSettings = () => ({ maxTokens: 1_000, temperature: 0.2 })
+    second.getModelSettings = () => ({ maxTokens: 2_000, temperature: 0.4 })
+    first.stream = async function* (request) {
+      requests.push(request)
+      yield { type: 'error', error: 'busy', metadata: { kind: 'network' } }
+    }
+    second.stream = async function* (request) {
+      requests.push(request)
+      yield {
+        type: 'done',
+        response: {
+          id: '2',
+          content: 'ok',
+          finishReason: 'stop',
+          usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+        },
+      }
+    }
+    const cascade = createCascadingLLMClient([
+      { providerId: 'a', model: 'first', client: first },
+      { providerId: 'b', model: 'second', client: second },
+    ])
+
+    expect(cascade.getModelSettings?.()).toBeNull()
+    await collect(cascade.stream({ messages: [], maxTokensLimit: 1_500 }))
+    expect(requests.map((request) => request.modelSettings)).toEqual([
+      { maxTokens: 1_000, temperature: 0.2 },
+      { maxTokens: 1_500, temperature: 0.4 },
+    ])
+  })
+
+  it('preserves request-specific settings over each model default', async () => {
+    const requests: Array<{ modelSettings?: { maxTokens?: number; temperature?: number } }> = []
+    const first = client('first', [{ type: 'error', error: 'busy', metadata: { kind: 'network' } }])
+    const second = client('second', [
+      {
+        type: 'done',
+        response: {
+          id: '2',
+          content: 'ok',
+          finishReason: 'stop',
+          usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+        },
+      },
+    ])
+    first.getModelSettings = () => ({ maxTokens: 1_000, temperature: 0.2 })
+    second.getModelSettings = () => ({ maxTokens: 2_000, temperature: 0.4 })
+    first.stream = async function* (request) {
+      requests.push(request)
+      yield { type: 'error', error: 'busy', metadata: { kind: 'network' } }
+    }
+    second.stream = async function* (request) {
+      requests.push(request)
+      yield {
+        type: 'done',
+        response: {
+          id: '2',
+          content: 'ok',
+          finishReason: 'stop',
+          usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+        },
+      }
+    }
+    const cascade = createCascadingLLMClient([
+      { providerId: 'a', model: 'first', client: first },
+      { providerId: 'b', model: 'second', client: second },
+    ])
+
+    await collect(cascade.stream({ messages: [], modelSettings: { maxTokens: 3_000 } }))
+    expect(requests.map((request) => request.modelSettings)).toEqual([
+      { maxTokens: 3_000, temperature: 0.2 },
+      { maxTokens: 3_000, temperature: 0.4 },
+    ])
+  })
+
+  it('exposes the successful fallback identity for stats attribution', async () => {
+    const first = client('first', [{ type: 'error', error: 'busy', metadata: { kind: 'network' } }])
+    const second = client('second', [
+      {
+        type: 'done',
+        response: {
+          id: '2',
+          content: 'ok',
+          finishReason: 'stop',
+          usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+        },
+      },
+    ])
+    first.getProviderName = () => 'Primary'
+    second.getProviderName = () => 'Fallback'
+    const cascade = createCascadingLLMClient([
+      { providerId: 'a', model: 'first', client: first },
+      { providerId: 'b', model: 'second', client: second },
+    ])
+    await collect(cascade.stream({ messages: [] }))
+    expect(cascade.getModel()).toBe('second')
+    expect(cascade.getProviderId?.()).toBe('b')
+    expect(cascade.getProviderName?.()).toBe('Fallback')
+  })
+
+  it('reports each failed model before trying the next one', async () => {
+    const first = client('first', [{ type: 'error', error: 'first failed', metadata: { kind: 'network' } }])
+    const second = client('second', [{ type: 'error', error: 'second failed', metadata: { kind: 'network' } }])
+    const third = client('third', [
+      {
+        type: 'done',
+        response: {
+          id: '3',
+          content: 'ok',
+          finishReason: 'stop',
+          usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+        },
+      },
+    ])
+    first.getProviderName = () => 'Primary'
+    second.getProviderName = () => 'Secondary'
+    const cascade = createCascadingLLMClient([
+      { providerId: 'a', model: 'first', client: first },
+      { providerId: 'b', model: 'second', client: second },
+      { providerId: 'c', model: 'third', client: third },
+    ])
+
+    const events = await collect(cascade.stream({ messages: [] }))
+    expect(events.filter((event) => event.type === 'model_cascade_fallback')).toEqual([
+      {
+        type: 'model_cascade_fallback',
+        fallback: { providerId: 'a', providerName: 'Primary', model: 'first', error: 'first failed' },
+      },
+      {
+        type: 'model_cascade_fallback',
+        fallback: { providerId: 'b', providerName: 'Secondary', model: 'second', error: 'second failed' },
+      },
+    ])
+  })
+
+  it('does not fall back on an abort error', async () => {
+    const first = client('first', [{ type: 'error', error: 'aborted', metadata: { kind: 'abort' } }])
+    const secondStream = vi.fn()
+    const second = client('second', [], secondStream)
+    const cascade = createCascadingLLMClient([
+      { providerId: 'a', model: 'first', client: first },
+      { providerId: 'b', model: 'second', client: second },
+    ])
+
+    expect(await collect(cascade.stream({ messages: [] }))).toEqual([
+      { type: 'error', error: 'aborted', metadata: { kind: 'abort' } },
+    ])
+    expect(secondStream).not.toHaveBeenCalled()
+  })
+
+  it('does not fall back after a tool-call delta', async () => {
+    const first = client('first', [
+      { type: 'tool_call_delta', index: 0, name: 'read_file' },
+      { type: 'error', error: 'failed', metadata: { kind: 'network' } },
+    ])
+    const second = client('second', [{ type: 'done', response: {} }])
+    const cascade = createCascadingLLMClient([
+      { providerId: 'a', model: 'first', client: first },
+      { providerId: 'b', model: 'second', client: second },
+    ])
+    expect((await collect(cascade.stream({ messages: [] }))).map((event) => event.type)).toEqual([
+      'tool_call_delta',
+      'error',
+    ])
+  })
+
+  it('does not fall back after visible output', async () => {
+    const first = client('first', [
+      { type: 'text_delta', content: 'partial' },
+      { type: 'error', error: 'failed', metadata: { kind: 'network' } },
+    ])
+    const second = client('second', [{ type: 'done', response: {} }])
+    const cascade = createCascadingLLMClient([
+      { providerId: 'a', model: 'first', client: first },
+      { providerId: 'b', model: 'second', client: second },
+    ])
+
+    const events = await collect(cascade.stream({ messages: [] }))
+    expect(events.map((event) => event.type)).toEqual(['text_delta', 'error'])
+  })
+
+  it('expires transient cooldowns', () => {
+    vi.useFakeTimers()
+    modelCooldownRegistry.mark('a', 'network', { kind: 'network' }, 60_000, 2_000)
+    expect(modelCooldownRegistry.get('a', 'network')).toBeDefined()
+    vi.advanceTimersByTime(2_001)
+    expect(modelCooldownRegistry.get('a', 'network')).toBeUndefined()
+    vi.useRealTimers()
+  })
+
+  it('uses Retry-After and marks configuration errors until cleared', () => {
+    const now = Date.now()
+    modelCooldownRegistry.mark('a', 'quota', { kind: 'overload', status: 429, retryAfterMs: 30_000 }, 60_000, 2_000)
+    const quota = modelCooldownRegistry.get('a', 'quota')
+    expect(quota?.until).toBeGreaterThanOrEqual(now + 29_000)
+    modelCooldownRegistry.mark('a', 'invalid', { kind: 'http', status: 401 }, 60_000, 2_000)
+    expect(modelCooldownRegistry.get('a', 'invalid')).toMatchObject({ kind: 'configuration' })
+    modelCooldownRegistry.clearProvider('a')
+    expect(modelCooldownRegistry.get('a', 'invalid')).toBeUndefined()
+  })
+
+  it('fails immediately and lists every unavailable model with delay or reason', async () => {
+    modelCooldownRegistry.mark('a', 'first', { kind: 'http', status: 429 }, 60_000, 2_000)
+    modelCooldownRegistry.mark('b', 'second', { kind: 'http', status: 401 }, 60_000, 2_000)
+    const first = client('first', [])
+    const second = client('second', [])
+    const cascade = createCascadingLLMClient([
+      { providerId: 'a', model: 'first', client: first },
+      { providerId: 'b', model: 'second', client: second },
+    ])
+    const events = await collect(cascade.stream({ messages: [] }))
+    expect(events[0]).toMatchObject({ type: 'error' })
+    const error = (events[0] as { error: string }).error
+    expect(error).toContain('a/first: 60s remaining')
+    expect(error).toContain('b/second: HTTP 401; unavailable until provider configuration changes')
+  })
+})

--- a/src/server/llm/model-cascade.ts
+++ b/src/server/llm/model-cascade.ts
@@ -1,0 +1,204 @@
+import type { LLMClientWithModel } from './client.js'
+import type { LLMCompletionRequest, LLMErrorMetadata, LLMStreamEvent } from './types.js'
+import { LLMError } from '../utils/errors.js'
+import { getSetting, SETTINGS_DEFAULTS, SETTINGS_KEYS } from '../db/settings.js'
+
+interface CascadeEntry {
+  providerId: string
+  model: string
+  client: LLMClientWithModel
+}
+
+interface UnavailableState {
+  kind: 'cooldown' | 'configuration'
+  until?: number
+  reason: string
+}
+
+function settingMs(key: string): number {
+  const fallback = Number(SETTINGS_DEFAULTS[key])
+  const value = Number(getSetting(key) ?? fallback)
+  return Number.isFinite(value) && value >= 0 ? value : fallback
+}
+
+class ModelCooldownRegistry {
+  private states = new Map<string, UnavailableState>()
+
+  private key(providerId: string, model: string): string {
+    return `${providerId}\u0000${model}`
+  }
+
+  get(providerId: string, model: string): UnavailableState | undefined {
+    const key = this.key(providerId, model)
+    const state = this.states.get(key)
+    if (state?.until !== undefined && state.until <= Date.now()) {
+      this.states.delete(key)
+      return undefined
+    }
+    return state
+  }
+
+  mark(
+    providerId: string,
+    model: string,
+    metadata: LLMErrorMetadata,
+    overloadMs = settingMs(SETTINGS_KEYS.MODEL_CASCADE_OVERLOAD_COOLDOWN_MS),
+    transientMs = settingMs(SETTINGS_KEYS.MODEL_CASCADE_TRANSIENT_COOLDOWN_MS),
+  ): void {
+    if (metadata.kind === 'abort') return
+    const status = metadata.status
+    if (status !== undefined && [401, 403, 404].includes(status)) {
+      this.states.set(this.key(providerId, model), {
+        kind: 'configuration',
+        reason: `HTTP ${status}; unavailable until provider configuration changes`,
+      })
+      return
+    }
+    const duration =
+      status === 429 || status === 503 || metadata.kind === 'overload'
+        ? (metadata.retryAfterMs ?? overloadMs)
+        : transientMs
+    this.states.set(this.key(providerId, model), {
+      kind: 'cooldown',
+      until: Date.now() + Math.max(0, duration),
+      reason: metadata.message ?? (status ? `HTTP ${status}` : metadata.kind),
+    })
+  }
+
+  clear(): void {
+    this.states.clear()
+  }
+
+  clearProvider(providerId: string): void {
+    for (const key of this.states.keys()) if (key.startsWith(`${providerId}\u0000`)) this.states.delete(key)
+  }
+}
+
+export const modelCooldownRegistry = new ModelCooldownRegistry()
+
+function errorMetadata(error: unknown): LLMErrorMetadata {
+  if (error instanceof LLMError && error.details && typeof error.details === 'object') {
+    return error.details as LLMErrorMetadata
+  }
+  return { kind: 'unknown', message: error instanceof Error ? error.message : String(error) }
+}
+
+function displayError(error: string): string {
+  const normalized = error.replace(/\s+/g, ' ').trim()
+  return normalized.length > 500 ? `${normalized.slice(0, 497)}...` : normalized
+}
+
+function attemptSettings(
+  entry: CascadeEntry,
+  request: LLMCompletionRequest,
+): NonNullable<LLMCompletionRequest['modelSettings']> {
+  const settings = { ...entry.client.getModelSettings?.(), ...request.modelSettings }
+  if (request.maxTokensLimit !== undefined) {
+    settings.maxTokens = Math.min(settings.maxTokens ?? 16_384, request.maxTokensLimit)
+  }
+  return settings
+}
+
+function unavailableMessage(entries: CascadeEntry[]): string {
+  const details = entries.map(({ providerId, model }) => {
+    const state = modelCooldownRegistry.get(providerId, model)
+    if (!state) return `${providerId}/${model}: unavailable`
+    if (state.until !== undefined)
+      return `${providerId}/${model}: ${Math.ceil((state.until - Date.now()) / 1000)}s remaining`
+    return `${providerId}/${model}: ${state.reason}`
+  })
+  return `All configured models are unavailable: ${details.join('; ')}`
+}
+
+export function createCascadingLLMClient(entries: CascadeEntry[]): LLMClientWithModel {
+  if (entries.length === 0) throw new Error('Model cascade must not be empty')
+  let current = entries.find((entry) => !modelCooldownRegistry.get(entry.providerId, entry.model)) ?? entries[0]!
+
+  const selectAvailable = () => {
+    const selected = entries.find((entry) => !modelCooldownRegistry.get(entry.providerId, entry.model))
+    if (selected) current = selected
+    return selected
+  }
+
+  return {
+    getModel: () => (selectAvailable() ?? current).model,
+    getProviderId: () => (selectAvailable() ?? current).providerId,
+    getProviderName: () => {
+      const selected = selectAvailable() ?? current
+      return selected.client.getProviderName?.() ?? selected.providerId
+    },
+    setModel: () => undefined,
+    getProfile: () => (selectAvailable() ?? current).client.getProfile(),
+    getBackend: () => (selectAvailable() ?? current).client.getBackend(),
+    setBackend: () => undefined,
+    getContextWindow: () => Math.min(...entries.map((entry) => entry.client.getContextWindow?.() ?? 200_000)),
+    getModelSettings: () => null,
+    async complete(request: LLMCompletionRequest) {
+      const available = entries.filter((entry) => !modelCooldownRegistry.get(entry.providerId, entry.model))
+      if (available.length === 0) throw new LLMError(unavailableMessage(entries), { kind: 'unavailable' })
+      let lastError: unknown
+      for (const entry of available) {
+        current = entry
+        try {
+          return await entry.client.complete({
+            ...request,
+            modelSettings: attemptSettings(entry, request),
+          })
+        } catch (error) {
+          lastError = error
+          const metadata = errorMetadata(error)
+          if (request.signal?.aborted || metadata.kind === 'abort') throw error
+          modelCooldownRegistry.mark(entry.providerId, entry.model, metadata)
+        }
+      }
+      throw lastError
+    },
+    async *stream(request: LLMCompletionRequest): AsyncIterable<LLMStreamEvent> {
+      const available = entries.filter((entry) => !modelCooldownRegistry.get(entry.providerId, entry.model))
+      if (available.length === 0) {
+        yield { type: 'error', error: unavailableMessage(entries), metadata: { kind: 'unavailable' } }
+        return
+      }
+      for (const [index, entry] of available.entries()) {
+        current = entry
+        let emitted = false
+        let failed: (LLMStreamEvent & { type: 'error' }) | undefined
+        const attemptRequest = {
+          ...request,
+          modelSettings: attemptSettings(entry, request),
+        }
+        for await (const event of entry.client.stream(attemptRequest)) {
+          if (event.type === 'error') {
+            failed = event
+            break
+          }
+          if (event.type === 'text_delta' || event.type === 'thinking_delta' || event.type === 'tool_call_delta')
+            emitted = true
+          yield event
+        }
+        if (!failed) return
+        if (request.signal?.aborted || failed.metadata?.kind === 'abort' || emitted) {
+          yield failed
+          return
+        }
+        modelCooldownRegistry.mark(
+          entry.providerId,
+          entry.model,
+          failed.metadata ?? { kind: 'unknown', message: failed.error },
+        )
+        if (available[index + 1]) {
+          yield {
+            type: 'model_cascade_fallback',
+            fallback: {
+              providerId: entry.providerId,
+              providerName: entry.client.getProviderName?.() ?? entry.providerId,
+              model: entry.model,
+              error: displayError(failed.metadata?.message ?? failed.error),
+            },
+          }
+        }
+      }
+      yield { type: 'error', error: unavailableMessage(entries), metadata: { kind: 'unavailable' } }
+    },
+  }
+}

--- a/src/server/llm/streaming.test.ts
+++ b/src/server/llm/streaming.test.ts
@@ -25,6 +25,22 @@ const mockResponse: LLMCompletionResponse = {
 }
 
 describe('streamWithSegments', () => {
+  it('forwards model cascade fallback events without adding content', async () => {
+    const fallback = {
+      type: 'model_cascade_fallback' as const,
+      fallback: { providerId: 'a', providerName: 'Primary', model: 'first', error: 'busy' },
+    }
+    const client = createMockClient([
+      fallback,
+      { type: 'done', response: { ...mockResponse, finishReason: 'stop', toolCalls: [] } },
+    ])
+    const gen = streamWithSegments(client, { messages: [] })
+
+    expect(await gen.next()).toEqual({ done: false, value: fallback })
+    expect((await gen.next()).value).toMatchObject({ type: 'done' })
+    expect((await gen.next()).value).toMatchObject({ content: '', thinkingContent: '', segments: [] })
+  })
+
   it('forwards tool_call_delta events from LLM client', async () => {
     const client = createMockClient([
       { type: 'tool_call_delta', index: 0, id: 'call-1', name: 'read_file' },

--- a/src/server/llm/streaming.ts
+++ b/src/server/llm/streaming.ts
@@ -111,6 +111,10 @@ export async function* streamWithSegments(
           }
           break
 
+        case 'model_cascade_fallback':
+          yield event
+          break
+
         case 'done':
           // Flush any remaining content
           flushThinking()
@@ -120,7 +124,7 @@ export async function* streamWithSegments(
           break
 
         case 'error':
-          yield { type: 'error', error: event.error }
+          yield { type: 'error', error: event.error, ...(event.metadata ? { metadata: event.metadata } : {}) }
           return null
       }
     }

--- a/src/server/llm/types.ts
+++ b/src/server/llm/types.ts
@@ -40,6 +40,7 @@ export interface LLMCompletionRequest {
     chatTemplateKwargs?: Record<string, unknown>
     queryParams?: Record<string, unknown>
   }
+  maxTokensLimit?: number
   /** When true, include the raw API response body in the result */
   returnRaw?: boolean
   /** When true, the client-level reasoningEffort (from thinkingLevel) is NOT applied.
@@ -63,12 +64,27 @@ export interface LLMCompletionResponse {
   raw?: string
 }
 
+export interface LLMErrorMetadata {
+  kind: 'http' | 'network' | 'timeout' | 'overload' | 'abort' | 'invalid_response' | 'unavailable' | 'unknown'
+  status?: number
+  retryAfterMs?: number
+  message?: string
+}
+
+export interface ModelCascadeFallback {
+  providerId: string
+  providerName: string
+  model: string
+  error: string
+}
+
 export type LLMStreamEvent =
   | { type: 'text_delta'; content: string }
   | { type: 'thinking_delta'; content: string }
   | { type: 'tool_call_delta'; index: number; id?: string; name?: string; arguments?: string }
+  | { type: 'model_cascade_fallback'; fallback: ModelCascadeFallback }
   | { type: 'done'; response: LLMCompletionResponse }
-  | { type: 'error'; error: string }
+  | { type: 'error'; error: string; metadata?: LLMErrorMetadata }
 
 export type StreamEvent = LLMStreamEvent
 

--- a/src/server/provider-manager.ts
+++ b/src/server/provider-manager.ts
@@ -4,6 +4,7 @@ import { createTransportLLMClient } from './providers/adapters/transport-client.
 import { createLLMClient, clearModelCache, getModelProfile, type LLMClientWithModel } from './llm/index.js'
 import { logger } from './utils/logger.js'
 import { ensureVersionPrefix, stripVersionPrefix, buildModelsUrl } from './llm/url-utils.js'
+import { modelCooldownRegistry } from './llm/model-cascade.js'
 
 function normalizeModelId(s: string): string {
   return s.toLowerCase().replace(/[-_\s:.]+/g, '')
@@ -349,6 +350,12 @@ export interface ProviderManagerOptions {
   adapters?: ProviderRegistry
 }
 
+let runtimeModelClientFactory: ((providerId: string, model: string) => LLMClientWithModel | undefined) | undefined
+
+export function createRuntimeModelClient(providerId: string, model: string): LLMClientWithModel | undefined {
+  return runtimeModelClientFactory?.(providerId, model)
+}
+
 export function createProviderManager(config: Config, options: ProviderManagerOptions = {}): ProviderManager {
   let providers: Provider[] = [...(config.providers ?? [])]
   // Enrich all models with profile defaults for display
@@ -356,6 +363,43 @@ export function createProviderManager(config: Config, options: ProviderManagerOp
   let defaultModelSelection: string | undefined = config.defaultModelSelection
   let llmClient = createLLMClient(config)
   const providerStatus = new Map<string, 'connected' | 'disconnected' | 'unknown'>()
+  runtimeModelClientFactory = (providerId, model) => {
+    const provider = providers.find((item) => item.id === providerId)
+    if (!provider || !provider.models.some((item) => item.id === model)) return undefined
+    const client = createLLMClient(createConfigForProvider(provider, model))
+    client.setBackend(provider.backend as LlmBackend)
+    const modelConfig = provider.models.find((item) => item.id === model)
+    client.getContextWindow = () => modelConfig?.contextWindow ?? config.context.maxTokens
+    client.getModelSettings = () => {
+      const mode = modelConfig?.thinkingEnabled === false ? 'non-thinking' : 'thinking'
+      const extraKwargsRaw =
+        mode === 'thinking' ? modelConfig?.thinkingExtraKwargs : modelConfig?.nonThinkingExtraKwargs
+      const queryParamsRaw =
+        mode === 'thinking' ? modelConfig?.thinkingQueryParams : modelConfig?.nonThinkingQueryParams
+      const parse = (raw?: string) => {
+        if (!raw) return undefined
+        try {
+          return JSON.parse(raw) as Record<string, unknown>
+        } catch {
+          return undefined
+        }
+      }
+      const chatTemplateKwargs = parse(extraKwargsRaw)
+      const queryParams = parse(queryParamsRaw)
+      return {
+        ...(modelConfig?.temperature !== undefined ? { temperature: modelConfig.temperature } : {}),
+        ...(modelConfig?.topP !== undefined ? { topP: modelConfig.topP } : {}),
+        ...(modelConfig?.topK !== undefined ? { topK: modelConfig.topK } : {}),
+        ...(modelConfig?.maxTokens !== undefined ? { maxTokens: modelConfig.maxTokens } : {}),
+        ...(modelConfig?.supportsVision !== undefined ? { supportsVision: modelConfig.supportsVision } : {}),
+        ...(chatTemplateKwargs ? { chatTemplateKwargs } : {}),
+        ...(queryParams ? { queryParams } : {}),
+      }
+    }
+    client.getProviderId = () => providerId
+    client.getProviderName = () => provider.name
+    return client
+  }
 
   logger.debug('ProviderManager created', {
     providers: providers.map((p) => ({
@@ -619,6 +663,7 @@ export function createProviderManager(config: Config, options: ProviderManagerOp
       const wasActive = providers[index]?.isActive
       providers.splice(index, 1)
       providerStatus.delete(providerId)
+      modelCooldownRegistry.clearProvider(providerId)
 
       if (wasActive && providers.length > 0) {
         providers[0]!.isActive = true
@@ -632,6 +677,12 @@ export function createProviderManager(config: Config, options: ProviderManagerOp
     },
 
     setProviders(newProviders, newDefaultModelSelection) {
+      const wasActiveProviderId = this.getActiveProviderId()
+      for (const previous of providers) {
+        const next = newProviders.find((item) => item.id === previous.id)
+        if (!next || JSON.stringify(next) !== JSON.stringify(previous)) modelCooldownRegistry.clearProvider(previous.id)
+      }
+
       providers = [...newProviders]
       defaultModelSelection = newDefaultModelSelection
 
@@ -738,6 +789,7 @@ export function createProviderManager(config: Config, options: ProviderManagerOp
     },
 
     async updateModelSettings(providerId: string, modelId: string, settings: ModelSettingsUpdate) {
+      modelCooldownRegistry.clearProvider(providerId)
       const provider = providers.find((p) => p.id === providerId)
       if (!provider) {
         return { success: false, error: 'Provider not found' }

--- a/src/server/routes/agents.test.ts
+++ b/src/server/routes/agents.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import type { Provider } from '../../shared/types.js'
+import { validateModelCascade } from './agents.js'
+
+const providers: Provider[] = [
+  {
+    id: 'primary',
+    name: 'Primary',
+    url: 'http://localhost',
+    backend: 'vllm',
+    models: [{ id: 'model/a', contextWindow: 1000, source: 'user' }],
+    isActive: true,
+    createdAt: '',
+  },
+]
+
+describe('agent model cascade validation', () => {
+  it('accepts inheritance and a valid cascade', () => {
+    expect(validateModelCascade({ metadata: {} }, providers)).toBeNull()
+    expect(
+      validateModelCascade({ metadata: { modelCascade: [{ providerId: 'primary', model: 'model/a' }] } }, providers),
+    ).toBeNull()
+  })
+
+  it('rejects empty, duplicate, unknown provider, and unknown model entries', () => {
+    expect(validateModelCascade({ metadata: { modelCascade: [] } }, providers)).toContain('non-empty')
+    expect(
+      validateModelCascade(
+        {
+          metadata: {
+            modelCascade: [
+              { providerId: 'primary', model: 'model/a' },
+              { providerId: 'primary', model: 'model/a' },
+            ],
+          },
+        },
+        providers,
+      ),
+    ).toContain('duplicate')
+    expect(
+      validateModelCascade({ metadata: { modelCascade: [{ providerId: 'missing', model: 'model' }] } }, providers),
+    ).toContain('Unknown provider')
+    expect(
+      validateModelCascade({ metadata: { modelCascade: [{ providerId: 'primary', model: 'missing' }] } }, providers),
+    ).toContain('Unknown model')
+  })
+})

--- a/src/server/routes/agents.ts
+++ b/src/server/routes/agents.ts
@@ -14,6 +14,31 @@ import {
 } from '../agents/registry.js'
 import type { AgentDefinition } from '../agents/types.js'
 import { createCrudRoutes, type CrudRouteConfig } from './crud-helpers.js'
+import { getRuntimeConfig } from '../runtime-config.js'
+
+export function validateModelCascade(
+  body: Record<string, unknown>,
+  providers = getRuntimeConfig().providers ?? [],
+): string | null {
+  const metadata = body['metadata'] as Record<string, unknown> | undefined
+  const cascade = metadata?.['modelCascade']
+  if (cascade === undefined || cascade === null) return null
+  if (!Array.isArray(cascade) || cascade.length === 0) return 'Model cascade must be a non-empty array when enabled'
+  const refs = cascade as Array<Record<string, unknown>>
+  if (refs.some((ref) => !ref || typeof ref !== 'object' || !ref['providerId'] || !ref['model'])) {
+    return 'Each model cascade entry requires providerId and model'
+  }
+  const keys = refs.map((ref) => `${String(ref['providerId'])}\u0000${String(ref['model'])}`)
+  if (new Set(keys).size !== keys.length) return 'Model cascade cannot contain duplicate models'
+  for (const ref of refs) {
+    const provider = providers.find((item) => item.id === String(ref['providerId']))
+    if (!provider) return `Unknown provider in model cascade: ${String(ref['providerId'])}`
+    if (!provider.models.some((item) => item.id === String(ref['model']))) {
+      return `Unknown model in model cascade: ${String(ref['providerId'])}/${String(ref['model'])}`
+    }
+  }
+  return null
+}
 
 const config: CrudRouteConfig<AgentDefinition> = {
   dirName: 'agents',
@@ -33,11 +58,25 @@ const config: CrudRouteConfig<AgentDefinition> = {
   validateCreate: (body) => {
     const meta = body['metadata'] as Record<string, unknown> | undefined
     if (!meta?.['id'] || !body['prompt']) return 'Missing required fields: metadata.id, prompt'
-    return null
+    return validateModelCascade(body)
   },
+  validateUpdate: validateModelCascade,
   mapToResponse: (a) => a.metadata as unknown as { [key: string]: unknown },
 }
 
-export function createAgentRoutes(configDir: string, projectDir?: string) {
-  return createCrudRoutes<AgentDefinition>(config, configDir, projectDir)
+export function createAgentRoutes(
+  configDir: string,
+  projectDir?: string,
+  getProviders: () => import('../../shared/types.js').Provider[] = () => getRuntimeConfig().providers ?? [],
+) {
+  const routeConfig: CrudRouteConfig<AgentDefinition> = {
+    ...config,
+    validateCreate: (body) => {
+      const meta = body['metadata'] as Record<string, unknown> | undefined
+      if (!meta?.['id'] || !body['prompt']) return 'Missing required fields: metadata.id, prompt'
+      return validateModelCascade(body, getProviders())
+    },
+    validateUpdate: (body) => validateModelCascade(body, getProviders()),
+  }
+  return createCrudRoutes<AgentDefinition>(routeConfig, configDir, projectDir)
 }

--- a/src/server/routes/crud-helpers.test.ts
+++ b/src/server/routes/crud-helpers.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { mergeMetadata } from './crud-helpers.js'
+
+describe('mergeMetadata', () => {
+  it('removes fields explicitly set to null', () => {
+    expect(
+      mergeMetadata(
+        { id: 'planner', name: 'Planner', modelCascade: [{ providerId: 'a', model: 'first' }] },
+        { modelCascade: null },
+        'planner',
+      ),
+    ).toEqual({ id: 'planner', name: 'Planner' })
+  })
+})

--- a/src/server/routes/crud-helpers.ts
+++ b/src/server/routes/crud-helpers.ts
@@ -42,6 +42,18 @@ export async function isProjectItem(
   return pathExists(getProjectItemPath(projectDir, dirName, id, ext))
 }
 
+export function mergeMetadata<T extends Record<string, unknown>>(
+  existing: T,
+  update: Record<string, unknown> | undefined,
+  id: string,
+): Record<string, unknown> {
+  const merged = { ...existing, ...update, id }
+  for (const [key, value] of Object.entries(update ?? {})) {
+    if (value === null) delete merged[key]
+  }
+  return merged
+}
+
 export interface CrudRouteConfig<T> {
   dirName: string
   ext: string
@@ -58,6 +70,7 @@ export interface CrudRouteConfig<T> {
   isDefault: (id: string) => Promise<boolean>
   getDefaultIds?: () => Promise<string[]>
   validateCreate?: (body: Record<string, unknown>) => string | null
+  validateUpdate?: (body: Record<string, unknown>) => string | null
   mapToResponse: (item: T) => { [key: string]: unknown }
   extraGetData?: () => Promise<{ [key: string]: unknown }>
   extraRoutes?: (router: Router) => void
@@ -145,11 +158,14 @@ export function createCrudRoutes<T extends { metadata: { id: string; name: strin
       return res.status(404).json({ error: 'Not found' })
     }
     const body = req.body as Record<string, unknown>
+    const validationError = config.validateUpdate?.(body)
+    if (validationError) return res.status(400).json({ error: validationError })
     const meta = body['metadata'] as Record<string, unknown> | undefined
+    const mergedMetadata = mergeMetadata(existing.metadata as Record<string, unknown>, meta, id)
     const updated = {
       ...existing,
       ...body,
-      metadata: { ...existing.metadata, ...meta, id },
+      metadata: mergedMetadata,
     } as unknown as T
     const isProject = await isProjectItem(projectDir, config.dirName, id, config.ext)
     if (isProject) {
@@ -169,10 +185,6 @@ export function createCrudRoutes<T extends { metadata: { id: string; name: strin
         return res.status(500).json({ error: 'Failed to delete project item' })
       }
       return res.json({ success: true })
-    }
-    const isDefault = await config.isDefault(id)
-    if (isDefault) {
-      return res.status(403).json({ error: 'Cannot delete built-in defaults' })
     }
     const result = await config.delete(configDir, id)
     if (!result.success) {

--- a/src/server/session/manager.ts
+++ b/src/server/session/manager.ts
@@ -426,7 +426,14 @@ export class SessionManager {
     const options: {
       contextWindowId?: string
       isSystemGenerated?: boolean
-      messageKind?: 'correction' | 'auto-prompt' | 'context-reset' | 'task-completed' | 'workflow-started' | 'command'
+      messageKind?:
+        | 'correction'
+        | 'auto-prompt'
+        | 'context-reset'
+        | 'task-completed'
+        | 'workflow-started'
+        | 'command'
+        | 'model-fallback'
       tokenCount?: number
       attachments?: Attachment[] // Optional image attachments
       subAgentId?: string

--- a/src/server/sub-agents/manager.ts
+++ b/src/server/sub-agents/manager.ts
@@ -146,6 +146,8 @@ export async function executeSubAgent(options: SubAgentExecutionOptions): Promis
   } = options
 
   const agentDef = await resolveAgentDef(subAgentType)
+  const { resolveAgentLLMClient } = await import('../agents/model-cascade.js')
+  const agentLLMClient = resolveAgentLLMClient(agentDef, llmClient)
   const eventStore = getEventStore()
   const subAgentId = crypto.randomUUID()
   const session = sessionManager.requireSession(sessionId)
@@ -218,7 +220,7 @@ export async function executeSubAgent(options: SubAgentExecutionOptions): Promis
   const gitignoreSection = hasRunCommand ? await loadGitIgnoreRules(effectiveWorkdir) : ''
 
   const systemPrompt =
-    buildBasePrompt(effectiveWorkdir, undefined, skills.length > 0 ? skills : undefined, llmClient.getModel()) +
+    buildBasePrompt(session.workdir, undefined, skills.length > 0 ? skills : undefined, agentLLMClient.getModel()) +
     '\n\n' +
     agentDef.prompt +
     (gitignoreSection ? '\n\n' + gitignoreSection : '') +
@@ -234,8 +236,8 @@ export async function executeSubAgent(options: SubAgentExecutionOptions): Promis
       append: (event) => eventStore.append(sessionId, event),
       sessionManager,
       sessionId,
-      llmClient,
-      statsIdentity,
+      llmClient: agentLLMClient,
+      statsIdentity: { ...statsIdentity, model: agentLLMClient.getModel() },
       signal,
       onMessage,
       assembleRequest: async (input) =>

--- a/src/server/ws/protocol.test.ts
+++ b/src/server/ws/protocol.test.ts
@@ -31,6 +31,39 @@ import {
 import type { StoredEvent } from '../events/types.js'
 
 describe('ws/protocol', () => {
+  it('transports model fallback messages through the standard message lifecycle', () => {
+    const content = JSON.stringify({ providerId: 'a', providerName: 'Primary', model: 'first', error: 'busy' })
+    const event: StoredEvent = {
+      seq: 1,
+      sessionId: 'session-1',
+      timestamp: Date.parse('2024-01-01T00:00:00.000Z'),
+      type: 'message.start',
+      data: {
+        messageId: 'fallback-1',
+        role: 'system',
+        content,
+        isSystemGenerated: true,
+        messageKind: 'model-fallback',
+      },
+    }
+
+    expect(storedEventToServerMessage(event)).toEqual({
+      type: 'chat.message',
+      payload: {
+        message: {
+          id: 'fallback-1',
+          role: 'system',
+          content,
+          timestamp: '2024-01-01T00:00:00.000Z',
+          tokenCount: 0,
+          isStreaming: false,
+          isSystemGenerated: true,
+          messageKind: 'model-fallback',
+        },
+      },
+    })
+  })
+
   describe('parseClientMessage', () => {
     it('parses a valid client message', () => {
       expect(

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -254,6 +254,13 @@ export interface Attachment {
   description?: string // Vision fallback description (for non-vision models)
 }
 
+export interface ModelCascadeFallback {
+  providerId: string
+  providerName: string
+  model: string
+  error: string
+}
+
 export interface Message {
   id: string
   role: MessageRole
@@ -275,7 +282,14 @@ export interface Message {
   completeReason?: 'complete' | 'stopped' | 'error' | 'waiting_for_user' | 'truncated' | 'step_done' // How the message ended
   isSystemGenerated?: boolean // true for auto-injected messages (retry prompts, etc.)
   isStreaming?: boolean // true while assistant is still generating
-  messageKind?: 'correction' | 'auto-prompt' | 'context-reset' | 'task-completed' | 'workflow-started' | 'command' // Visual styling hint for system-generated messages
+  messageKind?:
+    | 'correction'
+    | 'auto-prompt'
+    | 'context-reset'
+    | 'task-completed'
+    | 'workflow-started'
+    | 'command'
+    | 'model-fallback' // Visual styling hint for system-generated messages
   isCompactionSummary?: boolean // true if this is the summary message after compaction
   subAgentId?: string // If set, this message belongs to a sub-agent process
   subAgentType?: string // Sub-agent ID from agent registry

--- a/web/src/components/plan/ChatMessage.test.tsx
+++ b/web/src/components/plan/ChatMessage.test.tsx
@@ -1,0 +1,37 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from 'vitest'
+import { createRoot } from 'react-dom/client'
+import { flushSync } from 'react-dom'
+import type { Message } from '@shared/types.js'
+import { ChatMessage } from './ChatMessage'
+
+function renderMessage(content: string) {
+  const container = document.createElement('div')
+  const root = createRoot(container)
+  const message: Message = {
+    id: 'fallback-1',
+    role: 'system',
+    content,
+    timestamp: new Date().toISOString(),
+    isSystemGenerated: true,
+    messageKind: 'model-fallback',
+  }
+  flushSync(() => root.render(<ChatMessage message={message} />))
+  return container
+}
+
+describe('ChatMessage model fallback', () => {
+  it('shows the failed provider, model, and error', () => {
+    const container = renderMessage(
+      JSON.stringify({ providerId: 'provider-a', providerName: 'Primary', model: 'model-a', error: 'Rate limited' }),
+    )
+
+    expect(container.textContent).toContain('Primary / model-a')
+    expect(container.textContent).toContain('Rate limited')
+  })
+
+  it('renders malformed payloads without breaking the feed', () => {
+    expect(renderMessage('{}').textContent).toContain('Model fallback details unavailable')
+    expect(renderMessage('Unavailable model').textContent).toContain('Model fallback details unavailable')
+  })
+})

--- a/web/src/components/plan/ChatMessage.tsx
+++ b/web/src/components/plan/ChatMessage.tsx
@@ -1,5 +1,5 @@
 import { memo } from 'react'
-import type { Message } from '@shared/types.js'
+import type { Message, ModelCascadeFallback } from '@shared/types.js'
 import type { TaskCompletedPayload } from '@shared/protocol.js'
 import { Markdown } from '../shared/Markdown'
 import { AssistantMessage } from './AssistantMessage'
@@ -8,6 +8,7 @@ import { WorkflowStartedCard } from './WorkflowStartedCard'
 import { MessageAttachments } from '../shared/MessageAttachments.js'
 import { MessageOptionsMenu } from './MessageOptionsMenu'
 import { AutoPromptCard } from './AutoPromptCard'
+import { ModelFallbackMessage } from './ModelFallbackMessage'
 
 interface ChatMessageProps {
   message: Message
@@ -20,6 +21,24 @@ interface UserMessageProps {
   message: Message
   messageId?: string
   sessionId?: string
+}
+
+function parseModelFallback(content: string): ModelCascadeFallback | null {
+  try {
+    const value = JSON.parse(content) as Partial<ModelCascadeFallback> | null
+    if (
+      value &&
+      typeof value.providerId === 'string' &&
+      typeof value.providerName === 'string' &&
+      typeof value.model === 'string' &&
+      typeof value.error === 'string'
+    ) {
+      return value as ModelCascadeFallback
+    }
+  } catch {
+    return null
+  }
+  return null
 }
 
 function UserMessage({ message, messageId, sessionId }: UserMessageProps) {
@@ -126,6 +145,16 @@ export const ChatMessage = memo(function ChatMessage({
     } catch {
       // Fall through to default rendering
     }
+  }
+
+  if (message.messageKind === 'model-fallback') {
+    const fallback = parseModelFallback(message.content)
+    if (fallback) return <ModelFallbackMessage {...fallback} />
+    return (
+      <div className="feed-item rounded border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-200">
+        Model fallback details unavailable
+      </div>
+    )
   }
 
   // Context reset separator (full-width divider for fresh context)

--- a/web/src/components/plan/ModelFallbackMessage.tsx
+++ b/web/src/components/plan/ModelFallbackMessage.tsx
@@ -1,0 +1,16 @@
+import type { ModelCascadeFallback } from '@shared/types.js'
+
+export function ModelFallbackMessage({ providerId, providerName, model, error }: ModelCascadeFallback) {
+  const provider = providerName || providerId
+
+  return (
+    <div className="feed-item rounded border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs">
+      <span className="font-medium text-amber-300">Model failed</span>
+      <span className="text-text-secondary">
+        {' '}
+        · {provider} / {model} · trying next configured model
+      </span>
+      <div className="mt-1 whitespace-pre-wrap text-amber-200">{error}</div>
+    </div>
+  )
+}

--- a/web/src/components/settings/AgentsModal.test.tsx
+++ b/web/src/components/settings/AgentsModal.test.tsx
@@ -1,0 +1,170 @@
+/* @vitest-environment happy-dom */
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { AgentsModal } from './AgentsModal'
+
+const mocks = vi.hoisted(() => ({
+  fetchAgents: vi.fn().mockResolvedValue(undefined),
+  fetchAgent: vi.fn(),
+  fetchDefaultContent: vi.fn().mockResolvedValue({
+    metadata: {
+      id: 'planner',
+      name: 'Planner',
+      description: 'Plans work',
+      subagent: false,
+      allowedTools: [],
+      color: '#6b7280',
+    },
+    prompt: 'Plan carefully',
+  }),
+  createAgent: vi.fn().mockResolvedValue({ success: true }),
+  updateAgent: vi.fn().mockResolvedValue({ success: true }),
+  deleteAgent: vi.fn().mockResolvedValue({ success: true }),
+  fetchConfig: vi.fn().mockResolvedValue(undefined),
+  userItems: [] as Record<string, unknown>[],
+  overrideIds: [] as string[],
+}))
+
+vi.mock('../../stores/agents', () => ({
+  useAgentsStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({
+      defaults: [
+        {
+          id: 'planner',
+          name: 'Planner',
+          description: 'Plans work',
+          subagent: false,
+          allowedTools: [],
+          color: '#6b7280',
+        },
+      ],
+      userItems: mocks.userItems,
+      overrideIds: mocks.overrideIds,
+      loading: false,
+      fetchAgents: mocks.fetchAgents,
+      fetchAgent: mocks.fetchAgent,
+      fetchDefaultContent: mocks.fetchDefaultContent,
+      createAgent: mocks.createAgent,
+      updateAgent: mocks.updateAgent,
+      deleteAgent: mocks.deleteAgent,
+    }),
+}))
+
+vi.mock('../../stores/config', () => ({
+  useConfigStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({ providers: [], fetchConfig: mocks.fetchConfig }),
+}))
+
+vi.mock('../../lib/api', () => ({
+  authFetch: vi.fn().mockResolvedValue({ json: async () => ({ tools: [] }) }),
+}))
+
+describe('AgentsModal built-in customization', () => {
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+    mocks.createAgent.mockClear()
+    mocks.updateAgent.mockClear()
+    mocks.userItems = []
+    mocks.overrideIds = []
+  })
+
+  it('duplicates a read-only built-in with a fresh ID instead of updating it', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1234)
+    render(<AgentsModal isOpen onClose={vi.fn()} />)
+
+    expect(screen.queryByTitle('Edit')).toBeNull()
+    fireEvent.click(screen.getByTitle('View'))
+    await screen.findByText('Duplicate & Customize')
+
+    expect(screen.getByDisplayValue('planner')).toHaveProperty('readOnly', true)
+    fireEvent.click(screen.getByText('Duplicate & Customize'))
+
+    expect(screen.getByDisplayValue('planner-copy-1234')).toBeTruthy()
+    fireEvent.click(screen.getByText('Save'))
+
+    await waitFor(() =>
+      expect(mocks.createAgent).toHaveBeenCalledWith(
+        expect.objectContaining({ metadata: expect.objectContaining({ id: 'planner-copy-1234' }) }),
+      ),
+    )
+    expect(mocks.updateAgent).not.toHaveBeenCalled()
+  })
+
+  it('keeps existing built-in overrides resettable without exposing edit', () => {
+    mocks.userItems = [
+      {
+        id: 'planner',
+        name: 'Planner override',
+        description: 'Legacy override',
+        subagent: false,
+        allowedTools: [],
+      },
+    ]
+    mocks.overrideIds = ['planner']
+
+    render(<AgentsModal isOpen onClose={vi.fn()} />)
+
+    expect(screen.queryByTitle('Edit')).toBeNull()
+    expect(screen.getByTitle('Delete')).toBeTruthy()
+  })
+
+  it('rejects creating a custom agent with a built-in ID', async () => {
+    render(<AgentsModal isOpen onClose={vi.fn()} />)
+
+    fireEvent.click(screen.getByText('+ New'))
+    fireEvent.change(screen.getByPlaceholderText('My Agent'), { target: { value: 'Planner' } })
+    fireEvent.change(screen.getByPlaceholderText('Instructions for this agent...'), { target: { value: 'Prompt' } })
+    fireEvent.click(screen.getByText('Save'))
+
+    expect(await screen.findByText('This ID belongs to a built-in agent. Choose a different name.')).toBeTruthy()
+    expect(mocks.createAgent).not.toHaveBeenCalled()
+  })
+
+  it('duplicates a custom agent using its effective content', async () => {
+    mocks.userItems = [
+      {
+        id: 'reviewer',
+        name: 'Reviewer',
+        description: 'Reviews work',
+        subagent: true,
+        allowedTools: [],
+      },
+    ]
+    mocks.fetchAgent.mockResolvedValueOnce({
+      metadata: {
+        id: 'reviewer',
+        name: 'Reviewer',
+        description: 'Reviews work',
+        subagent: true,
+        allowedTools: [],
+      },
+      prompt: 'Review carefully',
+    })
+    vi.spyOn(Date, 'now').mockReturnValue(4321)
+    render(<AgentsModal isOpen onClose={vi.fn()} />)
+
+    fireEvent.click(screen.getAllByTitle('Duplicate')[1]!)
+    await screen.findByDisplayValue('reviewer-copy-4321')
+
+    expect(mocks.fetchAgent).toHaveBeenCalledWith('reviewer')
+    expect(mocks.fetchDefaultContent).not.toHaveBeenCalledWith('reviewer')
+  })
+
+  it('creates a distinct custom agent from the built-in duplicate action', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(5678)
+    render(<AgentsModal isOpen onClose={vi.fn()} />)
+
+    fireEvent.click(screen.getByTitle('Duplicate'))
+    await screen.findByDisplayValue('planner-copy-5678')
+    fireEvent.click(screen.getByText('Save'))
+
+    await waitFor(() =>
+      expect(mocks.createAgent).toHaveBeenCalledWith(
+        expect.objectContaining({ metadata: expect.objectContaining({ id: 'planner-copy-5678' }) }),
+      ),
+    )
+    expect(mocks.updateAgent).not.toHaveBeenCalled()
+  })
+})

--- a/web/src/components/settings/AgentsModal.tsx
+++ b/web/src/components/settings/AgentsModal.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from 'react'
 import { Modal } from '../shared/SelfContainedModal'
-import { useAgentsStore, type AgentFull } from '../../stores/agents'
+import { useAgentsStore, type AgentFull, type AgentModelRef } from '../../stores/agents'
+import { useConfigStore } from '../../stores/config'
 import { authFetch } from '../../lib/api'
-import { CRUDListHeader } from './CRUDModal'
+import { CRUDListHeader, ErrorBanner } from './CRUDModal'
 import { AgentGroup } from './agents/AgentListItem'
 import { AgentForm } from './agents/AgentForm'
 
@@ -22,6 +23,7 @@ function toSlug(name: string): string {
 export function AgentsModal({ isOpen, onClose, initialEditId }: AgentsModalProps) {
   const defaults = useAgentsStore((state) => state.defaults)
   const userItems = useAgentsStore((state) => state.userItems)
+  const overrideIds = useAgentsStore((state) => state.overrideIds)
   const loading = useAgentsStore((state) => state.loading)
   const fetchAgents = useAgentsStore((state) => state.fetchAgents)
   const fetchAgent = useAgentsStore((state) => state.fetchAgent)
@@ -29,6 +31,8 @@ export function AgentsModal({ isOpen, onClose, initialEditId }: AgentsModalProps
   const createAgent = useAgentsStore((state) => state.createAgent)
   const updateAgent = useAgentsStore((state) => state.updateAgent)
   const deleteAgentAction = useAgentsStore((state) => state.deleteAgent)
+  const providers = useConfigStore((state) => state.providers)
+  const fetchConfig = useConfigStore((state) => state.fetchConfig)
 
   const [view, setView] = useState<'list' | 'edit'>('list')
   const [editingId, setEditingId] = useState<string | null>(null)
@@ -41,6 +45,7 @@ export function AgentsModal({ isOpen, onClose, initialEditId }: AgentsModalProps
   const [formTools, setFormTools] = useState<string[]>([])
   const [formColor, setFormColor] = useState('#6b7280')
   const [formPrompt, setFormPrompt] = useState('')
+  const [formModelCascade, setFormModelCascade] = useState<AgentModelRef[] | undefined>()
   const [formError, setFormError] = useState('')
   const [saving, setSaving] = useState(false)
 
@@ -57,6 +62,7 @@ export function AgentsModal({ isOpen, onClose, initialEditId }: AgentsModalProps
     setFormTools(agent.metadata.allowedTools)
     setFormColor(agent.metadata.color ?? '#6b7280')
     setFormPrompt(agent.prompt)
+    setFormModelCascade(agent.metadata.modelCascade ?? undefined)
     setFormError('')
   }
 
@@ -68,6 +74,7 @@ export function AgentsModal({ isOpen, onClose, initialEditId }: AgentsModalProps
     setFormTools(content.metadata.allowedTools)
     setFormColor(content.metadata.color ?? '#6b7280')
     setFormPrompt(content.prompt)
+    setFormModelCascade(content.metadata.modelCascade ?? undefined)
     setFormError('')
     if (setAsNew) {
       setEditingId(null)
@@ -86,6 +93,7 @@ export function AgentsModal({ isOpen, onClose, initialEditId }: AgentsModalProps
   useEffect(() => {
     if (isOpen) {
       fetchAgents()
+      fetchConfig()
       authFetch('/api/tools')
         .then((r) => r.json())
         .then((d) => {
@@ -100,13 +108,11 @@ export function AgentsModal({ isOpen, onClose, initialEditId }: AgentsModalProps
         })
 
       if (initialEditId) {
-        const isDefault = defaults.some((d) => d.id === initialEditId)
-        if (isDefault) {
-          fetchDefaultContent(initialEditId).then((content) => {
-            if (!content) return
-            applyDuplicateFromContent(content, initialEditId, true)
-          })
-        } else {
+        fetchDefaultContent(initialEditId).then((content) => {
+          if (content) {
+            applyViewFromContent(content, initialEditId)
+            return
+          }
           fetchAgent(initialEditId).then((agent) => {
             if (!agent) return
             populateFormFromAgent(agent)
@@ -114,7 +120,7 @@ export function AgentsModal({ isOpen, onClose, initialEditId }: AgentsModalProps
             setIsReadOnly(false)
             setView('edit')
           })
-        }
+        })
       } else {
         setView('list')
         setEditingId(null)
@@ -137,7 +143,8 @@ export function AgentsModal({ isOpen, onClose, initialEditId }: AgentsModalProps
   }
 
   const handleDuplicate = async (agentId: string) => {
-    const content = await fetchDefaultContent(agentId)
+    const isDefault = defaults.some((agent) => agent.id === agentId)
+    const content = isDefault ? await fetchDefaultContent(agentId) : await fetchAgent(agentId)
     if (!content) return
     applyDuplicateFromContent(content, agentId, true)
   }
@@ -151,6 +158,7 @@ export function AgentsModal({ isOpen, onClose, initialEditId }: AgentsModalProps
     setFormTools(['read_file'])
     setFormColor('#6b7280')
     setFormPrompt('')
+    setFormModelCascade(undefined)
     setFormError('')
     setIsReadOnly(false)
     setView('edit')
@@ -166,13 +174,18 @@ export function AgentsModal({ isOpen, onClose, initialEditId }: AgentsModalProps
   }
 
   const handleDelete = async (agentId: string) => {
-    await deleteAgentAction(agentId)
+    const result = await deleteAgentAction(agentId)
+    if (!result.success) setFormError(result.error ?? 'Failed to reset agent override.')
   }
 
   const handleSave = async () => {
     const id = editingId ?? formId
     if (!id || !formName || !formPrompt) {
       setFormError('Name and prompt are required.')
+      return
+    }
+    if (!editingId && defaults.some((agent) => agent.id === id)) {
+      setFormError('This ID belongs to a built-in agent. Choose a different name.')
       return
     }
 
@@ -187,6 +200,7 @@ export function AgentsModal({ isOpen, onClose, initialEditId }: AgentsModalProps
         subagent: formSubagent,
         allowedTools: formTools.filter((t) => !alwaysAllowedNames.has(t)),
         color: formColor,
+        modelCascade: formModelCascade?.length ? formModelCascade : null,
       },
       prompt: formPrompt,
     }
@@ -222,8 +236,9 @@ export function AgentsModal({ isOpen, onClose, initialEditId }: AgentsModalProps
 
   const defaultSubAgents = defaults.filter((a) => a.subagent)
   const defaultTopLevelAgents = defaults.filter((a) => !a.subagent)
-  const userSubAgents = userItems.filter((a) => a.subagent)
-  const userTopLevelAgents = userItems.filter((a) => !a.subagent)
+  const customItems = userItems.filter((agent) => !overrideIds.includes(agent.id))
+  const userSubAgents = customItems.filter((a) => a.subagent)
+  const userTopLevelAgents = customItems.filter((a) => !a.subagent)
 
   if (view === 'edit') {
     return (
@@ -245,6 +260,9 @@ export function AgentsModal({ isOpen, onClose, initialEditId }: AgentsModalProps
           saving={saving}
           isReadOnly={isReadOnly}
           availableTools={availableTools}
+          providers={providers}
+          modelCascade={formModelCascade}
+          onModelCascadeChange={setFormModelCascade}
           onNameChange={handleNameChange}
           onIdChange={setFormId}
           onDescriptionChange={setFormDescription}
@@ -279,6 +297,7 @@ export function AgentsModal({ isOpen, onClose, initialEditId }: AgentsModalProps
         hasItems={defaults.length > 0 || userItems.length > 0}
       >
         <div className="space-y-4">
+          {formError && <ErrorBanner message={formError} />}
           {defaults.length > 0 && (
             <AgentGroup
               title="Built-in"
@@ -288,6 +307,8 @@ export function AgentsModal({ isOpen, onClose, initialEditId }: AgentsModalProps
               alwaysAllowedNames={alwaysAllowedNames}
               onView={handleView}
               onDuplicate={handleDuplicate}
+              onDelete={handleDelete}
+              canDelete={(agentId) => overrideIds.includes(agentId)}
             />
           )}
 

--- a/web/src/components/settings/CRUDListItem.tsx
+++ b/web/src/components/settings/CRUDListItem.tsx
@@ -12,6 +12,8 @@ export interface CRUDListItemProps {
   onDelete?: () => void
   actions?: ReactNode
   children?: ReactNode
+  deleteLabel?: string
+  onCancelDelete?: () => void
 }
 
 export function CRUDListItem({
@@ -23,6 +25,8 @@ export function CRUDListItem({
   onDelete,
   actions,
   children,
+  deleteLabel,
+  onCancelDelete,
 }: CRUDListItemProps) {
   return (
     <div className="flex items-center justify-between p-3 rounded border border-border bg-bg-tertiary">
@@ -40,14 +44,14 @@ export function CRUDListItem({
         )}
         <DuplicateIcon onClick={onDuplicate} />
         {!isBuiltIn && onEdit && <EditButton onClick={onEdit} />}
-        {!isBuiltIn &&
-          onDelete &&
+        {onDelete &&
           (isConfirmingDelete ? (
             <ConfirmButton
               onConfirm={() => {
                 onDelete?.()
               }}
-              onCancel={() => {}}
+              onCancel={() => onCancelDelete?.()}
+              label={deleteLabel}
             />
           ) : (
             <DeleteIcon onClick={() => onDelete?.()} />

--- a/web/src/components/settings/CRUDModal.tsx
+++ b/web/src/components/settings/CRUDModal.tsx
@@ -24,16 +24,17 @@ export function useConfirmDialog() {
 interface ConfirmButtonProps {
   onConfirm: () => void
   onCancel: () => void
+  label?: string
 }
 
-export function ConfirmButton({ onConfirm, onCancel }: ConfirmButtonProps) {
+export function ConfirmButton({ onConfirm, onCancel, label = 'Delete' }: ConfirmButtonProps) {
   return (
     <div className="flex items-center gap-1">
       <button
         onClick={onConfirm}
         className="px-1.5 py-0.5 rounded text-xs hover:opacity-90 transition-colors bg-accent-error/20 text-accent-error hover:bg-accent-error/30"
       >
-        Delete
+        {label}
       </button>
       <button
         onClick={onCancel}

--- a/web/src/components/settings/agents/AgentForm.test.tsx
+++ b/web/src/components/settings/agents/AgentForm.test.tsx
@@ -1,0 +1,55 @@
+/* @vitest-environment happy-dom */
+
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { AgentForm, type AgentFormProps } from './AgentForm'
+
+function props(overrides: Partial<AgentFormProps> = {}): AgentFormProps {
+  return {
+    formName: 'Planner',
+    formId: 'planner',
+    formDescription: '',
+    formSubagent: false,
+    formTools: [],
+    formColor: '#000000',
+    formPrompt: 'Prompt',
+    formError: '',
+    saving: false,
+    isReadOnly: false,
+    availableTools: [],
+    providers: [
+      {
+        id: 'p',
+        name: 'Provider',
+        url: '',
+        backend: 'vllm',
+        apiKey: undefined,
+        models: [{ id: 'm', contextWindow: 1000, source: 'user' }],
+        isActive: true,
+        createdAt: '',
+      },
+    ],
+    modelCascade: [{ providerId: 'p', model: 'm' }],
+    onModelCascadeChange: vi.fn(),
+    onNameChange: vi.fn(),
+    onIdChange: vi.fn(),
+    onDescriptionChange: vi.fn(),
+    onSubagentChange: vi.fn(),
+    onToolsChange: vi.fn(),
+    onColorChange: vi.fn(),
+    onPromptChange: vi.fn(),
+    onSave: vi.fn(),
+    onCancel: vi.fn(),
+    onDuplicate: vi.fn(),
+    ...overrides,
+  }
+}
+
+describe('AgentForm cascade', () => {
+  it('disables a saved cascade by requesting inheritance', () => {
+    const onModelCascadeChange = vi.fn()
+    render(<AgentForm {...props({ onModelCascadeChange })} />)
+    fireEvent.click(screen.getByText('Use session model'))
+    expect(onModelCascadeChange).toHaveBeenCalledWith(undefined)
+  })
+})

--- a/web/src/components/settings/agents/AgentForm.tsx
+++ b/web/src/components/settings/agents/AgentForm.tsx
@@ -1,8 +1,10 @@
 import { FormField, ModalActions, ErrorBanner } from '../CRUDModal'
 import { DropdownMenu } from '../../shared/DropdownMenu'
 import { parseAllowedTools, serializeTools } from './tools'
+import type { AgentModelRef } from '../../../stores/agents'
+import type { Provider } from '../../../stores/config'
 
-interface AgentFormProps {
+export interface AgentFormProps {
   formName: string
   formId: string
   formDescription: string
@@ -14,6 +16,9 @@ interface AgentFormProps {
   saving: boolean
   isReadOnly: boolean
   availableTools: { name: string; actions: string[]; topLevelOnly?: boolean }[]
+  providers: Provider[]
+  modelCascade?: AgentModelRef[]
+  onModelCascadeChange: (cascade: AgentModelRef[] | undefined) => void
   onNameChange: (name: string) => void
   onIdChange: (id: string) => void
   onDescriptionChange: (desc: string) => void
@@ -38,6 +43,9 @@ export function AgentForm({
   saving,
   isReadOnly,
   availableTools,
+  providers,
+  modelCascade,
+  onModelCascadeChange,
   onNameChange,
   onIdChange,
   onDescriptionChange,
@@ -146,6 +154,139 @@ export function AgentForm({
               </div>
             </div>
           </div>
+        </div>
+
+        <div>
+          <div className="flex items-center justify-between mb-1">
+            <div>
+              <label className="block text-xs text-text-secondary">Model cascade</label>
+              <span className="text-[11px] text-text-muted">
+                {modelCascade
+                  ? 'First available model is used; the session model is ignored.'
+                  : 'Inherits the session model.'}
+              </span>
+            </div>
+            <button
+              type="button"
+              disabled={isReadOnly}
+              onClick={() => {
+                if (modelCascade) onModelCascadeChange(undefined)
+                else {
+                  const provider = providers[0]
+                  const model = provider?.models.find((item) => item.selected)?.id ?? provider?.models[0]?.id
+                  if (provider && model) onModelCascadeChange([{ providerId: provider.id, model }])
+                }
+              }}
+              className="px-2 py-1 rounded text-xs bg-bg-tertiary text-text-secondary disabled:opacity-50"
+            >
+              {modelCascade ? 'Use session model' : 'Use custom cascade'}
+            </button>
+          </div>
+          {modelCascade && (
+            <div className="space-y-1.5 p-2 bg-bg-tertiary border border-border rounded">
+              {modelCascade.map((ref, index) => {
+                const provider = providers.find((item) => item.id === ref.providerId)
+                const models =
+                  provider?.models.filter(
+                    (item) => item.selected || !provider.models.some((entry) => entry.selected),
+                  ) ?? []
+                return (
+                  <div key={`${ref.providerId}-${ref.model}-${index}`} className="flex items-center gap-2">
+                    <span className="w-16 text-[11px] text-text-muted">
+                      {index === 0 ? 'Priority' : `Fallback ${index}`}
+                    </span>
+                    <select
+                      value={ref.providerId}
+                      disabled={isReadOnly}
+                      onChange={(event) => {
+                        const nextProvider = providers.find((item) => item.id === event.target.value)
+                        const nextModel =
+                          nextProvider?.models.find((item) => item.selected)?.id ?? nextProvider?.models[0]?.id ?? ''
+                        onModelCascadeChange(
+                          modelCascade.map((item, itemIndex) =>
+                            itemIndex === index ? { providerId: event.target.value, model: nextModel } : item,
+                          ),
+                        )
+                      }}
+                      className="flex-1 px-2 py-1 bg-bg-primary border border-border rounded text-xs"
+                    >
+                      {!provider && <option value={ref.providerId}>Missing provider: {ref.providerId}</option>}
+                      {providers.map((item) => (
+                        <option key={item.id} value={item.id}>
+                          {item.name}
+                        </option>
+                      ))}
+                    </select>
+                    <select
+                      value={ref.model}
+                      disabled={isReadOnly}
+                      onChange={(event) =>
+                        onModelCascadeChange(
+                          modelCascade.map((item, itemIndex) =>
+                            itemIndex === index ? { ...item, model: event.target.value } : item,
+                          ),
+                        )
+                      }
+                      className="flex-1 px-2 py-1 bg-bg-primary border border-border rounded text-xs"
+                    >
+                      {!models.some((item) => item.id === ref.model) && (
+                        <option value={ref.model}>Missing model: {ref.model}</option>
+                      )}
+                      {models.map((item) => (
+                        <option key={item.id} value={item.id}>
+                          {item.id}
+                        </option>
+                      ))}
+                    </select>
+                    <button
+                      type="button"
+                      disabled={isReadOnly || index === 0}
+                      onClick={() => {
+                        const next = [...modelCascade]
+                        ;[next[index - 1], next[index]] = [next[index]!, next[index - 1]!]
+                        onModelCascadeChange(next)
+                      }}
+                      className="px-1.5 text-xs disabled:opacity-30"
+                    >
+                      ↑
+                    </button>
+                    <button
+                      type="button"
+                      disabled={isReadOnly || index === modelCascade.length - 1}
+                      onClick={() => {
+                        const next = [...modelCascade]
+                        ;[next[index], next[index + 1]] = [next[index + 1]!, next[index]!]
+                        onModelCascadeChange(next)
+                      }}
+                      className="px-1.5 text-xs disabled:opacity-30"
+                    >
+                      ↓
+                    </button>
+                    <button
+                      type="button"
+                      disabled={isReadOnly || modelCascade.length === 1}
+                      onClick={() => onModelCascadeChange(modelCascade.filter((_, itemIndex) => itemIndex !== index))}
+                      className="px-1.5 text-xs text-error disabled:opacity-30"
+                    >
+                      ×
+                    </button>
+                  </div>
+                )
+              })}
+              <button
+                type="button"
+                disabled={isReadOnly || providers.length === 0}
+                onClick={() => {
+                  const provider = providers[0]
+                  const model = provider?.models.find((item) => item.selected)?.id ?? provider?.models[0]?.id
+                  if (provider && model) onModelCascadeChange([...modelCascade, { providerId: provider.id, model }])
+                }}
+                className="text-xs text-accent-primary disabled:opacity-50"
+              >
+                + Add fallback
+              </button>
+            </div>
+          )}
         </div>
 
         <div>

--- a/web/src/components/settings/agents/AgentListItem.test.tsx
+++ b/web/src/components/settings/agents/AgentListItem.test.tsx
@@ -1,0 +1,64 @@
+/* @vitest-environment happy-dom */
+
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { AgentGroup } from './AgentListItem'
+
+const agent = { id: 'planner', name: 'Planner', description: '', subagent: false, allowedTools: [] }
+
+describe('AgentGroup built-in actions', () => {
+  it('never exposes edit for built-in agents', () => {
+    render(
+      <AgentGroup
+        title="Built-in"
+        agents={[agent]}
+        subagents={[]}
+        isBuiltIn
+        onView={vi.fn()}
+        onDuplicate={vi.fn()}
+        onEdit={vi.fn()}
+      />,
+    )
+
+    expect(screen.queryByTitle('Edit')).toBeNull()
+    expect(screen.getByTitle('View')).toBeTruthy()
+    expect(screen.getByTitle('Duplicate')).toBeTruthy()
+  })
+
+  it('hides reset for pristine defaults and confirms overridden resets', () => {
+    const onDelete = vi.fn()
+    const { rerender } = render(
+      <AgentGroup
+        title="Built-in"
+        agents={[agent]}
+        subagents={[]}
+        isBuiltIn
+        onView={vi.fn()}
+        onDuplicate={vi.fn()}
+        onDelete={onDelete}
+        canDelete={() => false}
+      />,
+    )
+    expect(screen.queryByTitle('Delete')).toBeNull()
+
+    rerender(
+      <AgentGroup
+        title="Built-in"
+        agents={[agent]}
+        subagents={[]}
+        isBuiltIn
+        onView={vi.fn()}
+        onDuplicate={vi.fn()}
+        onDelete={onDelete}
+        canDelete={() => true}
+      />,
+    )
+    fireEvent.click(screen.getByTitle('Delete'))
+    expect(screen.getByText('Reset')).toBeTruthy()
+    fireEvent.click(screen.getByText('Cancel'))
+    expect(screen.queryByText('Reset')).toBeNull()
+    fireEvent.click(screen.getByTitle('Delete'))
+    fireEvent.click(screen.getByText('Reset'))
+    expect(onDelete).toHaveBeenCalledWith('planner')
+  })
+})

--- a/web/src/components/settings/agents/AgentListItem.tsx
+++ b/web/src/components/settings/agents/AgentListItem.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import type { AgentInfo } from '../../../stores/agents'
 import { CRUDListItem } from '../CRUDListItem'
 
@@ -10,6 +11,7 @@ export function AgentListItem({
   onEdit,
   onDuplicate,
   onDelete,
+  onCancelDelete,
 }: {
   agent: AgentInfo
   isBuiltIn: boolean
@@ -19,6 +21,7 @@ export function AgentListItem({
   onEdit?: () => void
   onDuplicate: () => void
   onDelete?: () => void
+  onCancelDelete?: () => void
 }) {
   const displayTools = agent.allowedTools.filter((t) => !alwaysAllowedNames?.has(t))
   return (
@@ -29,6 +32,8 @@ export function AgentListItem({
       onEdit={onEdit}
       onDuplicate={onDuplicate}
       onDelete={onDelete}
+      deleteLabel={isBuiltIn ? 'Reset' : 'Delete'}
+      onCancelDelete={onCancelDelete}
     >
       <div className="flex items-center gap-2">
         <span
@@ -66,6 +71,7 @@ export function AgentGroup({
   onDuplicate,
   onEdit,
   onDelete,
+  canDelete,
 }: {
   title: string
   agents: AgentInfo[]
@@ -76,19 +82,33 @@ export function AgentGroup({
   onDuplicate: (id: string) => void
   onEdit?: (id: string) => void
   onDelete?: (id: string) => void
+  canDelete?: (id: string) => boolean
 }) {
+  const [confirmingId, setConfirmingId] = useState<string | null>(null)
   if (agents.length === 0 && subagents.length === 0) return null
   const renderAgentItem = (agent: AgentInfo) => (
     <AgentListItem
       key={agent.id}
       agent={agent}
       isBuiltIn={isBuiltIn}
-      isConfirmingDelete={false}
+      isConfirmingDelete={confirmingId === agent.id}
       alwaysAllowedNames={alwaysAllowedNames}
       onView={() => onView(agent.id)}
-      onEdit={isBuiltIn ? undefined : () => onEdit?.(agent.id)}
+      onEdit={!isBuiltIn && onEdit ? () => onEdit(agent.id) : undefined}
       onDuplicate={() => onDuplicate(agent.id)}
-      onDelete={isBuiltIn ? undefined : () => onDelete?.(agent.id)}
+      onCancelDelete={() => setConfirmingId(null)}
+      onDelete={
+        onDelete && (canDelete?.(agent.id) ?? true)
+          ? () => {
+              if (confirmingId === agent.id) {
+                onDelete(agent.id)
+                setConfirmingId(null)
+              } else {
+                setConfirmingId(agent.id)
+              }
+            }
+          : undefined
+      }
     />
   )
   return (

--- a/web/src/components/settings/tabs/AdvancedTab.test.tsx
+++ b/web/src/components/settings/tabs/AdvancedTab.test.tsx
@@ -1,10 +1,11 @@
 /**
  * @vitest-environment jsdom
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { AdvancedTab } from './AdvancedTab'
+import { SETTINGS_KEYS } from '../../../stores/settings'
 
 vi.mock('wouter', () => ({
   useLocation: () => ['/', vi.fn()],
@@ -45,6 +46,8 @@ describe('AdvancedTab', () => {
     Object.keys(mockSettings).forEach((k) => delete mockSettings[k])
   })
 
+  afterEach(cleanup)
+
   it('renders the Dynamic System Prompt toggle', () => {
     const { container } = render(<AdvancedTab onClose={vi.fn()} />)
     expect(container.textContent).toContain('Dynamic System Prompt')
@@ -82,5 +85,68 @@ describe('AdvancedTab', () => {
     expect(dynamicToggle).toBeTruthy()
     await userEvent.setup().click(dynamicToggle!)
     expect(mockSetSetting).toHaveBeenCalledWith('llm.dynamicSystemPrompt', 'true')
+  })
+})
+
+describe('AdvancedTab model cascade cooldowns', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    Object.keys(mockSettings).forEach((k) => delete mockSettings[k])
+    mockSetSetting.mockResolvedValue({ success: true })
+  })
+
+  afterEach(cleanup)
+
+  it('loads, displays, and saves both global cooldown settings', async () => {
+    mockSettings[SETTINGS_KEYS.MODEL_CASCADE_OVERLOAD_COOLDOWN_MS] = '1200000'
+    mockSettings[SETTINGS_KEYS.MODEL_CASCADE_TRANSIENT_COOLDOWN_MS] = '120000'
+    render(<AdvancedTab onClose={vi.fn()} />)
+
+    const overload = screen.getByLabelText('Quota / overload (minutes)') as HTMLInputElement
+    const transient = screen.getByLabelText('Network / timeout / 5xx (minutes)') as HTMLInputElement
+    expect(overload.value).toBe('20')
+    expect(transient.value).toBe('2')
+
+    fireEvent.change(overload, { target: { value: '' } })
+    fireEvent.change(transient, { target: { value: '' } })
+    expect(mockSetSetting).not.toHaveBeenCalled()
+
+    fireEvent.change(overload, { target: { value: '15' } })
+    fireEvent.change(transient, { target: { value: '3' } })
+    expect(mockSetSetting).not.toHaveBeenCalled()
+    fireEvent.blur(overload)
+    fireEvent.blur(transient)
+    await waitFor(() => {
+      expect(mockSetSetting).toHaveBeenCalledWith(SETTINGS_KEYS.MODEL_CASCADE_OVERLOAD_COOLDOWN_MS, '900000')
+      expect(mockSetSetting).toHaveBeenCalledWith(SETTINGS_KEYS.MODEL_CASCADE_TRANSIENT_COOLDOWN_MS, '180000')
+    })
+  })
+
+  it('shows validation feedback for blank or negative cooldowns', async () => {
+    mockSettings[SETTINGS_KEYS.MODEL_CASCADE_OVERLOAD_COOLDOWN_MS] = '1200000'
+    render(<AdvancedTab onClose={vi.fn()} />)
+    const overload = screen.getByLabelText('Quota / overload (minutes)')
+
+    fireEvent.change(overload, { target: { value: '' } })
+    fireEvent.blur(overload)
+    expect(await screen.findByText('Enter a non-negative number of minutes.')).toBeTruthy()
+    expect(mockSetSetting).not.toHaveBeenCalled()
+
+    fireEvent.change(overload, { target: { value: '-1' } })
+    fireEvent.blur(overload)
+    expect(await screen.findByText('Enter a non-negative number of minutes.')).toBeTruthy()
+    expect(mockSetSetting).not.toHaveBeenCalled()
+  })
+
+  it('surfaces setting save failures', async () => {
+    mockSettings[SETTINGS_KEYS.MODEL_CASCADE_OVERLOAD_COOLDOWN_MS] = '1200000'
+    mockSetSetting.mockResolvedValueOnce({ success: false, error: 'Failed to save cooldown' })
+    render(<AdvancedTab onClose={vi.fn()} />)
+    const overload = screen.getByLabelText('Quota / overload (minutes)')
+
+    fireEvent.change(overload, { target: { value: '15' } })
+    fireEvent.blur(overload)
+
+    expect(await screen.findByText('Failed to save cooldown')).toBeTruthy()
   })
 })

--- a/web/src/components/settings/tabs/AdvancedTab.tsx
+++ b/web/src/components/settings/tabs/AdvancedTab.tsx
@@ -21,6 +21,9 @@ export function AdvancedTab({ onClose }: { onClose: () => void }) {
   })
 
   const [retryPatterns, setRetryPatterns] = useState<RetryPatternsValue>({ patterns: [], maxRetriesPerTurn: 10 })
+  const [overloadCooldown, setOverloadCooldown] = useState('20')
+  const [transientCooldown, setTransientCooldown] = useState('2')
+  const [cooldownError, setCooldownError] = useState('')
 
   useEffect(() => {
     setLocalToggles({
@@ -35,6 +38,8 @@ export function AdvancedTab({ onClose }: { onClose: () => void }) {
     getSetting(SETTINGS_KEYS.LLM_DYNAMIC_SYSTEM_PROMPT)
     getSetting(SETTINGS_KEYS.CACHE_WARMING)
     getSetting(SETTINGS_KEYS.RETRY_PATTERNS)
+    getSetting(SETTINGS_KEYS.MODEL_CASCADE_OVERLOAD_COOLDOWN_MS)
+    getSetting(SETTINGS_KEYS.MODEL_CASCADE_TRANSIENT_COOLDOWN_MS)
   }, [getSetting])
 
   useEffect(() => {
@@ -46,6 +51,14 @@ export function AdvancedTab({ onClose }: { onClose: () => void }) {
         // ignore parse errors
       }
     }
+    const rawOverload = settings[SETTINGS_KEYS.MODEL_CASCADE_OVERLOAD_COOLDOWN_MS]
+    const rawTransient = settings[SETTINGS_KEYS.MODEL_CASCADE_TRANSIENT_COOLDOWN_MS]
+    const overload = Number(rawOverload)
+    const transient = Number(rawTransient)
+    if (rawOverload?.trim() && Number.isFinite(overload) && overload >= 0)
+      setOverloadCooldown(String(overload / 60_000))
+    if (rawTransient?.trim() && Number.isFinite(transient) && transient >= 0)
+      setTransientCooldown(String(transient / 60_000))
   }, [settings])
 
   const handleRetryPatternsChange = useCallback(
@@ -72,6 +85,16 @@ export function AdvancedTab({ onClose }: { onClose: () => void }) {
     const newValue = !localToggles.cacheWarming
     setLocalToggles((prev) => ({ ...prev, cacheWarming: newValue }))
     setSetting(SETTINGS_KEYS.CACHE_WARMING, String(newValue))
+  }
+
+  const saveCooldown = async (key: string, value: string) => {
+    const minutes = Number(value)
+    if (!value.trim() || !Number.isFinite(minutes) || minutes < 0) {
+      setCooldownError('Enter a non-negative number of minutes.')
+      return
+    }
+    const result = await setSetting(key, String(minutes * 60_000))
+    setCooldownError(result.success ? '' : (result.error ?? 'Failed to save cooldown.'))
   }
 
   function handleLaunchOnboarding() {
@@ -122,6 +145,64 @@ export function AdvancedTab({ onClose }: { onClose: () => void }) {
         onToggle={handleToggleDynamicSystemPrompt}
         boldTitle
       />
+      <hr className="border-border" />
+      <div>
+        <h3 className="text-sm font-medium text-text-primary mb-1">Model Cascade Cooldowns</h3>
+        <p className="text-xs text-text-muted mb-3">
+          Unavailable models are skipped across all sessions until their cooldown expires.
+        </p>
+        <div className="grid grid-cols-2 gap-3">
+          <label className="text-xs text-text-secondary">
+            Quota / overload (minutes)
+            <input
+              type="number"
+              min="0"
+              step="1"
+              value={overloadCooldown}
+              onChange={(event) => setOverloadCooldown(event.target.value)}
+              onBlur={() => saveCooldown(SETTINGS_KEYS.MODEL_CASCADE_OVERLOAD_COOLDOWN_MS, overloadCooldown)}
+              className="mt-1 w-full px-2 py-1.5 bg-bg-tertiary border border-border rounded"
+            />
+          </label>
+          <label className="text-xs text-text-secondary">
+            Network / timeout / 5xx (minutes)
+            <input
+              type="number"
+              min="0"
+              step="0.5"
+              value={transientCooldown}
+              onChange={(event) => setTransientCooldown(event.target.value)}
+              onBlur={() => saveCooldown(SETTINGS_KEYS.MODEL_CASCADE_TRANSIENT_COOLDOWN_MS, transientCooldown)}
+              className="mt-1 w-full px-2 py-1.5 bg-bg-tertiary border border-border rounded"
+            />
+          </label>
+        </div>
+        {cooldownError && (
+          <p role="alert" className="mt-2 text-xs text-error">
+            {cooldownError}
+          </p>
+        )}
+      </div>
+      <hr className="border-border" />
+      <div>
+        <h3 className="text-sm font-medium text-text-primary mb-3">Integrations</h3>
+        <SettingsToggle
+          title='Show "Open in VSCode" links'
+          description="Display a link on file reads to open the file directly in VS Code."
+          enabled={localToggles.openInEditor}
+          onToggle={handleToggleOpenInEditor}
+        />
+      </div>
+      <hr className="border-border" />
+      <div>
+        <h3 className="text-sm font-medium text-text-primary mb-1">Onboarding</h3>
+        <p className="text-sm text-text-muted mb-4">
+          Reset your OpenFox setup and go through the initial configuration again.
+        </p>
+        <Button variant="secondary" onClick={handleLaunchOnboarding}>
+          Launch Onboarding
+        </Button>
+      </div>
     </div>
   )
 }

--- a/web/src/stores/agents.ts
+++ b/web/src/stores/agents.ts
@@ -3,6 +3,11 @@ import { authFetch } from '../lib/api'
 import { saveEntity, duplicateEntity } from './utils'
 import { fetchItems } from './fetch-items'
 
+export interface AgentModelRef {
+  providerId: string
+  model: string
+}
+
 export interface AgentInfo {
   id: string
   name: string
@@ -11,6 +16,7 @@ export interface AgentInfo {
   allowedTools: string[]
   color?: string
   results?: string[]
+  modelCascade?: AgentModelRef[]
 }
 
 export interface AgentFull {
@@ -22,6 +28,7 @@ export interface AgentFull {
     allowedTools: string[]
     color?: string
     results?: string[]
+    modelCascade?: AgentModelRef[] | null
   }
   prompt: string
 }
@@ -36,6 +43,7 @@ interface AgentsState {
   defaults: AgentInfo[]
   userItems: AgentInfo[]
   projectItems: AgentInfo[]
+  overrideIds: string[]
   loading: boolean
   fetchAgents: () => Promise<void>
   fetchAgent: (agentId: string) => Promise<AgentFull | null>
@@ -55,6 +63,7 @@ export const useAgentsStore = create<AgentsState>((set) => {
     defaults: [],
     userItems: [],
     projectItems: [],
+    overrideIds: [],
     loading: false,
 
     fetchAgents,
@@ -99,9 +108,7 @@ export const useAgentsStore = create<AgentsState>((set) => {
         const res = await authFetch(`/api/agents/${agentId}`, { method: 'DELETE' })
         const data = await res.json()
         if (res.ok) {
-          set((state) => ({
-            userItems: state.userItems.filter((a) => a.id !== agentId),
-          }))
+          await fetchAgents()
           return { success: true }
         }
         return { success: false, error: data.error ?? 'Failed to delete' }

--- a/web/src/stores/fetch-items.ts
+++ b/web/src/stores/fetch-items.ts
@@ -10,7 +10,7 @@ export async function fetchItems(url: string, set: SetFn, hasProjectItems?: bool
     set({
       defaults: data.defaults ?? [],
       userItems: data.userItems ?? [],
-      ...(hasProjectItems ? { projectItems: data.projectItems ?? [] } : {}),
+      ...(hasProjectItems ? { projectItems: data.projectItems ?? [], overrideIds: data.overrideIds ?? [] } : {}),
       loading: false,
     } as Record<string, unknown>)
   } catch {

--- a/web/src/stores/settings.ts
+++ b/web/src/stores/settings.ts
@@ -27,7 +27,14 @@ export const SETTINGS_KEYS = {
   SEARCH_SEARXNG_API_KEY: 'search.searxngApiKey',
   TOOLS_USE_RTK: 'tools.useRtk',
   TOOLS_SHELL: 'tools.shell',
+  MODEL_CASCADE_OVERLOAD_COOLDOWN_MS: 'llm.modelCascadeOverloadCooldownMs',
+  MODEL_CASCADE_TRANSIENT_COOLDOWN_MS: 'llm.modelCascadeTransientCooldownMs',
 } as const
+
+export interface SettingSaveResult {
+  success: boolean
+  error?: string
+}
 
 interface SettingsState {
   // Cached settings values
@@ -37,7 +44,7 @@ interface SettingsState {
   // Actions
   getSetting: (key: string) => Promise<string | null>
   getSettings: (keys: string[]) => Promise<void>
-  setSetting: (key: string, value: string) => Promise<void>
+  setSetting: (key: string, value: string) => Promise<SettingSaveResult>
 }
 
 function setLoading(key: string, loading: boolean) {
@@ -124,9 +131,15 @@ export const useSettingsStore = create<SettingsState>((set) => ({
         body: JSON.stringify({ value }),
       })
       const data = await res.json()
-      set(setValue(key, data.value ?? ''))
+      if (!res.ok) {
+        set(setLoading(key, false))
+        return { success: false, error: data.error ?? 'Failed to save setting' }
+      }
+      set(setValue(key, data.value ?? value))
+      return { success: true }
     } catch {
       set(setLoading(key, false))
+      return { success: false, error: 'Network error' }
     }
   },
 }))


### PR DESCRIPTION
## Summary

Add configurable ordered model cascades for top-level agents and sub-agents.

Each agent can now either:

- inherit the active session model, which remains the default;
- define its own ordered provider/model cascade.

When a custom cascade is enabled, it fully replaces the session model for that agent. The first configured model always has priority, and fallback entries may use different providers.

## Fallback behavior

Fallback only occurs when a model fails before producing visible or actionable output.

A fallback is not attempted after receiving:

- text;
- thinking content;
- a tool-call delta.

This prevents duplicated responses and repeated tool execution.

The cascade runtime tracks temporary model unavailability in shared process memory.

Default cooldowns are:

- `429`, `503`, overload or quota failures: use `Retry-After`, otherwise 20 minutes;
- network failures, timeouts and other `5xx` errors: 2 minutes;
- `400`, `401`, `403` and `404`: unavailable until provider configuration changes.

When every configured model is unavailable, the request fails immediately with the reason and remaining delay for each model.

Cooldown durations can be changed under Settings → Advanced.

## Agent configuration

The agent editor now includes an ordered model cascade UI with:

- session-model inheritance;
- provider and model selectors;
- priority and fallback ordering;
- add, remove and reorder controls;
- explicit warnings for missing providers or models.

Cascade entries use structured `{ providerId, model }` values because model IDs may contain `/`.

## Built-in agent customization

Built-in agents such as Planner and Builder remain read-only.

Opening one shows its effective configuration and the `Duplicate & Customize` action. Duplicating creates a new custom agent with a fresh ID instead of editing or overriding the built-in ID.

This prevents Planner and Builder copies from sharing their built-in identifiers.

Existing built-in overrides can still be reset to reveal the bundled default configuration.

## Runtime changes

Agent-specific model resolution is applied to:

- top-level agent execution;
- conversation preprocessing;
- sub-agent execution;
- model capabilities and context limits;
- sampling and provider-specific settings;
- metrics and provider/model attribution.

Context limits are selected conservatively across the cascade so fallback to a smaller-context model cannot overflow.

## Error handling

LLM errors now preserve structured metadata including:

- HTTP status;
- parsed `Retry-After`;
- network, timeout and cancellation classification.

Stream cleanup also cancels the active reader, and terminal stream failures no longer emit duplicate recoverable errors.

## Testing

Added or updated coverage for:

- ordered fallback;
- cooldown expiration and priority restoration;
- `Retry-After`;
- permanent provider/model unavailability;
- no fallback after text or tool-call output;
- all-models-unavailable errors;
- successful fallback attribution;
- top-level and sub-agent cascade isolation;
- cascade persistence and validation;
- clearing cascades through explicit null metadata;
- built-in duplication with fresh IDs;
- built-in override reset;
- advanced cooldown settings;
- fallback UI messages.

Verification completed:

- `npm run typecheck` passes;
- `npm run lint` passes;
- focused agent duplication and override tests pass: 31/31;
- broad unit suite passes except for 12 existing macOS path-security assertions caused by `/tmp` resolving to `/private/tmp`.

## Follow-up work

Two improvements are intentionally left for follow-up work:

### Dynamic active model selector

When a cascade is active, update the main model selector dynamically to reflect the model currently used by the cascade runtime.

The UI should distinguish between:

- the session model;
- the configured priority model;
- the model currently used by the active cascade.

### Global all-purpose cascade

Add an optional global cascade applying to every top-level agent and sub-agent.

Expected precedence:

1. explicit agent-level cascade;
2. global all-purpose agent cascade;
3. active session model.
