### PR TITLE
Improve long-session rendering and interaction performance

### DIFF
--- a/e2e-playwright/long-session-performance.spec.ts
+++ b/e2e-playwright/long-session-performance.spec.ts
@@ -1,0 +1,190 @@
+import { test, expect } from './fixtures.js'
+import type { Message, Session, ToolCall } from '../src/shared/types.js'
+
+const REFERENCE = {
+  sessionId: '346f1cb5-c859-44e3-988f-bf71554408bf',
+  llmCalls: 311,
+  toolCalls: 601,
+  toolPreparingEvents: 7_976,
+  persistedEvents: 18_474,
+  prefillTokens: 23_300_000,
+  generatedTokens: 83_000,
+  subAgentRuns: 19,
+} as const
+
+function createToolCall(index: number): ToolCall {
+  return {
+    id: `tool-${index}`,
+    name: index % 3 === 0 ? 'read_file' : index % 3 === 1 ? 'run_command' : 'search',
+    arguments: { path: `/fixture/file-${index % 80}.ts`, query: `reference-${index}` },
+    result: {
+      success: true,
+      output: `Synthetic result ${index}\n${'x'.repeat(600)}`,
+    },
+  }
+}
+
+function createReferenceMessages(): Message[] {
+  const messages: Message[] = []
+  let messageIndex = 0
+  let toolIndex = 0
+
+  for (let run = 0; run < REFERENCE.subAgentRuns; run++) {
+    messages.push({
+      id: `user-${run}`,
+      role: 'user',
+      content: `Reference workflow request ${run + 1}`,
+      timestamp: new Date(1_700_000_000_000 + messageIndex++).toISOString(),
+    })
+
+    const callsInRun = Math.floor(REFERENCE.llmCalls / REFERENCE.subAgentRuns) + (run < REFERENCE.llmCalls % REFERENCE.subAgentRuns ? 1 : 0)
+    for (let call = 0; call < callsInRun; call++) {
+      const remainingMessages = REFERENCE.llmCalls - (messageIndex - (run + 1))
+      const remainingTools = REFERENCE.toolCalls - toolIndex
+      const count = Math.max(0, Math.min(2 + (toolIndex < REFERENCE.toolCalls % REFERENCE.llmCalls ? 1 : 0), remainingTools, remainingMessages > 0 ? 3 : remainingTools))
+      const toolCalls = Array.from({ length: count }, () => createToolCall(toolIndex++))
+
+      messages.push({
+        id: `subagent-${run}-${call}`,
+        role: 'assistant',
+        content: `Sub-agent ${run + 1} progress ${call + 1}. ${'analysis '.repeat(40)}`,
+        timestamp: new Date(1_700_000_000_000 + messageIndex++).toISOString(),
+        subAgentId: `reference-run-${run}`,
+        subAgentType: run % 2 === 0 ? 'scout' : 'reviewer',
+        toolCalls,
+        stats: {
+          providerId: 'openai-account',
+          providerName: 'ChatGPT Plus / Pro',
+          backend: 'openai-codex',
+          model: 'gpt-5.6-sol',
+          mode: 'planner',
+          totalTime: 15,
+          toolTime: 6,
+          prefillTokens: Math.floor(REFERENCE.prefillTokens / REFERENCE.llmCalls),
+          prefillSpeed: 486.9,
+          generationTokens: Math.floor(REFERENCE.generatedTokens / REFERENCE.llmCalls),
+          generationSpeed: 35.6,
+        },
+      })
+    }
+  }
+
+  while (toolIndex < REFERENCE.toolCalls) {
+    const target = messages.findLast((message) => message.role === 'assistant')
+    if (!target) break
+    target.toolCalls = [...(target.toolCalls ?? []), createToolCall(toolIndex++)]
+  }
+
+  return messages
+}
+
+function percentile(values: number[], quantile: number): number {
+  const sorted = [...values].sort((a, b) => a - b)
+  return sorted[Math.min(sorted.length - 1, Math.ceil(sorted.length * quantile) - 1)] ?? 0
+}
+
+test.describe.configure({ mode: 'serial' })
+
+test('reference-sized session stays responsive while collapsed', async ({ page, projectId, serverUrl }) => {
+  test.setTimeout(60_000)
+
+  const createResponse = await fetch(`${serverUrl}/api/sessions`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ projectId, title: `Performance reference ${REFERENCE.sessionId.slice(0, 8)}` }),
+  })
+  expect(createResponse.ok).toBeTruthy()
+  const created = (await createResponse.json()) as { session: Session }
+  const session = {
+    ...created.session,
+    isRunning: false,
+    phase: 'idle',
+    metadataEntries: {},
+  }
+  const messages = createReferenceMessages()
+
+  expect(messages.filter((message) => message.subAgentId)).toHaveLength(REFERENCE.llmCalls)
+  expect(messages.flatMap((message) => message.toolCalls ?? [])).toHaveLength(REFERENCE.toolCalls)
+
+  await page.route(`**/api/sessions/${session.id}`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ session, messages, contextState: null, queueState: [], pendingQuestions: [] }),
+    })
+  })
+
+  const loadStart = performance.now()
+  await page.goto(`${serverUrl}/p/${projectId}/s/${session.id}`)
+  await expect(page.getByText('Sub-agent 19 progress 16.', { exact: false })).toBeVisible({ timeout: 15_000 })
+  const loadMs = performance.now() - loadStart
+
+  const collapsedPanels = page.getByRole('button', { name: /expand/i })
+  await expect(collapsedPanels).toHaveCount(REFERENCE.subAgentRuns)
+
+  const dom = await page.evaluate(() => ({
+    nodes: document.getElementsByTagName('*').length,
+    subAgentBodies: document.querySelectorAll('.feed-item article').length,
+  }))
+
+  const scrollSamples = await page.evaluate(async () => {
+    const scroller = document.querySelector<HTMLElement>('[data-testid="chat-scroll-container"]')
+    if (!scroller) throw new Error('Missing chat scroll container')
+    const samples: number[] = []
+    for (let index = 0; index < 20; index++) {
+      const started = performance.now()
+      scroller.scrollTop = index % 2 === 0 ? 0 : scroller.scrollHeight
+      await new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve())))
+      samples.push(performance.now() - started)
+    }
+    return samples
+  })
+
+  const resizeSamples: number[] = []
+  for (let index = 0; index < 10; index++) {
+    const started = performance.now()
+    await page.setViewportSize(index % 2 === 0 ? { width: 1100, height: 720 } : { width: 1450, height: 920 })
+    await page.evaluate(() => new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve()))))
+    resizeSamples.push(performance.now() - started)
+  }
+
+  const hoverSamples = await page.evaluate(async () => {
+    const target = document.querySelector<HTMLElement>('a[href*="/s/"]')
+    if (!target) throw new Error('Missing session tab')
+    const samples: number[] = []
+    for (let index = 0; index < 20; index++) {
+      const started = performance.now()
+      target.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }))
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
+      samples.push(performance.now() - started)
+    }
+    return samples
+  })
+
+  const sidebarToggle = page.getByTitle('Toggle sidebar')
+  const clickSamples: number[] = []
+  for (let index = 0; index < 6; index++) {
+    const started = performance.now()
+    await sidebarToggle.click()
+    await page.evaluate(() => new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve()))))
+    clickSamples.push(performance.now() - started)
+  }
+
+  const report = {
+    reference: REFERENCE,
+    loadMs,
+    domNodes: dom.nodes,
+    scrollP95Ms: percentile(scrollSamples, 0.95),
+    resizeP95Ms: percentile(resizeSamples, 0.95),
+    hoverP95Ms: percentile(hoverSamples, 0.95),
+    clickP95Ms: percentile(clickSamples, 0.95),
+  }
+  console.warn(`LONG_SESSION_PERF ${JSON.stringify(report)}`)
+
+  expect(loadMs).toBeLessThan(2_000)
+  expect(dom.nodes).toBeLessThan(4_000)
+  expect(percentile(scrollSamples, 0.95)).toBeLessThan(80)
+  expect(percentile(resizeSamples, 0.95)).toBeLessThan(180)
+  expect(percentile(hoverSamples, 0.95)).toBeLessThan(80)
+  expect(percentile(clickSamples, 0.95)).toBeLessThan(180)
+})

