### PR TITLE
feat: display all session metadata keys in sidebar

### DIFF
--- a/e2e/session-rest.test.ts
+++ b/e2e/session-rest.test.ts
@@ -364,5 +364,41 @@ describe('Session REST API', () => {
       })
       expect(res.status).toBe(400)
     })
+
+    it('returns 400 when an entry is null', async () => {
+      const res = await fetch(`${server.url}/api/sessions/${sessionId}/metadata/qa_findings`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ entries: [null] }),
+      })
+      expect(res.status).toBe(400)
+    })
+
+    it('returns 400 when an entry is a primitive', async () => {
+      const res = await fetch(`${server.url}/api/sessions/${sessionId}/metadata/qa_findings`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ entries: [42] }),
+      })
+      expect(res.status).toBe(400)
+    })
+
+    it('returns 400 when description is not a string', async () => {
+      const res = await fetch(`${server.url}/api/sessions/${sessionId}/metadata/qa_findings`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ entries: [{ description: 42, status: 'open' }] }),
+      })
+      expect(res.status).toBe(400)
+    })
+
+    it('returns 400 when status is not a string', async () => {
+      const res = await fetch(`${server.url}/api/sessions/${sessionId}/metadata/qa_findings`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ entries: [{ description: 'Bug', status: {} }] }),
+      })
+      expect(res.status).toBe(400)
+    })
   })
 })

--- a/e2e/session-rest.test.ts
+++ b/e2e/session-rest.test.ts
@@ -275,4 +275,94 @@ describe('Session REST API', () => {
       expect(listData.sessions).toEqual([])
     })
   })
