### PR TITLE
fix(lsp): Windows LSP servers fail to start (.cmd/.bat shims, spawn race)

### DIFF
--- a/src/server/lsp/server.test.ts
+++ b/src/server/lsp/server.test.ts
@@ -40,6 +40,11 @@ function createProcessMock(withStdio = true) {
   proc.stdin = withStdio ? new EventEmitter() : null
   proc.stdout = withStdio ? new EventEmitter() : null
   proc.stderr = new EventEmitter()
+  // start() waits for 'spawn' before wiring JSON-RPC; emit it as soon as the
+  // listener registers (microtask, since tests run with fake timers)
+  proc.on('newListener', (event: string) => {
+    if (event === 'spawn') queueMicrotask(() => proc.emit('spawn'))
+  })
   return proc
 }
 

--- a/src/server/lsp/server.ts
+++ b/src/server/lsp/server.ts
@@ -212,8 +212,16 @@ export class LspServer {
     this.state = 'starting'
 
     try {
-      // Spawn the language server process using resolved command path
-      this.process = spawn(this.commandPath, this.config.serverArgs, {
+      // Spawn the language server process using resolved command path.
+      // Windows .cmd/.bat shims cannot be spawned directly (Node rejects them
+      // without a shell). With a shell, pass a single pre-quoted command line:
+      // args arrays alongside shell:true are deprecated (DEP0190), and quoting
+      // keeps cmd.exe happy when the path contains spaces.
+      const needsShell = process.platform === 'win32' && /\.(cmd|bat)$/i.test(this.commandPath)
+      const command = needsShell
+        ? [`"${this.commandPath}"`, ...this.config.serverArgs].join(' ')
+        : this.commandPath
+      this.process = spawn(command, needsShell ? [] : this.config.serverArgs, {
         cwd: this.workdir,
         stdio: ['pipe', 'pipe', 'pipe'],
         env: {
@@ -222,11 +230,30 @@ export class LspServer {
           PATH: process.env['PATH'],
         },
         windowsHide: true,
+        shell: needsShell,
+      })
+
+      // Wait for the process to actually spawn before wiring JSON-RPC onto its
+      // stdio. If spawn fails (e.g. ENOENT), sending initialize would leave an
+      // in-flight write on a destroyed stdin, and vscode-jsonrpc's sendRequest
+      // (async promise executor, connection.js) turns that write failure into
+      // an unhandled rejection that crashes the whole OpenFox process.
+      await new Promise<void>((resolve, reject) => {
+        this.process!.once('spawn', resolve)
+        this.process!.once('error', reject)
       })
 
       if (!this.process.stdin || !this.process.stdout) {
         throw new Error('Failed to get stdio streams from language server process')
       }
+
+      // A dying server can still emit late stream errors (e.g. write after its
+      // stdin got destroyed); without a listener those crash the process.
+      const onStreamError = (err: Error) => {
+        logger.debug('LSP stream error', { language: this.config.id, error: err.message })
+      }
+      this.process.stdin.on('error', onStreamError)
+      this.process.stdout.on('error', onStreamError)
 
       // Set up JSON-RPC connection
       this.connection = createMessageConnection(

--- a/src/server/utils/which.ts
+++ b/src/server/utils/which.ts
@@ -37,6 +37,31 @@ async function existsExecutable(path: string): Promise<boolean> {
 }
 
 /**
+ * Candidate filenames for a command in a directory.
+ * On Windows, the bare name in node_modules/.bin is a bash shim that
+ * spawn() cannot execute — try Windows-executable extensions first.
+ */
+function candidateNames(command: string): string[] {
+  if (process.platform !== 'win32') {
+    return [command]
+  }
+  return ['.cmd', '.exe', '.bat', ''].map((ext) => command + ext)
+}
+
+/**
+ * Find an executable candidate for a command inside a directory.
+ */
+async function findInDir(dir: string, command: string): Promise<string | null> {
+  for (const name of candidateNames(command)) {
+    const fullPath = join(dir, name)
+    if (await existsExecutable(fullPath)) {
+      return fullPath
+    }
+  }
+  return null
+}
+
+/**
  * Find the path to an executable command.
  * Search order:
  * 1. Bundled language servers in @openfox/server's node_modules/.bin
@@ -55,17 +80,17 @@ export async function which(command: string, workdir?: string): Promise<string |
 
   // 1. Check bundled node_modules/.bin first (language servers bundled with @openfox/server)
   for (const binDir of getBundledBinPaths()) {
-    const fullPath = join(binDir, command)
-    if (await existsExecutable(fullPath)) {
-      return fullPath
+    const found = await findInDir(binDir, command)
+    if (found) {
+      return found
     }
   }
 
   // 2. Check project-local node_modules/.bin (if workdir provided)
   if (workdir) {
-    const projectBin = join(workdir, 'node_modules', '.bin', command)
-    if (await existsExecutable(projectBin)) {
-      return projectBin
+    const found = await findInDir(join(workdir, 'node_modules', '.bin'), command)
+    if (found) {
+      return found
     }
   }
 
@@ -76,9 +101,9 @@ export async function which(command: string, workdir?: string): Promise<string |
   for (const dir of paths) {
     if (!dir) continue
 
-    const fullPath = join(dir, command)
-    if (await existsExecutable(fullPath)) {
-      return fullPath
+    const found = await findInDir(dir, command)
+    if (found) {
+      return found
     }
   }
 


### PR DESCRIPTION
## Symptoms

On Windows, LSP support is completely broken — and worse, it can crash the whole OpenFox server.

Concrete example: ask the LLM to run/edit a Python parsing script. The first `.py` file touched triggers a pyright startup, and the server dies:

``
[ERROR] LSP server process error {"language":"python","error":"spawn D:\github\Openfox\node_modules\.bin\pyright-langserver ENOENT"}
``
``
[ERROR] Failed to start LSP server {"language":"python","command":"pyright-langserver","error":"Pending response rejected since connection got disposed"}
``
``
Error [ERR_STREAM_DESTROYED]: Cannot call write after a stream was destroyed
    at WritableStreamWrapper.write (node_modules\vscode-jsonrpc\lib\node\ril.js:78:16)
``
    ...

The Node process exits — every session is lost, not just the LSP.

## Cause

Two distinct bugs stacked on each other:

1. **`which()` is not Windows-aware** (`src/server/utils/which.ts`). It probes `join(dir, command)` without ever trying Windows executable extensions, and `access(X_OK)` is a no-op on win32 (any existing file passes). In `node_modules/.bin` it therefore resolves the **extensionless bash shim** (`pyright-langserver`) instead of `pyright-langserver.cmd`. Windows cannot execute a bash script → `spawn()` fails with ENOENT.

2. **A failed spawn crashes the whole server** (`src/server/lsp/server.ts`). `start()` wires the JSON-RPC connection and sends `initialize` immediately after `spawn()`. When the spawn fails, the `error` event disposes the connection while the initialize write is still in flight; the write then lands on the destroyed stdin. This hits an upstream bug in `vscode-jsonrpc` (`sendRequest` uses an async promise executor and re-throws on write failure — connection.js:1091, still present in 9.0.1, so bumping doesn't help): the rejection is unhandled and kills the Node process.

## Fix

- `which.ts`: on win32, try `command + ext` for `.cmd`, `.exe`, `.bat` before the bare name, in every search location (bundled `.bin`, project-local `.bin`, system PATH). Extracted a shared `findInDir()` helper (also removes the existing triplication).
- `server.ts`: spawn `.cmd`/`.bat` through a shell, passing a single pre-quoted command line (Node rejects `.cmd` without a shell; the args-array-with-shell form is deprecated, DEP0190; quoting survives spaces in the path).
- `server.ts`: **await the `spawn` event before wiring JSON-RPC**. A failed spawn now rejects cleanly inside `start()`'s try/catch — the server is marked unavailable and no write ever reaches a destroyed stream. Also attach `error` listeners on stdin/stdout so late stream errors from a dying server can never surface as uncaught exceptions.
- `server.test.ts`: the process mock now emits `spawn` when the listener registers.

## Tests

**Windows 11 (win32):**
- `tsc --noEmit` clean; `vitest` on `src/server/utils/which.test.ts` + `src/server/lsp/` → 88/88 pass.
- E2E with the real bundled pyright: `which('pyright-langserver')` resolves `...\.bin\pyright-langserver.cmd`, `LspServer.start()` completes the full `initialize` handshake via cmd.exe (`state: running`), clean stop.
- Crash repro (spawn of a nonexistent command through `LspServer.start()`): before the fix, uncaught `ERR_STREAM_DESTROYED` kills the process; after, `start()` rejects cleanly (`spawn ... ENOENT`) and the process stays alive.
- Full unit suite: 206 failures, all pre-existing Windows portability issues in unrelated files (`path-security` expects `/tmp`, `worktree`, `process-tree`…) — none in `lsp/` or `which`.

**Unix:** not re-run locally (Windows machine). The changes are win32-gated no-ops there: `candidateNames()` returns the bare command on non-win32, `needsShell` is always false, and the `spawn`-event await is
portable Node ≥ 15.1 behavior. Existing CI suite covers the Unix path.

**The Python parsing script (concrete example) :**  after implementing the fix , the LLM successfully ran the python parsing scripting without any crash.