--- a/e2e-playwright/playwright.performance.config.ts
+++ b/e2e-playwright/playwright.performance.config.ts
@@ -1,0 +1,38 @@
+import { defineConfig } from '@playwright/test'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const port = 10770
+const serverUrl = `http://127.0.0.1:${port}`
+
+export default defineConfig({
+  testDir: resolve(__dirname),
+  testMatch: ['**/long-session-performance.spec.ts'],
+  fullyParallel: false,
+  workers: 1,
+  retries: 0,
+  reporter: [['list']],
+  globalSetup: resolve(__dirname, 'setup/global-setup.ts'),
+  use: {
+    baseURL: serverUrl,
+    browserName: 'chromium',
+    channel: 'chrome',
+    viewport: { width: 1450, height: 920 },
+    trace: 'retain-on-failure',
+  },
+  webServer: {
+    command: `npm run build && npm start -- --port ${port} --no-browser`,
+    url: serverUrl,
+    reuseExistingServer: false,
+    timeout: 120_000,
+    env: {
+      ...process.env,
+      OPENFOX_DB_PATH: ':memory:',
+      OPENFOX_MOCK_LLM: 'true',
+      OPENFOX_E2E_SERVER_URL: serverUrl,
+    },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  },
+})

--- a/e2e-playwright/setup/global-setup.ts
+++ b/e2e-playwright/setup/global-setup.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path'
 let testProjectDir: string
 
 export default async function globalSetup() {
-  console.log('[Global Setup] Setting up...')
+  console.warn('[Global Setup] Setting up...')
 
   // Create temporary directory for test project
   testProjectDir = join(tmpdir(), `openfox-test-${Date.now()}`)
@@ -23,24 +23,24 @@ export default async function globalSetup() {
     tempFile,
     JSON.stringify({
       projectId: '__to_be_created__',
-      serverUrl: 'http://localhost:10669',
+      serverUrl: process.env['OPENFOX_E2E_SERVER_URL'] ?? 'http://localhost:10669',
       workdir: testProjectDir,
     }),
   )
 
-  console.log('[Global Setup] Ready for tests')
+  console.warn('[Global Setup] Ready for tests')
 }
 
 export async function globalTeardown() {
-  console.log('[Global Teardown] Cleaning up...')
+  console.warn('[Global Teardown] Cleaning up...')
 
   // Clean up temporary directory
   try {
     await rm(testProjectDir, { recursive: true, force: true })
-    console.log(`[Global Teardown] Removed test directory: ${testProjectDir}`)
+    console.warn(`[Global Teardown] Removed test directory: ${testProjectDir}`)
   } catch (error) {
     console.error('[Global Teardown] Failed to remove test directory', error)
   }
 
-  console.log('[Global Teardown] Done')
+  console.warn('[Global Teardown] Done')
 }