+
+  describe('PUT /api/sessions/:id/metadata/:key', () => {
+    let sessionId: string
+
+    beforeEach(async () => {
+      const res = await fetch(`${server.url}/api/sessions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ projectId, title: 'Metadata Test' }),
+      })
+      const data: any = await res.json()
+      sessionId = data.session.id
+    })
+
+    it('sets entries for an arbitrary key', async () => {
+      const res = await fetch(`${server.url}/api/sessions/${sessionId}/metadata/qa_findings`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          entries: [{ id: '0', description: 'Login button broken', status: 'open' }],
+        }),
+      })
+      expect(res.status).toBe(200)
+      const data: any = await res.json()
+      expect(data.success).toBe(true)
+
+      const getRes = await fetch(`${server.url}/api/sessions/${sessionId}`)
+      const sessionData: any = await getRes.json()
+      const entries = sessionData.session.metadataEntries?.['qa_findings'] ?? []
+      expect(entries).toHaveLength(1)
+      expect(entries[0].description).toBe('Login button broken')
+    })
+
+    it('clears entries when passed an empty array', async () => {
+      await fetch(`${server.url}/api/sessions/${sessionId}/metadata/qa_findings`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          entries: [{ id: '0', description: 'Some finding', status: 'open' }],
+        }),
+      })
+
+      const clearRes = await fetch(`${server.url}/api/sessions/${sessionId}/metadata/qa_findings`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ entries: [] }),
+      })
+      expect(clearRes.status).toBe(200)
+
+      const getRes = await fetch(`${server.url}/api/sessions/${sessionId}`)
+      const sessionData: any = await getRes.json()
+      const entries = sessionData.session.metadataEntries?.['qa_findings'] ?? []
+      expect(entries).toHaveLength(0)
+    })
+
+    it('preserves additional fields on entries', async () => {
+      const res = await fetch(`${server.url}/api/sessions/${sessionId}/metadata/qa_findings`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          entries: [{ id: '0', description: 'Bug', status: 'open', severity: 'high', file: 'src/foo.ts' }],
+        }),
+      })
+      expect(res.status).toBe(200)
+
+      const getRes = await fetch(`${server.url}/api/sessions/${sessionId}`)
+      const sessionData: any = await getRes.json()
+      const entry = sessionData.session.metadataEntries?.['qa_findings']?.[0]
+      expect(entry?.severity).toBe('high')
+      expect(entry?.file).toBe('src/foo.ts')
+    })
+
+    it('returns 404 for unknown session', async () => {
+      const res = await fetch(`${server.url}/api/sessions/nonexistent/metadata/qa_findings`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ entries: [] }),
+      })
+      expect(res.status).toBe(404)
+    })
+
+    it('returns 400 when entries is not an array', async () => {
+      const res = await fetch(`${server.url}/api/sessions/${sessionId}/metadata/qa_findings`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ entries: 'not-an-array' }),
+      })
+      expect(res.status).toBe(400)
+    })
+  })
 })

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -705,9 +705,10 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
       return res.status(400).json({ error: 'entries is required and must be an array' })
     }
 
-    const mapped = entries.map((c: { id?: string; description: string; status?: string }, i: number) => ({
+    const mapped = entries.map((c: { id?: string; description?: string; status?: string; [key: string]: unknown }, i: number) => ({
+      ...c,
       id: c.id ?? String(i),
-      description: c.description,
+      description: c.description ?? '',
       status: c.status ?? 'open',
     }))
     sessionManager.setMetadataEntries(sessionId, key, mapped)

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -705,9 +705,22 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
       return res.status(400).json({ error: 'entries is required and must be an array' })
     }
 
+    for (let i = 0; i < entries.length; i++) {
+      const c = entries[i]
+      if (c === null || typeof c !== 'object' || Array.isArray(c)) {
+        return res.status(400).json({ error: `entries[${i}] must be an object` })
+      }
+      if (c.description !== undefined && typeof c.description !== 'string') {
+        return res.status(400).json({ error: `entries[${i}].description must be a string` })
+      }
+      if (c.status !== undefined && typeof c.status !== 'string') {
+        return res.status(400).json({ error: `entries[${i}].status must be a string` })
+      }
+    }
+
     const mapped = entries.map((c: { id?: string; description?: string; status?: string; [key: string]: unknown }, i: number) => ({
       ...c,
-      id: c.id ?? String(i),
+      id: c.id != null ? String(c.id) : String(i),
       description: c.description ?? '',
       status: c.status ?? 'open',
     }))

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -692,6 +692,28 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
     res.json({ success: true })
   })
 
+  app.put('/api/sessions/:id/metadata/:key', async (req, res) => {
+    const sessionId = req.params.id
+    const key = req.params.key
+    const session = sessionManager.getSession(sessionId)
+    if (!session) {
+      return res.status(404).json({ error: 'Session not found' })
+    }
+
+    const { entries } = req.body
+    if (!Array.isArray(entries)) {
+      return res.status(400).json({ error: 'entries is required and must be an array' })
+    }
+
+    const mapped = entries.map((c: { id?: string; description: string; status?: string }, i: number) => ({
+      id: c.id ?? String(i),
+      description: c.description,
+      status: c.status ?? 'open',
+    }))
+    sessionManager.setMetadataEntries(sessionId, key, mapped)
+    res.json({ success: true })
+  })
+
   // Session mode (REST)
   app.put('/api/sessions/:id/mode', async (req, res) => {
     const { getEventStore } = await import('./events/index.js')

--- a/web/src/components/plan/SessionSidebar.tsx
+++ b/web/src/components/plan/SessionSidebar.tsx
@@ -5,6 +5,7 @@ import { useConfigStore } from '../../stores/config'
 import { useSessionStore } from '../../stores/session'
 import { authFetch } from '../../lib/api'
 import { formatTime, formatSpeed } from '../../lib/format-stats'
+import { formatMetadataKeyLabel } from '../../lib/metadata-keys'
 import { StatsModal } from './StatsModal'
 import { MetadataEntries, MetadataSectionHeader } from '../shared/MetadataEntries'
 import { CriteriaEditor } from './CriteriaEditor'
@@ -84,25 +85,32 @@ export function SessionSidebar({ messages, workdir }: SessionSidebarProps) {
         <div className="mt-4">
           <MetadataSectionHeader entries={session?.metadataEntries?.['criteria'] ?? []} title="Acceptance Criteria" />
           {session && <CriteriaEditor entries={session?.metadataEntries?.['criteria'] ?? []} sessionId={session.id} />}
-          {session && (session.metadataEntries?.['review_findings']?.length ?? 0) > 0 && (
-            <div className="mt-6">
-              <MetadataSectionHeader entries={session.metadataEntries!['review_findings']!} title="Review Findings" />
-              <MetadataEntries
-                entries={session.metadataEntries!['review_findings']!}
-                onClearAll={async () => {
-                  try {
-                    await authFetch(`/api/sessions/${session.id}/review-findings`, {
-                      method: 'PUT',
-                      headers: { 'Content-Type': 'application/json' },
-                      body: JSON.stringify({ review_findings: [] }),
-                    })
-                  } catch (e) {
-                    console.error('Failed to clear review findings:', e)
-                  }
-                }}
-              />
-            </div>
-          )}
+          {session &&
+            Object.entries(session.metadataEntries ?? {})
+              .filter(([key, entries]) => key !== 'criteria' && entries.length > 0)
+              .map(([key, entries]) => (
+                <div key={key} className="mt-6">
+                  <MetadataSectionHeader entries={entries} title={formatMetadataKeyLabel(key)} />
+                  <MetadataEntries
+                    entries={entries}
+                    onClearAll={
+                      key === 'review_findings'
+                        ? async () => {
+                            try {
+                              await authFetch(`/api/sessions/${session.id}/review-findings`, {
+                                method: 'PUT',
+                                headers: { 'Content-Type': 'application/json' },
+                                body: JSON.stringify({ review_findings: [] }),
+                              })
+                            } catch (e) {
+                              console.error('Failed to clear review findings:', e)
+                            }
+                          }
+                        : undefined
+                    }
+                  />
+                </div>
+              ))}
         </div>
       </div>
 

--- a/web/src/components/plan/SessionSidebar.tsx
+++ b/web/src/components/plan/SessionSidebar.tsx
@@ -86,31 +86,35 @@ export function SessionSidebar({ messages, workdir }: SessionSidebarProps) {
           <MetadataSectionHeader entries={session?.metadataEntries?.['criteria'] ?? []} title="Acceptance Criteria" />
           {session && <CriteriaEditor entries={session?.metadataEntries?.['criteria'] ?? []} sessionId={session.id} />}
           {session &&
-            Object.entries(session.metadataEntries ?? {})
-              .filter(([key, entries]) => key !== 'criteria' && entries.length > 0)
-              .map(([key, entries]) => (
-                <div key={key} className="mt-6">
-                  <MetadataSectionHeader entries={entries} title={formatMetadataKeyLabel(key)} />
-                  <MetadataEntries
-                    entries={entries}
-                    onClearAll={
-                      key === 'review_findings'
-                        ? async () => {
-                            try {
-                              await authFetch(`/api/sessions/${session.id}/review-findings`, {
-                                method: 'PUT',
-                                headers: { 'Content-Type': 'application/json' },
-                                body: JSON.stringify({ review_findings: [] }),
-                              })
-                            } catch (e) {
-                              console.error('Failed to clear review findings:', e)
-                            }
-                          }
-                        : undefined
-                    }
-                  />
-                </div>
-              ))}
+            (() => {
+              const knownOrder = ['review_findings', 'todos']
+              const all = session.metadataEntries ?? {}
+              const known = knownOrder.filter((k) => k in all)
+              const unknown = Object.keys(all)
+                .filter((k) => k !== 'criteria' && !knownOrder.includes(k))
+                .sort()
+              return [...known, ...unknown]
+                .filter((key) => (all[key]?.length ?? 0) > 0)
+                .map((key) => (
+                  <div key={key} className="mt-6">
+                    <MetadataSectionHeader entries={all[key]!} title={formatMetadataKeyLabel(key)} />
+                    <MetadataEntries
+                      entries={all[key]!}
+                      onClearAll={async () => {
+                        try {
+                          await authFetch(`/api/sessions/${session.id}/metadata/${key}`, {
+                            method: 'PUT',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({ entries: [] }),
+                          })
+                        } catch (e) {
+                          console.error(`Failed to clear ${key}:`, e)
+                        }
+                      }}
+                    />
+                  </div>
+                ))
+            })()}
         </div>
       </div>
 

--- a/web/src/components/shared/CriteriaGroupDisplay.tsx
+++ b/web/src/components/shared/CriteriaGroupDisplay.tsx
@@ -2,6 +2,7 @@ import { memo } from 'react'
 import type { ToolCall, MetadataEntry } from '@shared/types.js'
 import { Markdown } from './Markdown'
 import { MetadataStatusIcon } from './MetadataStatusIcon'
+import { formatMetadataKeyLabel } from '../../lib/metadata-keys'
 
 interface CriteriaGroupDisplayProps {
   toolCalls: ToolCall[]
@@ -40,18 +41,12 @@ export const CriteriaGroupDisplay = memo(function CriteriaGroupDisplay({
 
   const isSessionMetadata = toolCalls.some((tc) => tc.name === 'session_metadata')
 
-  const metadataKeyLabels: Record<string, string> = {
-    criteria: 'Acceptance Criteria',
-    review_findings: 'Review Findings',
-    todos: 'Tasks',
-  }
-
   const headerTitle = (() => {
     if (!isSessionMetadata) return 'Acceptance Criteria'
     const keys = new Set(toolCalls.map((tc) => tc.arguments['key'] as string | undefined).filter(Boolean))
     if (keys.size === 1) {
       const key = keys.values().next().value
-      return key ? (metadataKeyLabels[key] ?? key) : 'Session Data'
+      return key ? formatMetadataKeyLabel(key) : 'Session Data'
     }
     return 'Session Data'
   })()

--- a/web/src/components/shared/ToolCallPreparing.tsx
+++ b/web/src/components/shared/ToolCallPreparing.tsx
@@ -1,5 +1,6 @@
 import { memo } from 'react'
 import { ToolIcon } from './ToolIcon'
+import { formatMetadataKeyLabel } from '../../lib/metadata-keys'
 
 interface ToolCallPreparingProps {
   name: string
@@ -20,11 +21,6 @@ const toolDescriptions: Record<string, string> = {
   todo_write: 'Updating tasks',
 }
 
-const metadataKeyLabels: Record<string, string> = {
-  criteria: 'criteria',
-  review_findings: 'review findings',
-  todos: 'tasks',
-}
 
 function getToolDescription(name: string, args?: string): string {
   const base = toolDescriptions[name]
@@ -34,7 +30,7 @@ function getToolDescription(name: string, args?: string): string {
       const parsed = JSON.parse(args)
       const key = parsed.key as string | undefined
       if (key) {
-        const label = metadataKeyLabels[key] ?? key
+        const label = formatMetadataKeyLabel(key).toLowerCase()
         return `${base} ${label}`
       }
     } catch {

--- a/web/src/components/shared/ToolCallPreparing.tsx
+++ b/web/src/components/shared/ToolCallPreparing.tsx
@@ -1,6 +1,6 @@
 import { memo } from 'react'
 import { ToolIcon } from './ToolIcon'
-import { formatMetadataKeyLabel } from '../../lib/metadata-keys'
+import { formatMetadataKeyLabelLower } from '../../lib/metadata-keys'
 
 interface ToolCallPreparingProps {
   name: string
@@ -30,7 +30,7 @@ function getToolDescription(name: string, args?: string): string {
       const parsed = JSON.parse(args)
       const key = parsed.key as string | undefined
       if (key) {
-        const label = formatMetadataKeyLabel(key).toLowerCase()
+        const label = formatMetadataKeyLabelLower(key)
         return `${base} ${label}`
       }
     } catch {

--- a/web/src/lib/metadata-keys.test.ts
+++ b/web/src/lib/metadata-keys.test.ts
@@ -22,6 +22,12 @@ describe('formatMetadataKeyLabel', () => {
     expect(formatMetadataKeyLabel('single')).toBe('Single')
     expect(formatMetadataKeyLabel('ui_tests')).toBe('Ui Tests')
   })
+
+  it('safely handles reserved JS property names', () => {
+    expect(formatMetadataKeyLabel('toString')).toBe('ToString')
+    expect(formatMetadataKeyLabel('constructor')).toBe('Constructor')
+    expect(() => formatMetadataKeyLabel('__proto__')).not.toThrow()
+  })
 })
 
 describe('formatMetadataKeyLabelLower', () => {
@@ -35,5 +41,11 @@ describe('formatMetadataKeyLabelLower', () => {
     expect(formatMetadataKeyLabelLower('qa_findings')).toBe('qa findings')
     expect(formatMetadataKeyLabelLower('custom_key')).toBe('custom key')
     expect(formatMetadataKeyLabelLower('single')).toBe('single')
+  })
+
+  it('safely handles reserved JS property names', () => {
+    expect(formatMetadataKeyLabelLower('toString')).toBe('toString')
+    expect(formatMetadataKeyLabelLower('constructor')).toBe('constructor')
+    expect(() => formatMetadataKeyLabelLower('__proto__')).not.toThrow()
   })
 })

--- a/web/src/lib/metadata-keys.test.ts
+++ b/web/src/lib/metadata-keys.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest'
+import { metadataKeyLabels, formatMetadataKeyLabel } from './metadata-keys'
+
+describe('metadataKeyLabels', () => {
+  it('contains known keys', () => {
+    expect(metadataKeyLabels['criteria']).toBe('Acceptance Criteria')
+    expect(metadataKeyLabels['review_findings']).toBe('Review Findings')
+    expect(metadataKeyLabels['todos']).toBe('Tasks')
+  })
+})
+
+describe('formatMetadataKeyLabel', () => {
+  it('returns known label for known keys', () => {
+    expect(formatMetadataKeyLabel('criteria')).toBe('Acceptance Criteria')
+    expect(formatMetadataKeyLabel('review_findings')).toBe('Review Findings')
+    expect(formatMetadataKeyLabel('todos')).toBe('Tasks')
+  })
+
+  it('formats unknown keys by capitalizing words', () => {
+    expect(formatMetadataKeyLabel('qa_findings')).toBe('QA Findings')
+    expect(formatMetadataKeyLabel('custom_key')).toBe('Custom Key')
+    expect(formatMetadataKeyLabel('single')).toBe('Single')
+    expect(formatMetadataKeyLabel('ui_tests')).toBe('UI Tests')
+  })
+})

--- a/web/src/lib/metadata-keys.test.ts
+++ b/web/src/lib/metadata-keys.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { metadataKeyLabels, formatMetadataKeyLabel } from './metadata-keys'
+import { metadataKeyLabels, formatMetadataKeyLabel, formatMetadataKeyLabelLower } from './metadata-keys'
 
 describe('metadataKeyLabels', () => {
   it('contains known keys', () => {
@@ -16,10 +16,24 @@ describe('formatMetadataKeyLabel', () => {
     expect(formatMetadataKeyLabel('todos')).toBe('Tasks')
   })
 
-  it('formats unknown keys by capitalizing words', () => {
-    expect(formatMetadataKeyLabel('qa_findings')).toBe('QA Findings')
+  it('formats unknown keys by capitalizing first letter of each word', () => {
+    expect(formatMetadataKeyLabel('qa_findings')).toBe('Qa Findings')
     expect(formatMetadataKeyLabel('custom_key')).toBe('Custom Key')
     expect(formatMetadataKeyLabel('single')).toBe('Single')
-    expect(formatMetadataKeyLabel('ui_tests')).toBe('UI Tests')
+    expect(formatMetadataKeyLabel('ui_tests')).toBe('Ui Tests')
+  })
+})
+
+describe('formatMetadataKeyLabelLower', () => {
+  it('returns lowercase label for known keys', () => {
+    expect(formatMetadataKeyLabelLower('criteria')).toBe('criteria')
+    expect(formatMetadataKeyLabelLower('review_findings')).toBe('review findings')
+    expect(formatMetadataKeyLabelLower('todos')).toBe('tasks')
+  })
+
+  it('replaces underscores with spaces for unknown keys', () => {
+    expect(formatMetadataKeyLabelLower('qa_findings')).toBe('qa findings')
+    expect(formatMetadataKeyLabelLower('custom_key')).toBe('custom key')
+    expect(formatMetadataKeyLabelLower('single')).toBe('single')
   })
 })

--- a/web/src/lib/metadata-keys.ts
+++ b/web/src/lib/metadata-keys.ts
@@ -1,25 +1,28 @@
-export const metadataKeyLabels: Record<string, string> = {
+const metadataKeyLabels: Record<string, string> = Object.assign(Object.create(null) as Record<string, string>, {
   criteria: 'Acceptance Criteria',
   review_findings: 'Review Findings',
   todos: 'Tasks',
-}
+})
 
-const metadataKeyLabelsLower: Record<string, string> = {
+export { metadataKeyLabels }
+
+const metadataKeyLabelsLower: Record<string, string> = Object.assign(Object.create(null) as Record<string, string>, {
   criteria: 'criteria',
   review_findings: 'review findings',
   todos: 'tasks',
-}
+})
 
 export function formatMetadataKeyLabel(key: string): string {
-  return (
-    metadataKeyLabels[key] ??
-    key
-      .split('_')
-      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-      .join(' ')
-  )
+  return Object.hasOwn(metadataKeyLabels, key)
+    ? (metadataKeyLabels[key] as string)
+    : key
+        .split('_')
+        .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+        .join(' ')
 }
 
 export function formatMetadataKeyLabelLower(key: string): string {
-  return metadataKeyLabelsLower[key] ?? key.replace(/_/g, ' ')
+  return Object.hasOwn(metadataKeyLabelsLower, key)
+    ? (metadataKeyLabelsLower[key] as string)
+    : key.replace(/_/g, ' ')
 }

--- a/web/src/lib/metadata-keys.ts
+++ b/web/src/lib/metadata-keys.ts
@@ -1,0 +1,15 @@
+export const metadataKeyLabels: Record<string, string> = {
+  criteria: 'Acceptance Criteria',
+  review_findings: 'Review Findings',
+  todos: 'Tasks',
+}
+
+export function formatMetadataKeyLabel(key: string): string {
+  return (
+    metadataKeyLabels[key] ??
+    key
+      .split('_')
+      .map((word) => (word.length <= 2 ? word.toUpperCase() : word.charAt(0).toUpperCase() + word.slice(1)))
+      .join(' ')
+  )
+}

--- a/web/src/lib/metadata-keys.ts
+++ b/web/src/lib/metadata-keys.ts
@@ -4,12 +4,22 @@ export const metadataKeyLabels: Record<string, string> = {
   todos: 'Tasks',
 }
 
+const metadataKeyLabelsLower: Record<string, string> = {
+  criteria: 'criteria',
+  review_findings: 'review findings',
+  todos: 'tasks',
+}
+
 export function formatMetadataKeyLabel(key: string): string {
   return (
     metadataKeyLabels[key] ??
     key
       .split('_')
-      .map((word) => (word.length <= 2 ? word.toUpperCase() : word.charAt(0).toUpperCase() + word.slice(1)))
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
       .join(' ')
   )
+}
+
+export function formatMetadataKeyLabelLower(key: string): string {
+  return metadataKeyLabelsLower[key] ?? key.replace(/_/g, ' ')
 }


### PR DESCRIPTION
## Contexte

La sidebar de droite affichait uniquement les sections **Acceptance Criteria** et **Review Findings**, ignorant silencieusement toute autre clé créée via `session_metadata` (ex: `qa_findings`, `todos`, etc.).

## Changements

### Fonctionnalité principale
- La sidebar affiche désormais **dynamiquement toutes les clés** de `session.metadataEntries`
- Ordre déterministe : clés connues (`review_findings`, `todos`) en premier, puis les inconnues triées alphabétiquement
- Labels automatiques pour les clés inconnues (ex: `qa_findings` → `Qa Findings`)
- Clés connues conservent leurs labels localisés (`Review Findings`, `Tasks`)
- Sections sans entrées restent masquées

### Clear All
- Bouton **Clear All** disponible pour **toutes** les clés via l'endpoint générique `PUT /api/sessions/:id/metadata/:key`
- L'endpoint `PUT /api/sessions/:id/review-findings` est conservé pour rétrocompatibilité

### Factorisation
- Extraction d'un utilitaire partagé `web/src/lib/metadata-keys.ts` : `metadataKeyLabels`, `formatMetadataKeyLabel`, `formatMetadataKeyLabelLower`
- `CriteriaGroupDisplay` et `ToolCallPreparing` utilisent cet utilitaire (plus de duplication)
- `ToolCallPreparing` utilise `formatMetadataKeyLabelLower` pour éviter `.toLowerCase()` sur un label déjà formaté

### Sécurité & robustesse
- `metadataKeyLabels` utilise un objet null-prototype (`Object.create(null)`) + `Object.hasOwn` — immunisé contre les clés réservées JS (`toString`, `constructor`, `__proto__`)
- La route `PUT /api/sessions/:id/metadata/:key` valide chaque élément du tableau : retourne 400 pour `null`, primitives, `description` ou `status` non-string
- Les champs additionnels des entrées sont préservés (`{ ...entry, id, description, status }`)

## Tests
- Tests unitaires : `formatMetadataKeyLabel`, `formatMetadataKeyLabelLower`, clés réservées JS
- 9 tests e2e pour `PUT /api/sessions/:id/metadata/:key` : set, clear, préservation des champs, 404, 400 (non-array, null, primitif, description invalide, status invalide)

## Fichiers modifiés

- `web/src/lib/metadata-keys.ts` — utilitaire partagé (null-prototype, `Object.hasOwn`)
- `web/src/lib/metadata-keys.test.ts` — tests unitaires
- `web/src/components/plan/SessionSidebar.tsx` — rendu dynamique ordonné + clear all générique
- `web/src/components/shared/CriteriaGroupDisplay.tsx` — import depuis utilitaire partagé
- `web/src/components/shared/ToolCallPreparing.tsx` — idem
- `src/server/index.ts` — endpoint `PUT /api/sessions/:id/metadata/:key` avec validation
- `e2e/session-rest.test.ts` — 9 tests e2e de la nouvelle route