### PR TITLE
fix: orphaned child processes on Windows when aborting commands

### DIFF
--- a/src/server/utils/process-tree.ts
+++ b/src/server/utils/process-tree.ts
@@ -95,6 +95,12 @@ export async function terminateProcessTree(
   }
 
   if (options?.immediate) {
+    // On Windows getDescendantPids relies on `ps` and returns [] — taskkill /f /t
+    // (via killProcessTree) is already immediate and kills the whole tree.
+    if (process.platform === 'win32') {
+      await killProcessTree(pid)
+      return
+    }
     const allPids = await getDescendantPids(pid)
     allPids.push(pid)
     for (const p of allPids) {

--- a/src/server/workflows/shell.ts
+++ b/src/server/workflows/shell.ts
@@ -3,6 +3,7 @@
  */
 
 import { checkAborted, spawnShellProcess } from '../utils/shell.js'
+import { terminateProcessTree } from '../utils/process-tree.js'
 
 export interface ShellResult {
   exitCode: number
@@ -34,14 +35,14 @@ export function executeShellCommand(
 
     const timer = setTimeout(() => {
       killed = true
-      proc.kill('SIGTERM')
+      void terminateProcessTree(proc)
       resolve({ exitCode: 1, stdout, stderr: stderr + '\nCommand timed out', success: false })
     }, timeout)
 
     const onAbort = () => {
       if (!killed) {
         killed = true
-        proc.kill('SIGTERM')
+        void terminateProcessTree(proc, { immediate: true })
         clearTimeout(timer)
         reject(new Error('Aborted'))
       }


### PR DESCRIPTION
## Symptoms

On Windows, interrupting work leaves child processes running in the background:

- In the chat, run a long command (e.g. `ping -n 120 127.0.0.1`), then click **Stop**
  while it executes. The UI reports the command as stopped, but:

  ```
  > tasklist | findstr PING
  PING.EXE                     16400 Console                    1     5 108 Ko
  ```

  The child keeps running (npm installs, tsc watchers, etc. keep eating CPU the
  same way). Letting the exact same command hit its **timeout** instead kills the
  tree correctly — only the user-abort path leaks.

- Cancelling a **workflow** whose shell step is still running leaks the step's
  children the same way (this one on all platforms, not just Windows).

## Cause

1. `terminateProcessTree(proc, { immediate: true })` — the abort path of
   `run_command` (`src/server/tools/shell.ts`) — bypasses the win32 `taskkill`
   branch that `killProcessTree()` has, and instead enumerates the tree via
   `getDescendantPids()` (`src/server/utils/process-tree.ts`). That helper shells
   out to `ps`, which doesn't exist on Windows, so it silently returns `[]` and
   only the root `cmd.exe` gets killed; its children are orphaned. The timeout
   path goes through `killProcessTree()` and is correct.
2. Workflow shell steps (`src/server/workflows/shell.ts`, `executeShellCommand()`)
   call `proc.kill('SIGTERM')` directly on both the timeout and abort paths. That
   only signals the spawned shell, never its children — orphans on every platform.

## Fix

- `src/server/utils/process-tree.ts`: on win32, route the `immediate` path through
  `killProcessTree()` — `taskkill /pid X /f /t` is already forceful and immediate,
  so semantics are preserved. Unix `immediate` path untouched.
- `src/server/workflows/shell.ts`: replace both `proc.kill('SIGTERM')` calls with
  `terminateProcessTree(proc)` (timeout: graceful tree kill) and
  `terminateProcessTree(proc, { immediate: true })` (abort), reusing the existing
  shared helper instead of a bare signal.

No new vitest test: `process-tree.test.ts` is `ps`/`bash`-based and doesn't run on
Windows, and mocking `taskkill` would only test the mock. Verified empirically
instead (below).

## Tests

**Windows (win32):**
- Repro script (tsx, spawns `cmd.exe /c ping -n 60 127.0.0.1`, counts `PING.EXE`
  via `tasklist` before/during/after kill):
  - Before fix: `immediate (abort path): during=1 after=1 → FAIL` (orphan);
    non-immediate path passes.
  - After fix: both paths `after=0 → PASS`.
- `npx vitest run src/server/workflows/executor.test.ts` → 46 passed, 0 failed.
- `npm run typecheck` → no errors in the touched files.
- Full `npm run test:unit` is not Windows-clean on upstream `develop`
  (pre-existing: hardcoded Unix paths, `ps`, symlink privileges — unrelated to
  this diff).

**Unix:** not run locally. The win32 branch added in `process-tree.ts` is
unreachable off-Windows, and `terminateProcessTree()` on Unix performs the same
SIGTERM (then SIGKILL) the workflow code did, extended to the whole tree —
covered by the existing `process-tree.test.ts` suite in CI.