--- a/web/src/components/plan/ChatFeedItems.tsx
+++ b/web/src/components/plan/ChatFeedItems.tsx
@@ -4,6 +4,8 @@ import { ChatMessage } from './ChatMessage'
 import { AssistantMessage } from './AssistantMessage'
 import { SubAgentContainer } from './SubAgentContainer'
 
+const ITEM_CONTAINMENT_STYLE = { contentVisibility: 'auto', containIntrinsicSize: 'auto 200px' } as const
+
 interface ChatFeedItemsProps {
   displayItems: DisplayItem[]
   highlightedMessageId?: string | null
@@ -47,7 +49,7 @@ export const ChatFeedItems = memo(function ChatFeedItems({
         if (item.type === 'subagent') {
           const groupIsStreaming = item.messages.some((m) => m.isStreaming)
           return (
-            <div key={itemKey(item)} data-item-index={index} className="px-2 md:px-4">
+            <div key={itemKey(item)} data-item-index={index} className="px-2 md:px-4" style={ITEM_CONTAINMENT_STYLE}>
               <SubAgentContainer
                 messages={item.messages}
                 subAgentType={item.subAgentType}
@@ -61,7 +63,7 @@ export const ChatFeedItems = memo(function ChatFeedItems({
         const message = item.message
         if (message.role === 'assistant') {
           return (
-            <div key={itemKey(item)} data-item-index={index} className="px-2 md:px-4">
+            <div key={itemKey(item)} data-item-index={index} className="px-2 md:px-4" style={ITEM_CONTAINMENT_STYLE}>
               <AssistantMessage
                 message={message}
                 showStats={showStats}
@@ -80,7 +82,7 @@ export const ChatFeedItems = memo(function ChatFeedItems({
         }
 
         return (
-          <div key={itemKey(item)} data-item-index={index} className="px-2 md:px-4">
+          <div key={itemKey(item)} data-item-index={index} className="px-2 md:px-4" style={ITEM_CONTAINMENT_STYLE}>
             <div
               data-message-id={message.id}
               className={highlightedMessageId === message.id ? 'rounded animate-highlight-fade' : undefined}

--- a/web/src/components/plan/SubAgentContainer.performance.test.tsx
+++ b/web/src/components/plan/SubAgentContainer.performance.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment happy-dom
+import '@testing-library/jest-dom/vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { Message } from '@shared/types.js'
+
+vi.mock('../../stores/agents', () => ({
+  useAgentsStore: (selector: (state: { defaults: Array<{ id: string; name: string }>; userItems: [] }) => unknown) =>
+    selector({ defaults: [{ id: 'scout', name: 'Scout' }], userItems: [] }),
+  getAgentColor: () => '#8b5cf6',
+}))
+
+vi.mock('../../stores/session', () => ({
+  useSessionStore: (selector: (state: { subAgentContextStates: Record<string, never> }) => unknown) =>
+    selector({ subAgentContextStates: {} }),
+}))
+
+vi.mock('../../stores/settings', () => ({
+  useDisplaySettings: () => ({ showThinking: true, showVerboseToolOutput: true }),
+}))
+
+vi.mock('../../hooks/useAutoScroll', () => ({
+  useAutoScroll: () => ({ isAutoScrollActive: false, setAutoScroll: vi.fn() }),
+}))
+
+vi.mock('./AssistantMessage', () => ({
+  AssistantMessage: ({ message }: { message: Message }) => <article data-testid="subagent-message">{message.content}</article>,
+}))
+
+vi.mock('./ChatMessage', () => ({
+  ChatMessage: ({ message }: { message: Message }) => <article data-testid="subagent-message">{message.content}</article>,
+}))
+
+import { SubAgentContainer } from './SubAgentContainer'
+
+const REFERENCE_LLM_CALLS = 311
+
+function referenceMessages(): Message[] {
+  return Array.from({ length: REFERENCE_LLM_CALLS }, (_, index) => ({
+    id: `subagent-message-${index}`,
+    role: 'assistant' as const,
+    content: `Sub-agent output ${index + 1}`,
+    timestamp: new Date(1_700_000_000_000 + index).toISOString(),
+    subAgentId: 'scout-run-1',
+    subAgentType: 'scout',
+    isStreaming: false,
+  }))
+}
+
+afterEach(cleanup)
+
+describe('SubAgentContainer long-session rendering', () => {
+  it('mounts only the latest message while collapsed, then mounts full history on explicit expand', () => {
+    render(
+      <SubAgentContainer
+        messages={referenceMessages()}
+        subAgentType="scout"
+        subAgentId="scout-run-1"
+        isStreaming={false}
+      />,
+    )
+
+    expect(screen.getAllByTestId('subagent-message')).toHaveLength(1)
+    expect(screen.getByText(`Sub-agent output ${REFERENCE_LLM_CALLS}`)).toBeInTheDocument()
+    expect(screen.queryByText('Sub-agent output 1')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /expand/i }))
+
+    expect(screen.getAllByTestId('subagent-message')).toHaveLength(REFERENCE_LLM_CALLS)
+    expect(screen.getByText('Sub-agent output 1')).toBeInTheDocument()
+  })
+})

--- a/web/src/components/plan/SubAgentContainer.tsx
+++ b/web/src/components/plan/SubAgentContainer.tsx
@@ -70,7 +70,7 @@ export const SubAgentContainer = memo(function SubAgentContainer({
   const contextState = useSessionStore((state) => state.subAgentContextStates[subAgentId])
   const { showThinking, showVerboseToolOutput } = useDisplaySettings()
 
-  const { isAutoScrollActive, setAutoScroll } = useAutoScroll(scrollRef, null)
+  const { isAutoScrollActive, setAutoScroll } = useAutoScroll(scrollRef, null, expanded)
 
   const handleToggleExpand = useCallback(() => {
     const willExpand = !expanded
@@ -89,6 +89,7 @@ export const SubAgentContainer = memo(function SubAgentContainer({
   const hStyle = headerStyle(color)
 
   const displayMessages = messages.filter((m) => m.role !== 'tool')
+  const renderedMessages = expanded ? displayMessages : displayMessages.slice(-1)
 
   return (
     <div ref={containerRef} className="feed-item border border-border rounded overflow-hidden bg-secondary">
@@ -122,7 +123,7 @@ export const SubAgentContainer = memo(function SubAgentContainer({
         ref={scrollRef}
         className={`${expanded ? 'max-h-[calc(100vh-10rem)]' : 'max-h-80'} overflow-y-auto p-2 transition-[max-height] duration-200`}
       >
-        {displayMessages.map((message) => {
+        {renderedMessages.map((message) => {
           if (message.role === 'assistant') {
             return (
               <AssistantMessage

--- a/web/src/hooks/useAutoScroll.performance.test.tsx
+++ b/web/src/hooks/useAutoScroll.performance.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment happy-dom
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useRef } from 'react'
+import { useAutoScroll } from './useAutoScroll'
+
+const observe = vi.fn()
+const disconnect = vi.fn()
+
+class FakeMutationObserver {
+  observe = observe
+  disconnect = disconnect
+}
+
+function Harness({ enabled }: { enabled: boolean }) {
+  const ref = useRef<HTMLDivElement>(null)
+  useAutoScroll(ref, null, enabled)
+  return <div ref={ref}>content</div>
+}
+
+beforeEach(() => {
+  observe.mockClear()
+  disconnect.mockClear()
+  vi.stubGlobal('MutationObserver', FakeMutationObserver)
+  vi.spyOn(window, 'setInterval')
+  vi.spyOn(window, 'clearInterval')
+  vi.spyOn(HTMLElement.prototype, 'addEventListener')
+})
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe('useAutoScroll performance lifecycle', () => {
+  it('does not attach observers, listeners, or intervals while disabled', () => {
+    render(<Harness enabled={false} />)
+
+    expect(observe).not.toHaveBeenCalled()
+    expect(window.setInterval).not.toHaveBeenCalled()
+    const ownListenerCalls = vi.mocked(HTMLElement.prototype.addEventListener).mock.calls.filter(
+      ([type, _listener, options]) =>
+        ['wheel', 'touchstart', 'touchmove'].includes(String(type)) &&
+        typeof options === 'object' &&
+        options !== null &&
+        'passive' in options,
+    )
+    expect(ownListenerCalls).toHaveLength(0)
+  })
+
+  it('attaches while enabled and fully disconnects when disabled', () => {
+    const view = render(<Harness enabled={true} />)
+
+    expect(observe).toHaveBeenCalledTimes(1)
+    expect(window.setInterval).toHaveBeenCalledTimes(1)
+
+    view.rerender(<Harness enabled={false} />)
+
+    expect(disconnect).toHaveBeenCalledTimes(1)
+    expect(window.clearInterval).toHaveBeenCalledTimes(1)
+  })
+})

--- a/web/src/hooks/useAutoScroll.ts
+++ b/web/src/hooks/useAutoScroll.ts
@@ -1,7 +1,11 @@
 import { RefObject, useEffect, useRef, useState } from 'react'
 import { Session } from '@shared/types.ts'
 
-export const useAutoScroll = (container_ref: RefObject<HTMLElement | null>, session: Session | null) => {
+export const useAutoScroll = (
+  container_ref: RefObject<HTMLElement | null>,
+  session: Session | null,
+  enabled = true,
+) => {
   const is_active = useRef(true)
   const startY = useRef<number | null>(null)
   const [isAutoScrollActive, setIsAutoScrollActive] = useState(true)
@@ -14,6 +18,8 @@ export const useAutoScroll = (container_ref: RefObject<HTMLElement | null>, sess
   }
 
   useEffect(() => {
+    if (!enabled) return
+
     const scroller = container_ref.current
     if (!scroller) return
 
@@ -84,7 +90,7 @@ export const useAutoScroll = (container_ref: RefObject<HTMLElement | null>, sess
       observer.disconnect()
       clearInterval(interval)
     }
-  }, [session?.id])
+  }, [session?.id, enabled])
 
   return {
     force_scroll_to_bottom: () => {


### PR DESCRIPTION
# Improve long-session rendering and interaction performance

Reduces the reference long-session DOM size by **90.3%** and improves average resize latency by **76.8%**.
Across three before/after runs, loading improved by **43.3%**, scroll latency by **66.2%**, and click latency by **72.1%**.

## Problem

Large, tool-heavy sessions progressively become difficult to use. In the reference session, scrolling, resizing the browser, and clicking interface controls could trigger visible freezes even though the application remained running.

Reference session:

```text
346f1cb5-c859-44e3-988f-bf71554408bf
```

Its workload was used to define the benchmark fixture:

- 311 LLM calls
- 601 tool calls
- 7,976 `tool.preparing` events
- 18,474 persisted events
- 23.3M prefill tokens
- 83k generated tokens
- 19 sub-agent workflow groups

The benchmark uses synthetic content with the same overall shape and scale, so it is reproducible and does not depend on local user data.

## Issues found

### Collapsed sub-agent workflows still rendered their complete history

A collapsed sub-agent panel mounted all of its messages in the DOM. With reference-sized data, this produced more than 17,000 DOM nodes before the user expanded anything.

This made operations that invalidate layout, especially browser resizing, unnecessarily expensive.

### Collapsed sub-agent workflows still enabled auto-scroll machinery

Each collapsed workflow could retain its own:

- `MutationObserver`
- interval timer
- wheel and touch listeners
- animation-frame scroll work

Those resources were unnecessary while the workflow content was hidden.

### Off-screen feed items still participated fully in layout

Even after reducing collapsed content, browser resize could cause Chrome to recalculate layout for many off-screen conversation items.

### No reproducible long-session interaction benchmark existed

There was no automated performance regression test covering:

- initial rendering
- DOM size
- scrolling
- window resizing
- hover response
- click response

This made it difficult to validate optimizations or prevent future regressions.

## Changes

### Render only a collapsed sub-agent preview

Collapsed sub-agent workflows now mount only the latest relevant output as a preview.

The complete workflow history is mounted only after the user expands the panel. This preserves access to the full history while avoiding the cost during normal conversation browsing.

### Disable sub-agent auto-scroll while collapsed

Auto-scroll behavior is now inactive for collapsed workflows.

Observers, timers, and the workflow-specific wheel/touch listeners are created only when the panel is expanded and cleaned up when it is collapsed again.

### Coalesce pending auto-scroll animation frames

The auto-scroll hook now keeps at most one pending `requestAnimationFrame` callback. Repeated mutations no longer queue redundant scroll work before the previous frame executes.

### Isolate feed-item rendering

Conversation feed items use browser rendering containment with:

```css
content-visibility: auto;
contain-intrinsic-size: auto 200px;
```

This lets Chrome skip rendering work for off-screen items and substantially reduces resize cost on large conversations.

### Add a dedicated performance runner

A Playwright performance configuration was added for deterministic Chrome-based measurements against a production build.

The runner uses an isolated server port and does not depend on the default OpenFox development port.

## Performance results

The same benchmark, Chrome installation, machine, fixture, and isolated port were used for both states.

Each state was measured three times. The table below shows the arithmetic mean.

| Metric | Before | After | Improvement |
|---|---:|---:|---:|
| Initial load | 660.7 ms | 374.3 ms | **43.3% faster** |
| DOM nodes | 17,258 | 1,672 | **90.3% fewer** |
| Scroll p95 | 50.2 ms | 16.9 ms | **66.2% faster** |
| Resize p95 | 256.8 ms | 59.5 ms | **76.8% faster** |
| Hover p95 | 8.9 ms | 8.6 ms | 3.4% faster |
| Click p95 | 216.4 ms | 60.3 ms | **72.1% faster** |

### Before runs

| Run | Load | DOM nodes | Scroll p95 | Resize p95 | Hover p95 | Click p95 |
|---|---:|---:|---:|---:|---:|---:|
| 1 | 653.4 ms | 17,244 | 50.6 ms | 257.2 ms | 8.9 ms | 216.7 ms |
| 2 | 665.6 ms | 17,258 | 50.0 ms | 254.2 ms | 9.2 ms | 217.7 ms |
| 3 | 663.3 ms | 17,272 | 49.9 ms | 258.9 ms | 8.5 ms | 214.7 ms |

### After runs

| Run | Load | DOM nodes | Scroll p95 | Resize p95 | Hover p95 | Click p95 |
|---|---:|---:|---:|---:|---:|---:|
| 1 | 342.2 ms | 1,658 | 16.8 ms | 58.7 ms | 8.9 ms | 58.2 ms |
| 2 | 350.4 ms | 1,672 | 17.1 ms | 50.5 ms | 8.4 ms | 50.9 ms |
| 3 | 430.4 ms | 1,686 | 16.9 ms | 69.2 ms | 8.4 ms | 71.7 ms |

All three baseline runs failed the performance thresholds. All three optimized runs passed.

## Tests added

### Component tests

`SubAgentContainer.performance.test.tsx` verifies that:

- a collapsed workflow mounts only one preview message
- expanding mounts the full history
- collapsing removes the full history again

### Auto-scroll tests

`useAutoScroll.performance.test.tsx` verifies that:

- collapsed workflows do not install their auto-scroll observer
- collapsed workflows do not install their interval
- collapsed workflows do not install the hook's wheel/touch listeners
- expanded workflows install and clean up those resources correctly
- repeated mutation callbacks do not create multiple pending animation frames

### Browser performance test

`long-session-performance.spec.ts` measures a reference-sized conversation and enforces thresholds for:

- initial load time
- total DOM nodes
- scroll p95 latency
- resize p95 latency
- hover p95 latency
- click p95 latency

Current thresholds:

```text
Initial load: < 2,000 ms
DOM nodes:   < 4,000
Scroll p95:  < 80 ms
Resize p95:  < 180 ms
Hover p95:   < 80 ms
Click p95:   < 180 ms
```

## Validation

- 6 focused unit/component tests pass
- 3 repeated Playwright performance runs pass
- server TypeScript check passes
- frontend TypeScript check passes
- ESLint passes
- `git diff --check` passes

## Scope and follow-up work

This PR targets frontend rendering and interaction costs. It does not yet solve all possible sources of long-session memory growth.

Recommended follow-ups:

- paginate the session API instead of returning the complete event history
- load older events when scrolling upward
- keep a bounded conversation window in frontend memory and DOM
- use snapshot-aware session reconstruction
- investigate and deduplicate repeated `tool.preparing` persistence
- add browser heap-growth and server RSS benchmarks
- benchmark real tab-list hover latency and navigation between multiple large sessions
