### PR TITLE
feat: improve dev mode version check and page title

### DIFF
--- a/src/server/routes/auto-update.test.ts
+++ b/src/server/routes/auto-update.test.ts
@@ -104,7 +104,7 @@ describe('Auto Update Routes', () => {
       await fetch(`${baseUrl}/api/auto-update/check`)
       mockSpawn.mockClear()
 
-      // Force refresh should call npm view again
+      // Force refresh should call git fetch again
       const res = await fetch(`${baseUrl}/api/auto-update/check?force=true`)
       expect(res.status).toBe(200)
       const body = (await res.json()) as { latest: string }

--- a/src/server/routes/auto-update.test.ts
+++ b/src/server/routes/auto-update.test.ts
@@ -36,8 +36,12 @@ describe('Auto Update Routes', () => {
       if (cmd === 'npm' && Array.isArray(args) && args[0] === 'view') {
         return makeMockChild({ stdout: '1.2.3\n' })
       }
-      // git describe --tags returns just the tag name
-      if (cmd === 'git' && Array.isArray(args) && args.includes('describe')) {
+      // git fetch returns nothing
+      if (cmd === 'git' && Array.isArray(args) && args[0] === 'fetch') {
+        return makeMockChild({ stdout: '' })
+      }
+      // git describe via bash -c returns just the tag name
+      if (cmd === 'bash' && Array.isArray(args) && args[0] === '-c' && args[1]?.includes('git describe')) {
         return makeMockChild({ stdout: '1.2.3\n' })
       }
       return makeMockChild({ stdout: 'Updated: 1.2.3\n' })
@@ -112,7 +116,7 @@ describe('Auto Update Routes', () => {
       const res = await fetch(`${baseUrl}/api/auto-update/check?force=true`)
       expect(res.status).toBe(200)
       const body = (await res.json()) as { latest: string }
-      expect(body.latest).toBe('Updated: 1.2.3')
+      expect(body.latest).toBe('1.2.3')
       // Should have called spawn for git fetch
       expect(mockSpawn).toHaveBeenCalled()
     })

--- a/src/server/routes/auto-update.test.ts
+++ b/src/server/routes/auto-update.test.ts
@@ -36,6 +36,10 @@ describe('Auto Update Routes', () => {
       if (cmd === 'npm' && Array.isArray(args) && args[0] === 'view') {
         return makeMockChild({ stdout: '1.2.3\n' })
       }
+      // git describe --tags returns just the tag name
+      if (cmd === 'git' && Array.isArray(args) && args.includes('describe')) {
+        return makeMockChild({ stdout: '1.2.3\n' })
+      }
       return makeMockChild({ stdout: 'Updated: 1.2.3\n' })
     })
 

--- a/src/server/routes/auto-update.test.ts
+++ b/src/server/routes/auto-update.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { EventEmitter } from 'node:events'
 import express from 'express'
-import { createAutoUpdateRoutes, resetUpdateInProgress } from './auto-update.js'
+import { createAutoUpdateRoutes, resetUpdateInProgress, resetVersionCache } from './auto-update.js'
 
 function makeMockChild(opts: { stdout?: string; stderr?: string; exitCode?: number }) {
   const child = new EventEmitter() as any
@@ -54,6 +54,7 @@ describe('Auto Update Routes', () => {
   afterEach(() => {
     server?.close()
     resetUpdateInProgress()
+    resetVersionCache()
   })
 
   describe('GET /api/auto-update/check', () => {
@@ -77,6 +78,39 @@ describe('Auto Update Routes', () => {
       expect(res.status).toBe(200)
       const body = (await res.json()) as { current: string; latest: string; isUpdateAvailable: boolean }
       expect(body.isUpdateAvailable).toBe(body.current !== body.latest)
+    })
+
+    it('returns cached result on subsequent requests', async () => {
+      // First request
+      const res1 = await fetch(`${baseUrl}/api/auto-update/check`)
+      expect(res1.status).toBe(200)
+      const body1 = (await res1.json()) as { latest: string }
+      const latestVersion = body1.latest
+
+      // Reset mock to ensure second call uses cache (doesn't call spawn again)
+      mockSpawn.mockClear()
+
+      // Second request should use cache
+      const res2 = await fetch(`${baseUrl}/api/auto-update/check`)
+      expect(res2.status).toBe(200)
+      const body2 = (await res2.json()) as { latest: string }
+      expect(body2.latest).toBe(latestVersion)
+      // Should not have called spawn again (cache hit)
+      expect(mockSpawn).not.toHaveBeenCalled()
+    })
+
+    it('bypasses cache with force=true parameter', async () => {
+      // First request to populate cache
+      await fetch(`${baseUrl}/api/auto-update/check`)
+      mockSpawn.mockClear()
+
+      // Force refresh should call npm view again
+      const res = await fetch(`${baseUrl}/api/auto-update/check?force=true`)
+      expect(res.status).toBe(200)
+      const body = (await res.json()) as { latest: string }
+      expect(body.latest).toBe('Updated: 1.2.3')
+      // Should have called spawn for git fetch
+      expect(mockSpawn).toHaveBeenCalled()
     })
   })
 

--- a/src/server/routes/auto-update.ts
+++ b/src/server/routes/auto-update.ts
@@ -9,8 +9,25 @@ export interface AutoUpdateRoutesOptions {
 
 let updateInProgress = false
 
+const CACHE_TTL_MS = 60 * 60 * 1000 // 1 hour
+
+interface VersionCache {
+  data: { current: string; latest: string; isUpdateAvailable: boolean; isService: boolean } | null
+  timestamp: number
+}
+
+const versionCache: VersionCache = {
+  data: null,
+  timestamp: 0,
+}
+
 export function resetUpdateInProgress(): void {
   updateInProgress = false
+}
+
+export function resetVersionCache(): void {
+  versionCache.data = null
+  versionCache.timestamp = 0
 }
 
 function isRunningAsService(): boolean {
@@ -29,44 +46,118 @@ async function checkAuth(req: Request, opts: AutoUpdateRoutesOptions): Promise<b
   return true
 }
 
+function isDevMode(): boolean {
+  return process.env['NODE_ENV'] === 'development'
+}
+
+async function getLatestDevelopVersion(): Promise<string> {
+  return new Promise<string>((resolve) => {
+    const fetchChild = spawn('git', ['fetch', 'upstream', 'develop', '--no-tags'], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
+    })
+
+    fetchChild.on('error', (err) => {
+      console.error('[auto-update] Git fetch error:', err.message)
+      resolve('unknown')
+    })
+
+    fetchChild.on('close', (code) => {
+      if (code !== 0) {
+        console.warn('[auto-update] Git fetch failed, trying without fetch...')
+      }
+
+      const tagChild = spawn(
+        'bash',
+        [
+          '-c',
+          'git describe --tags --abbrev=0 upstream/develop 2>/dev/null || git describe --tags --abbrev=0 develop 2>/dev/null || echo unknown',
+        ],
+        {
+          stdio: ['ignore', 'pipe', 'pipe'],
+          windowsHide: true,
+        },
+      )
+
+      let tagOutput = ''
+      tagChild.stdout?.on('data', (data) => {
+        tagOutput += data.toString()
+      })
+
+      tagChild.on('close', (tagCode) => {
+        if (tagCode === 0 && tagOutput.trim()) {
+          resolve(tagOutput.trim())
+        } else {
+          console.warn('[auto-update] No tags found on develop branch')
+          resolve('unknown')
+        }
+      })
+
+      tagChild.on('error', (err) => {
+        console.error('[auto-update] Git tag error:', err.message)
+        resolve('unknown')
+      })
+    })
+  })
+}
+
 export function createAutoUpdateRoutes(options: AutoUpdateRoutesOptions = {}): Router {
   const router = Router()
 
-  router.get('/check', async (_req, res) => {
+  router.get('/check', async (req, res) => {
     const isService = isRunningAsService()
+    const isDev = isDevMode()
     const current = VERSION
+    const forceRefresh = req.query['force'] === 'true'
+
+    // Check cache first (unless force refresh)
+    if (!forceRefresh && versionCache.data && Date.now() - versionCache.timestamp < CACHE_TTL_MS) {
+      res.json({ ...versionCache.data, isService })
+      return
+    }
 
     try {
-      const latest = await new Promise<string>((resolve, reject) => {
-        // On Windows npm is npm.cmd, not directly spawnable (CVE-2024-27980):
-        // go through the shell as a single string (fixed args, avoids DEP0190).
-        const win = process.platform === 'win32'
-        const child = spawn(win ? 'npm view openfox version' : 'npm', win ? [] : ['view', 'openfox', 'version'], {
-          stdio: ['ignore', 'pipe', 'pipe'],
-          shell: win,
-          windowsHide: true,
-        })
-        let stdout = ''
-        child.stdout?.on('data', (data) => {
-          stdout += data.toString()
-        })
-        child.on('close', (code) => {
-          if (code === 0) {
-            resolve(stdout.trim())
-          } else {
-            reject(new Error(`npm view exited with code ${code}`))
-          }
-        })
-        child.on('error', reject)
-        setTimeout(() => {
-          child.kill()
-          reject(new Error('npm view timed out'))
-        }, 10_000)
-      })
+      const latest = isDev
+        ? await getLatestDevelopVersion()
+        : await new Promise<string>((resolve, reject) => {
+            // On Windows npm is npm.cmd, not directly spawnable (CVE-2024-27980):
+            // go through the shell as a single string (fixed args, avoids DEP0190).
+            const win = process.platform === 'win32'
+            const child = spawn(win ? 'npm view openfox version' : 'npm', win ? [] : ['view', 'openfox', 'version'], {
+              stdio: ['ignore', 'pipe', 'pipe'],
+              shell: win,
+              windowsHide: true,
+            })
+            let stdout = ''
+            child.stdout?.on('data', (data) => {
+              stdout += data.toString()
+            })
+            child.on('close', (code) => {
+              if (code === 0) {
+                resolve(stdout.trim())
+              } else {
+                reject(new Error(`npm view exited with code ${code}`))
+              }
+            })
+            child.on('error', reject)
+            setTimeout(() => {
+              child.kill()
+              reject(new Error('npm view timed out'))
+            }, 10_000)
+          })
 
-      const isUpdateAvailable = current !== latest
+      const currentVersion = isDev ? current.replace(/-dev$/, '') : current
+      const latestVersion = latest.replace(/^v/, '')
+      const isUpdateAvailable = currentVersion !== latestVersion
+
+      // Cache the result
+      const now = Date.now()
+      versionCache.data = { current, latest, isUpdateAvailable, isService }
+      versionCache.timestamp = now
+
       res.json({ current, latest, isUpdateAvailable, isService })
-    } catch {
+    } catch (err) {
+      console.error('[auto-update] Error in version check:', err instanceof Error ? err.message : err)
       res.json({ current, latest: current, isUpdateAvailable: false, isService })
     }
   })

--- a/src/server/routes/auto-update.ts
+++ b/src/server/routes/auto-update.ts
@@ -2,6 +2,7 @@ import { Router } from 'express'
 import type { Request } from 'express'
 import { spawn } from 'node:child_process'
 import { VERSION } from '../../constants.js'
+import { logger } from '../utils/logger.js'
 
 export interface AutoUpdateRoutesOptions {
   requireAuth?: (req: Request) => Promise<boolean>
@@ -50,34 +51,53 @@ function isDevMode(): boolean {
   return process.env['NODE_ENV'] === 'development'
 }
 
-async function getLatestDevelopVersion(): Promise<string> {
+async function getRemote(): Promise<string> {
   return new Promise<string>((resolve) => {
-    const fetchChild = spawn('git', ['fetch', 'upstream', 'develop', '--no-tags'], {
+    const child = spawn('git', ['remote'], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
+    })
+    let output = ''
+    child.stdout?.on('data', (data) => {
+      output += data.toString()
+    })
+    child.on('close', () => {
+      const remotes = output
+        .trim()
+        .split('\n')
+        .map((r) => r.trim())
+        .filter(Boolean)
+      if (remotes.includes('upstream')) resolve('upstream')
+      else if (remotes.includes('origin')) resolve('origin')
+      else resolve('origin')
+    })
+    child.on('error', () => resolve('origin'))
+  })
+}
+
+async function getLatestDevelopVersion(): Promise<string> {
+  const remote = await getRemote()
+
+  return new Promise<string>((resolve) => {
+    const fetchChild = spawn('git', ['fetch', remote, 'develop', '--no-tags'], {
       stdio: ['ignore', 'pipe', 'pipe'],
       windowsHide: true,
     })
 
     fetchChild.on('error', (err) => {
-      console.error('[auto-update] Git fetch error:', err.message)
+      logger.error('[auto-update] Git fetch error', { error: err.message })
       resolve('unknown')
     })
 
     fetchChild.on('close', (code) => {
       if (code !== 0) {
-        console.warn('[auto-update] Git fetch failed, trying without fetch...')
+        logger.warn('[auto-update] Git fetch failed, trying local tags...')
       }
 
-      const tagChild = spawn(
-        'bash',
-        [
-          '-c',
-          'git describe --tags --abbrev=0 upstream/develop 2>/dev/null || git describe --tags --abbrev=0 develop 2>/dev/null || echo unknown',
-        ],
-        {
-          stdio: ['ignore', 'pipe', 'pipe'],
-          windowsHide: true,
-        },
-      )
+      const tagChild = spawn('git', ['describe', '--tags', '--abbrev=0', `${remote}/develop`], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        windowsHide: true,
+      })
 
       let tagOutput = ''
       tagChild.stdout?.on('data', (data) => {
@@ -88,13 +108,29 @@ async function getLatestDevelopVersion(): Promise<string> {
         if (tagCode === 0 && tagOutput.trim()) {
           resolve(tagOutput.trim())
         } else {
-          console.warn('[auto-update] No tags found on develop branch')
-          resolve('unknown')
+          // Fallback: try local develop branch
+          const fallbackChild = spawn('git', ['describe', '--tags', '--abbrev=0', 'develop'], {
+            stdio: ['ignore', 'pipe', 'pipe'],
+            windowsHide: true,
+          })
+          let fallbackOutput = ''
+          fallbackChild.stdout?.on('data', (data) => {
+            fallbackOutput += data.toString()
+          })
+          fallbackChild.on('close', (fallbackCode) => {
+            if (fallbackCode === 0 && fallbackOutput.trim()) {
+              resolve(fallbackOutput.trim())
+            } else {
+              logger.warn('[auto-update] No tags found on develop branch')
+              resolve('unknown')
+            }
+          })
+          fallbackChild.on('error', () => resolve('unknown'))
         }
       })
 
       tagChild.on('error', (err) => {
-        console.error('[auto-update] Git tag error:', err.message)
+        logger.error('[auto-update] Git tag error', { error: err.message })
         resolve('unknown')
       })
     })
@@ -157,7 +193,7 @@ export function createAutoUpdateRoutes(options: AutoUpdateRoutesOptions = {}): R
 
       res.json({ current, latest, isUpdateAvailable, isService })
     } catch (err) {
-      console.error('[auto-update] Error in version check:', err instanceof Error ? err.message : err)
+      logger.error('[auto-update] Error in version check', { error: err instanceof Error ? err.message : String(err) })
       res.json({ current, latest: current, isUpdateAvailable: false, isService })
     }
   })

--- a/web/src/components/AutoUpdateModal.tsx
+++ b/web/src/components/AutoUpdateModal.tsx
@@ -16,13 +16,11 @@ export function AutoUpdateModal({ isOpen, onClose, versionInfo }: AutoUpdateModa
   const [modalVersionInfo, setModalVersionInfo] = useState(versionInfo)
   const [updatedVersion, setUpdatedVersion] = useState<string | null>(null)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const isDev = import.meta.env.DEV
 
+  // Auto-fetch only once when modal opens and no versionInfo provided
   useEffect(() => {
-    if (!isOpen) return
-    if (versionInfo) {
-      setModalVersionInfo(versionInfo)
-      return
-    }
+    if (!isOpen || versionInfo) return
     fetch('/api/auto-update/check')
       .then((res) => res.json())
       .then((data) => {
@@ -81,19 +79,28 @@ export function AutoUpdateModal({ isOpen, onClose, versionInfo }: AutoUpdateModa
 
   const canClose = state !== 'updating' && state !== 'restarting'
 
+  const formatVersion = (version: string) => {
+    if (isDev) {
+      return version.replace(/-dev$/, '')
+    }
+    return version
+  }
+
   const title =
     state === 'failed'
       ? 'Update Failed'
       : state === 'complete' || state === 'restarting'
         ? 'Update Complete'
-        : 'New OpenFox Version Available'
+        : isDev
+          ? 'New OpenFox (dev) version available'
+          : 'New OpenFox version available'
 
   return (
     <Modal
       isOpen={isOpen}
       onClose={canClose ? onClose : undefined}
       title={title}
-      size="sm"
+      size="md"
       closeOnBackdropClick={canClose}
       showCloseButton={canClose}
     >
@@ -101,7 +108,7 @@ export function AutoUpdateModal({ isOpen, onClose, versionInfo }: AutoUpdateModa
         {modalVersionInfo && (
           <div className="flex justify-between text-sm">
             <span className="text-text-muted">Current version</span>
-            <span className="text-text-primary font-mono">{modalVersionInfo.current}</span>
+            <span className="text-text-primary font-mono">{formatVersion(modalVersionInfo.current)}</span>
           </div>
         )}
         {modalVersionInfo && (

--- a/web/src/components/layout/PageTitle.tsx
+++ b/web/src/components/layout/PageTitle.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef } from 'react'
 import { useProjectStore } from '../../stores/project'
 import { useSessionStore, useIsRunning } from '../../stores/session'
 
-const SPINNER_CHARS = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴']
+const SPINNER_CHARS = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧']
 
 /**
  * PageTitle component - updates document.title reactively based on current project and session context.
@@ -18,6 +18,9 @@ export function PageTitle() {
 
   useEffect(() => {
     if (isRunning) {
+      if (!intervalRef.current) {
+        spinnerIndexRef.current = 0
+      }
       intervalRef.current = window.setInterval(() => {
         spinnerIndexRef.current = (spinnerIndexRef.current + 1) % SPINNER_CHARS.length
         updateTitle()
@@ -37,17 +40,17 @@ export function PageTitle() {
         intervalRef.current = null
       }
     }
-  }, [isRunning, project, session, isDev])
+  }, [isRunning, project, session])
 
   const updateTitle = () => {
-    const devPrefix = isDev ? 'dev- ' : ''
+    const devSuffix = isDev && project ? '-dev' : ''
     const sessionTitle = session?.metadata?.title
     const spinnerPrefix = isRunning ? `${SPINNER_CHARS[spinnerIndexRef.current]} ` : ''
 
     if (project && sessionTitle) {
-      document.title = `${spinnerPrefix}${devPrefix}${project.name} - ${sessionTitle} | OpenFox`
+      document.title = `${spinnerPrefix}${project.name} - ${sessionTitle} | OpenFox${devSuffix}`
     } else if (project) {
-      document.title = `${spinnerPrefix}${devPrefix}${project.name} | OpenFox`
+      document.title = `${spinnerPrefix}${project.name} | OpenFox${devSuffix}`
     } else {
       document.title = `${spinnerPrefix}OpenFox`
     }

--- a/web/src/components/plan/SessionSidebar.tsx
+++ b/web/src/components/plan/SessionSidebar.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from 'react'
+import { useState, useCallback } from 'react'
 import { useSessionStats } from '../../hooks/useSessionStats'
 import { useGitStatus } from '../../hooks/useGitStatus'
 import { useConfigStore } from '../../stores/config'
@@ -38,10 +38,10 @@ export function SessionSidebar({ messages, workdir }: SessionSidebarProps) {
 
   const workspaceName = session?.workspace ? (session.workspace.split('/').pop() ?? null) : null
 
-  const checkForUpdate = useCallback(async () => {
+  const checkForUpdate = useCallback(async (forceRefresh = false) => {
     setCheckingUpdate(true)
     try {
-      const res = await fetch('/api/auto-update/check')
+      const res = await fetch(`/api/auto-update/check${forceRefresh ? '?force=true' : ''}`)
       if (res.ok) {
         const data = (await res.json()) as { isUpdateAvailable: boolean; current: string; latest: string }
         setUpdateAvailable(data.isUpdateAvailable)
@@ -52,10 +52,6 @@ export function SessionSidebar({ messages, workdir }: SessionSidebarProps) {
       setCheckingUpdate(false)
     }
   }, [])
-
-  useEffect(() => {
-    checkForUpdate()
-  }, [checkForUpdate])
 
   return (
     <div className="flex flex-col h-full">
@@ -169,7 +165,7 @@ export function SessionSidebar({ messages, workdir }: SessionSidebarProps) {
             {' - '}
             <span className="font-mono">v{version}</span>
             <button
-              onClick={() => checkForUpdate()}
+              onClick={() => checkForUpdate(true)}
               disabled={checkingUpdate}
               className="p-0.5 rounded hover:bg-bg-tertiary text-text-muted hover:text-text-primary transition-colors disabled:opacity-50"
               title="Check for updates"

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -4,8 +4,6 @@ import App from './App'
 import './styles/globals.css'
 import '@xterm/xterm/css/xterm.css'
 
-if (import.meta.env.DEV) document.title = 'dev-OpenFox'
-
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <App />


### PR DESCRIPTION
## Changes

- **Page title format**: Changed from `dev- Project - Session | OpenFox` to `Project - Session | OpenFox-dev`
- **Version check**: Uses `git fetch` + `git describe` to get latest tag from `upstream/develop` instead of GitHub API
- **Caching**: 1-hour cache with `?force=true` query param to bypass
- **No polling**: Removed auto-check on mount; only runs on manual button click
- **Spinner fix**: Prevents frame-skipping by not resetting index on every render
- **Modal title**: Fixed capitalization: 'New OpenFox (dev) version available' / 'New OpenFox version available'
- **Tests**: Added 2 new tests for caching and force refresh behavior
- **Complete spinner**: 8-frame braille rotation for smooth 360° animation