### PR TITLE
fix: resolve file attachments before passing messages to transport plugins

### DIFF
--- a/src/server/llm/client-pure.ts
+++ b/src/server/llm/client-pure.ts
@@ -16,8 +16,8 @@ import type {
 import type { Attachment } from '../../shared/types.js'
 import type { ModelProfile } from './profiles.js'
 import type { BackendCapabilities } from './backend.js'
-import { extractPdfText } from '../tools/pdf-utils.js'
 import { TEXT_MIME_PREFIXES, TEXT_MIME_EXACT } from '../../shared/constants.js'
+import { extractPdfFromDataUrl } from './resolve-attachments.js'
 
 export { resolveAttachmentsInMessages } from './resolve-attachments.js'
 
@@ -134,23 +134,8 @@ async function convertAttachment(
   }
 
   if (mimeType === 'application/pdf') {
-    try {
-      const base64Match = attachment.data.match(/^data:.*?;base64,(.+)$/)
-      if (base64Match?.[1]) {
-        const buffer = Buffer.from(base64Match[1], 'base64')
-        const result = await extractPdfText(buffer)
-        return {
-          type: 'text',
-          text: `[PDF: ${attachment.filename || 'document.pdf'}]\n${result.text}`,
-        }
-      }
-    } catch {
-      // fall through to error placeholder below
-    }
-    return {
-      type: 'text',
-      text: `[PDF: ${attachment.filename || 'document.pdf'}] (could not extract text)`,
-    }
+    const text = await extractPdfFromDataUrl(attachment.data, attachment.filename || 'document.pdf')
+    return { type: 'text', text }
   }
 
   if (modelSupportsVision) {

--- a/src/server/llm/client-pure.ts
+++ b/src/server/llm/client-pure.ts
@@ -19,6 +19,8 @@ import type { BackendCapabilities } from './backend.js'
 import { extractPdfText } from '../tools/pdf-utils.js'
 import { TEXT_MIME_PREFIXES, TEXT_MIME_EXACT } from '../../shared/constants.js'
 
+export { resolveAttachmentsInMessages } from './resolve-attachments.js'
+
 export interface ModelParams {
   temperature?: number
   topP?: number

--- a/src/server/llm/resolve-attachments.test.ts
+++ b/src/server/llm/resolve-attachments.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from 'vitest'
+import { resolveAttachmentsInMessages } from './client-pure.js'
+import type { LLMMessage } from './types.js'
+
+function makeSimplePdfBuffer(): Buffer {
+  const stream = 'BT /F1 12 Tf 100 700 Td (Hello PDF) Tj ET'
+  const len = Buffer.byteLength(stream, 'latin1')
+  return Buffer.from(
+    `%PDF-1.4\n1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj\n3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 612 792]/Resources<</Font<</F1 4 0 R>>>>/Contents 5 0 R>>endobj\n4 0 obj<</Type/Font/Subtype/Type1/BaseFont/Helvetica>>endobj\n5 0 obj<</Length ${len}>>stream\n${stream}\nendstream\nxref\n0 6\n0000000000 65535 f \n0000000009 00000 n \n0000000061 00000 n \n0000000114 00000 n \n0000000268 00000 n \n0000000342 00000 n \ntrailer<</Size 6/Root 1 0 R>>\nstartxref\n428\n%%EOF`,
+    'latin1',
+  )
+}
+
+describe('resolveAttachmentsInMessages', () => {
+  it('returns messages without attachments unchanged', async () => {
+    const messages: LLMMessage[] = [
+      { role: 'user', content: 'hello' },
+      { role: 'assistant', content: 'world' },
+    ]
+    const result = await resolveAttachmentsInMessages(messages, false)
+    expect(result).toHaveLength(2)
+    expect(result[0]?.content).toBe('hello')
+    expect(result[0]?.attachments).toBeUndefined()
+  })
+
+  it('injects text file content into message content', async () => {
+    const messages: LLMMessage[] = [
+      {
+        role: 'user',
+        content: 'check this file',
+        attachments: [
+          {
+            id: 'a1',
+            filename: 'hello.ts',
+            mimeType: 'text/plain',
+            size: 20,
+            data: 'const x = 1',
+          },
+        ],
+      },
+    ]
+    const result = await resolveAttachmentsInMessages(messages, false)
+    expect(result[0]?.content).toContain('hello.ts')
+    expect(result[0]?.content).toContain('const x = 1')
+    expect(result[0]?.attachments).toEqual([])
+  })
+
+  it('injects PDF text content into message content', async () => {
+    const pdfBuffer = makeSimplePdfBuffer()
+    const base64 = `data:application/pdf;base64,${pdfBuffer.toString('base64')}`
+    const messages: LLMMessage[] = [
+      {
+        role: 'user',
+        content: 'read this pdf',
+        attachments: [
+          {
+            id: 'p1',
+            filename: 'doc.pdf',
+            mimeType: 'application/pdf',
+            size: pdfBuffer.length,
+            data: base64,
+          },
+        ],
+      },
+    ]
+    const result = await resolveAttachmentsInMessages(messages, false)
+    expect(result[0]?.content).toContain('doc.pdf')
+    expect(result[0]?.attachments).toEqual([])
+  })
+
+  it('converts image to placeholder text when vision not supported', async () => {
+    const messages: LLMMessage[] = [
+      {
+        role: 'user',
+        content: 'look at this',
+        attachments: [
+          {
+            id: 'i1',
+            filename: 'photo.png',
+            mimeType: 'image/png',
+            size: 500,
+            data: 'data:image/png;base64,abc',
+          },
+        ],
+      },
+    ]
+    const result = await resolveAttachmentsInMessages(messages, false)
+    expect(result[0]?.content).toContain('photo.png')
+    expect(result[0]?.attachments).toEqual([])
+  })
+
+  it('keeps image attachments intact when vision is supported', async () => {
+    const messages: LLMMessage[] = [
+      {
+        role: 'user',
+        content: 'look at this',
+        attachments: [
+          {
+            id: 'i2',
+            filename: 'photo.png',
+            mimeType: 'image/png',
+            size: 500,
+            data: 'data:image/png;base64,abc',
+          },
+        ],
+      },
+    ]
+    const result = await resolveAttachmentsInMessages(messages, true)
+    expect(result[0]?.content).toBe('look at this')
+    expect(result[0]?.attachments).toHaveLength(1)
+    expect(result[0]?.attachments?.[0]?.filename).toBe('photo.png')
+  })
+
+  it('decodes base64 data URL for text files', async () => {
+    const content = 'const hello = "world"'
+    const base64 = `data:text/plain;base64,${Buffer.from(content).toString('base64')}`
+    const messages: LLMMessage[] = [
+      {
+        role: 'user',
+        content: 'check this',
+        attachments: [
+          {
+            id: 'b1',
+            filename: 'hello.ts',
+            mimeType: 'text/plain',
+            size: content.length,
+            data: base64,
+          },
+        ],
+      },
+    ]
+    const result = await resolveAttachmentsInMessages(messages, false)
+    expect(result[0]?.content).toContain('hello.ts')
+    expect(result[0]?.content).toContain('const hello = "world"')
+    expect(result[0]?.content).not.toContain('base64')
+  })
+
+
+  it('handles tool messages with attachments', async () => {
+    const messages: LLMMessage[] = [
+      {
+        role: 'tool',
+        content: 'result',
+        toolCallId: 'tc1',
+        attachments: [
+          {
+            id: 't1',
+            filename: 'output.txt',
+            mimeType: 'text/plain',
+            size: 10,
+            data: 'some output',
+          },
+        ],
+      },
+    ]
+    const result = await resolveAttachmentsInMessages(messages, false)
+    expect(result[0]?.content).toContain('output.txt')
+    expect(result[0]?.content).toContain('some output')
+    expect(result[0]?.attachments).toEqual([])
+  })
+})

--- a/src/server/llm/resolve-attachments.test.ts
+++ b/src/server/llm/resolve-attachments.test.ts
@@ -136,6 +136,58 @@ describe('resolveAttachmentsInMessages', () => {
   })
 
 
+  it('produces placeholder for unknown mime type when vision is supported', async () => {
+    const messages: LLMMessage[] = [
+      {
+        role: 'user',
+        content: 'check this',
+        attachments: [
+          {
+            id: 'u1',
+            filename: 'audio.mp3',
+            mimeType: 'audio/mpeg',
+            size: 100,
+            data: 'data:audio/mpeg;base64,abc',
+          },
+        ],
+      },
+    ]
+    const result = await resolveAttachmentsInMessages(messages, true)
+    expect(result[0]?.content).toContain('audio.mp3')
+    expect(result[0]?.content).toContain('audio/mpeg')
+    expect(result[0]?.attachments).toEqual([])
+  })
+
+  it('preserves image attachments and produces placeholder for unknown type in mixed message', async () => {
+    const messages: LLMMessage[] = [
+      {
+        role: 'user',
+        content: 'mixed',
+        attachments: [
+          {
+            id: 'img1',
+            filename: 'photo.png',
+            mimeType: 'image/png',
+            size: 500,
+            data: 'data:image/png;base64,abc',
+          },
+          {
+            id: 'aud1',
+            filename: 'clip.mp3',
+            mimeType: 'audio/mpeg',
+            size: 100,
+            data: 'data:audio/mpeg;base64,abc',
+          },
+        ],
+      },
+    ]
+    const result = await resolveAttachmentsInMessages(messages, true)
+    expect(result[0]?.attachments).toHaveLength(1)
+    expect(result[0]?.attachments?.[0]?.filename).toBe('photo.png')
+    expect(result[0]?.content).toContain('clip.mp3')
+    expect(result[0]?.content).toContain('audio/mpeg')
+  })
+
   it('handles tool messages with attachments', async () => {
     const messages: LLMMessage[] = [
       {

--- a/src/server/llm/resolve-attachments.ts
+++ b/src/server/llm/resolve-attachments.ts
@@ -1,19 +1,7 @@
 import type { LLMMessage } from './types.js'
 import type { Attachment } from '../../shared/types.js'
 import { extractPdfText } from '../tools/pdf-utils.js'
-
-const TEXT_MIME_EXACT = [
-  'text/plain',
-  'text/markdown',
-  'text/csv',
-  'text/html',
-  'text/xml',
-  'application/json',
-  'application/xml',
-  'application/javascript',
-  'application/typescript',
-]
-const TEXT_MIME_PREFIXES = ['text/']
+import { TEXT_MIME_EXACT, TEXT_MIME_PREFIXES } from '../../shared/constants.js'
 
 function decodeDataUrlToText(data: string): string {
   const match = data.match(/^data:.*?;base64,(.+)$/)
@@ -24,15 +12,15 @@ function decodeDataUrlToText(data: string): string {
 }
 
 export async function extractPdfFromDataUrl(data: string, filename: string): Promise<string> {
-  try {
-    const base64Match = data.match(/^data:.*?;base64,(.+)$/)
-    if (base64Match?.[1]) {
+  const base64Match = data.match(/^data:.*?;base64,(.+)$/)
+  if (base64Match?.[1]) {
+    try {
       const buffer = Buffer.from(base64Match[1], 'base64')
       const result = await extractPdfText(buffer)
       return `[PDF: ${filename}]\n${result.text}`
+    } catch {
+      return `[PDF: ${filename}] (could not extract text)`
     }
-  } catch {
-    // fall through
   }
   return `[PDF: ${filename}] (could not extract text)`
 }

--- a/src/server/llm/resolve-attachments.ts
+++ b/src/server/llm/resolve-attachments.ts
@@ -1,0 +1,95 @@
+import type { LLMMessage } from './types.js'
+import type { Attachment } from '../../shared/types.js'
+import { extractPdfText } from '../tools/pdf-utils.js'
+
+const TEXT_MIME_EXACT = [
+  'text/plain',
+  'text/markdown',
+  'text/csv',
+  'text/html',
+  'text/xml',
+  'application/json',
+  'application/xml',
+  'application/javascript',
+  'application/typescript',
+]
+const TEXT_MIME_PREFIXES = ['text/']
+
+function decodeDataUrlToText(data: string): string {
+  const match = data.match(/^data:.*?;base64,(.+)$/)
+  if (match?.[1]) {
+    return Buffer.from(match[1], 'base64').toString('utf8')
+  }
+  return data
+}
+
+async function resolveAttachmentToText(attachment: Attachment, supportsVision: boolean): Promise<string> {
+  const mimeType = attachment.mimeType
+
+  if (TEXT_MIME_EXACT.includes(mimeType) || TEXT_MIME_PREFIXES.some((p) => mimeType.startsWith(p))) {
+    const text = decodeDataUrlToText(attachment.data)
+    return `[File: ${attachment.filename || 'file'}]\n${text}`
+  }
+
+  if (mimeType === 'application/pdf') {
+    try {
+      const base64Match = attachment.data.match(/^data:.*?;base64,(.+)$/)
+      if (base64Match?.[1]) {
+        const buffer = Buffer.from(base64Match[1], 'base64')
+        const result = await extractPdfText(buffer)
+        return `[PDF: ${attachment.filename || 'document.pdf'}]\n${result.text}`
+      }
+    } catch {
+      // fall through
+    }
+    return `[PDF: ${attachment.filename || 'document.pdf'}] (could not extract text)`
+  }
+
+  if (supportsVision) {
+    return ''
+  }
+
+  if (attachment.description) {
+    return `[Image: ${attachment.filename || 'image'} - description: ${attachment.description}]`
+  }
+
+  return `[Image: ${attachment.filename || 'image'}] (vision not supported, cannot describe)`
+}
+
+export async function resolveAttachmentsInMessages(
+  messages: LLMMessage[],
+  supportsVision: boolean,
+): Promise<LLMMessage[]> {
+  const result: LLMMessage[] = []
+  for (const msg of messages) {
+    if (!msg.attachments || msg.attachments.length === 0) {
+      result.push(msg)
+      continue
+    }
+
+    if (supportsVision && msg.attachments.every((a) => a.mimeType.startsWith('image/'))) {
+      result.push(msg)
+      continue
+    }
+
+    const parts: string[] = []
+    if (msg.content?.trim()) parts.push(msg.content)
+    const remainingImageAttachments: Attachment[] = []
+
+    for (const attachment of msg.attachments) {
+      if (supportsVision && attachment.mimeType.startsWith('image/')) {
+        remainingImageAttachments.push(attachment)
+        continue
+      }
+      const text = await resolveAttachmentToText(attachment, supportsVision)
+      if (text) parts.push(text)
+    }
+
+    result.push({
+      ...msg,
+      content: parts.join('\n\n'),
+      attachments: remainingImageAttachments,
+    })
+  }
+  return result
+}

--- a/src/server/llm/resolve-attachments.ts
+++ b/src/server/llm/resolve-attachments.ts
@@ -23,6 +23,20 @@ function decodeDataUrlToText(data: string): string {
   return data
 }
 
+export async function extractPdfFromDataUrl(data: string, filename: string): Promise<string> {
+  try {
+    const base64Match = data.match(/^data:.*?;base64,(.+)$/)
+    if (base64Match?.[1]) {
+      const buffer = Buffer.from(base64Match[1], 'base64')
+      const result = await extractPdfText(buffer)
+      return `[PDF: ${filename}]\n${result.text}`
+    }
+  } catch {
+    // fall through
+  }
+  return `[PDF: ${filename}] (could not extract text)`
+}
+
 async function resolveAttachmentToText(attachment: Attachment, supportsVision: boolean): Promise<string> {
   const mimeType = attachment.mimeType
 
@@ -32,21 +46,11 @@ async function resolveAttachmentToText(attachment: Attachment, supportsVision: b
   }
 
   if (mimeType === 'application/pdf') {
-    try {
-      const base64Match = attachment.data.match(/^data:.*?;base64,(.+)$/)
-      if (base64Match?.[1]) {
-        const buffer = Buffer.from(base64Match[1], 'base64')
-        const result = await extractPdfText(buffer)
-        return `[PDF: ${attachment.filename || 'document.pdf'}]\n${result.text}`
-      }
-    } catch {
-      // fall through
-    }
-    return `[PDF: ${attachment.filename || 'document.pdf'}] (could not extract text)`
+    return extractPdfFromDataUrl(attachment.data, attachment.filename || 'document.pdf')
   }
 
   if (supportsVision) {
-    return ''
+    return `[File: ${attachment.filename || 'file'} (unsupported type: ${mimeType})]`
   }
 
   if (attachment.description) {

--- a/src/server/providers/adapters/transport-client.test.ts
+++ b/src/server/providers/adapters/transport-client.test.ts
@@ -145,7 +145,9 @@ describe('createTransportLLMClient', () => {
         },
       ],
       modelSettings: { supportsVision: true },
-    })) {}
+    })) {
+      // consume stream
+    }
 
     const msg = capturedMessages[0] as { attachments?: unknown[] }
     expect(msg.attachments).toHaveLength(1)

--- a/src/server/providers/adapters/transport-client.test.ts
+++ b/src/server/providers/adapters/transport-client.test.ts
@@ -118,6 +118,42 @@ describe('createTransportLLMClient', () => {
     expect(msg.attachments).toEqual([])
   })
 
+  it('resolves attachments before passing messages to complete()', async () => {
+    const provider: Provider = {
+      id: 'copilot',
+      name: 'GitHub Copilot',
+      url: 'https://api.githubcopilot.com',
+      backend: 'openai',
+      credentialRef: 'cred',
+      models: [{ id: 'gpt-4o', contextWindow: 128000, source: 'backend' }],
+      isActive: true,
+      createdAt: new Date().toISOString(),
+    }
+
+    const capturedMessages: unknown[] = []
+    const mockComplete = vi.fn(async (request: { messages: unknown[] }) => {
+      capturedMessages.push(...request.messages)
+      return { id: 'r1', content: '', toolCalls: [], finishReason: 'stop' as const, usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 } }
+    })
+    const client = createTransportLLMClient(provider, 'gpt-4o', { ...transport, complete: mockComplete })
+
+    await client.complete({
+      messages: [
+        {
+          role: 'user',
+          content: 'read this file',
+          attachments: [{ id: 'f2', filename: 'hello.ts', mimeType: 'text/plain', size: 20, data: 'const x = 1' }],
+        },
+      ],
+    })
+
+    expect(capturedMessages).toHaveLength(1)
+    const msg = capturedMessages[0] as { content: string; attachments?: unknown[] }
+    expect(msg.content).toContain('hello.ts')
+    expect(msg.content).toContain('const x = 1')
+    expect(msg.attachments).toEqual([])
+  })
+
   it('respects modelSettings.supportsVision override in stream', async () => {
     const provider: Provider = {
       id: 'copilot',

--- a/src/server/providers/adapters/transport-client.test.ts
+++ b/src/server/providers/adapters/transport-client.test.ts
@@ -70,4 +70,51 @@ describe('createTransportLLMClient', () => {
       },
     )
   })
+
+  it('resolves attachments before passing messages to the transport', async () => {
+    const provider: Provider = {
+      id: 'copilot',
+      name: 'GitHub Copilot',
+      url: 'https://api.githubcopilot.com',
+      backend: 'openai',
+      credentialRef: 'cred',
+      models: [{ id: 'gpt-4o', contextWindow: 128000, source: 'backend' }],
+      isActive: true,
+      createdAt: new Date().toISOString(),
+    }
+
+    const capturedMessages: unknown[] = []
+    const mockStream = vi.fn(async function* (request: { messages: unknown[] }) {
+      capturedMessages.push(...request.messages)
+      yield { type: 'done', response: undefined } as never
+    })
+    const mockTransport: ProviderTransportAdapter = { ...transport, stream: mockStream }
+    const client = createTransportLLMClient(provider, 'gpt-4o', mockTransport)
+
+    for await (const _event of client.stream({
+      messages: [
+        {
+          role: 'user',
+          content: 'read this file',
+          attachments: [
+            {
+              id: 'f1',
+              filename: 'hello.ts',
+              mimeType: 'text/plain',
+              size: 20,
+              data: 'const x = 1',
+            },
+          ],
+        },
+      ],
+    })) {
+      // consume
+    }
+
+    expect(capturedMessages).toHaveLength(1)
+    const msg = capturedMessages[0] as { content: string; attachments?: unknown[] }
+    expect(msg.content).toContain('hello.ts')
+    expect(msg.content).toContain('const x = 1')
+    expect(msg.attachments).toEqual([])
+  })
 })

--- a/src/server/providers/adapters/transport-client.test.ts
+++ b/src/server/providers/adapters/transport-client.test.ts
@@ -117,4 +117,70 @@ describe('createTransportLLMClient', () => {
     expect(msg.content).toContain('const x = 1')
     expect(msg.attachments).toEqual([])
   })
+
+  it('respects modelSettings.supportsVision override in stream', async () => {
+    const provider: Provider = {
+      id: 'copilot',
+      name: 'GitHub Copilot',
+      url: 'https://api.githubcopilot.com',
+      backend: 'openai',
+      models: [{ id: 'gpt-4o', contextWindow: 128000, source: 'backend', supportsVision: false }],
+      isActive: true,
+      createdAt: new Date().toISOString(),
+    }
+
+    const capturedMessages: unknown[] = []
+    const mockStream = vi.fn(async function* (request: { messages: unknown[] }) {
+      capturedMessages.push(...request.messages)
+      yield { type: 'done', response: undefined } as never
+    })
+    const client = createTransportLLMClient(provider, 'gpt-4o', { ...transport, stream: mockStream })
+
+    for await (const _event of client.stream({
+      messages: [
+        {
+          role: 'user',
+          content: 'look',
+          attachments: [{ id: 'i1', filename: 'photo.png', mimeType: 'image/png', size: 10, data: 'data:image/png;base64,abc' }],
+        },
+      ],
+      modelSettings: { supportsVision: true },
+    })) {}
+
+    const msg = capturedMessages[0] as { attachments?: unknown[] }
+    expect(msg.attachments).toHaveLength(1)
+  })
+
+  it('respects modelSettings.supportsVision override in complete', async () => {
+    const provider: Provider = {
+      id: 'copilot',
+      name: 'GitHub Copilot',
+      url: 'https://api.githubcopilot.com',
+      backend: 'openai',
+      models: [{ id: 'gpt-4o', contextWindow: 128000, source: 'backend', supportsVision: false }],
+      isActive: true,
+      createdAt: new Date().toISOString(),
+    }
+
+    const capturedMessages: unknown[] = []
+    const mockComplete = vi.fn(async (request: { messages: unknown[] }) => {
+      capturedMessages.push(...request.messages)
+      return { id: 'r1', content: '', toolCalls: [], finishReason: 'stop' as const, usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 } }
+    })
+    const client = createTransportLLMClient(provider, 'gpt-4o', { ...transport, complete: mockComplete })
+
+    await client.complete({
+      messages: [
+        {
+          role: 'user',
+          content: 'look',
+          attachments: [{ id: 'i1', filename: 'photo.png', mimeType: 'image/png', size: 10, data: 'data:image/png;base64,abc' }],
+        },
+      ],
+      modelSettings: { supportsVision: true },
+    })
+
+    const msg = capturedMessages[0] as { attachments?: unknown[] }
+    expect(msg.attachments).toHaveLength(1)
+  })
 })

--- a/src/server/providers/adapters/transport-client.ts
+++ b/src/server/providers/adapters/transport-client.ts
@@ -3,6 +3,7 @@ import { getBackendCapabilities, type Backend } from '../../llm/backend.js'
 import { getModelProfile } from '../../llm/profiles.js'
 import type { LLMClientWithModel } from '../../llm/client.js'
 import type { ProviderTransportAdapter } from '../../../provider/index.js'
+import { resolveAttachmentsInMessages } from '../../llm/client-pure.js'
 
 export function createTransportLLMClient(
   provider: Provider,
@@ -48,7 +49,13 @@ export function createTransportLLMClient(
     setBackend(next) {
       backend = next
     },
-    complete: (request) => transport.complete(request, context()),
-    stream: (request) => transport.stream(request, context()),
+    complete: async (request) => {
+      const resolved = { ...request, messages: await resolveAttachmentsInMessages(request.messages, profile.supportsVision ?? false) }
+      return transport.complete(resolved, context())
+    },
+    stream: async function* (request) {
+      const resolved = { ...request, messages: await resolveAttachmentsInMessages(request.messages, profile.supportsVision ?? false) }
+      yield* transport.stream(resolved, context())
+    },
   }
 }

--- a/src/server/providers/adapters/transport-client.ts
+++ b/src/server/providers/adapters/transport-client.ts
@@ -50,11 +50,13 @@ export function createTransportLLMClient(
       backend = next
     },
     complete: async (request) => {
-      const resolved = { ...request, messages: await resolveAttachmentsInMessages(request.messages, profile.supportsVision ?? false) }
+      const supportsVision = request.modelSettings?.supportsVision ?? profile.supportsVision ?? false
+      const resolved = { ...request, messages: await resolveAttachmentsInMessages(request.messages, supportsVision) }
       return transport.complete(resolved, context())
     },
     stream: async function* (request) {
-      const resolved = { ...request, messages: await resolveAttachmentsInMessages(request.messages, profile.supportsVision ?? false) }
+      const supportsVision = request.modelSettings?.supportsVision ?? profile.supportsVision ?? false
+      const resolved = { ...request, messages: await resolveAttachmentsInMessages(request.messages, supportsVision) }
       yield* transport.stream(resolved, context())
     },
   }


### PR DESCRIPTION
## Problème

Les fichiers attachés aux messages (texte, PDF, images) n'étaient pas visibles par les modèles utilisant des providers à base de plugins de transport (GitHub Copilot, ChatGPT). Ces plugins implémentent leur propre logique `convertMessage` qui ne lit que `LLMMessage.content` (string), ignorant complètement `LLMMessage.attachments`.

**Cause racine** : `transport-client.ts` transmettait `request` directement à `transport.stream/complete` sans résoudre les attachments au préalable.

## Changements

- **`resolve-attachments.ts`** — `resolveAttachmentsInMessages` résout les fichiers texte, les PDFs (via `extractPdfText`), les images (conservées intactes si `supportsVision=true`, sinon placeholder texte). Exporte le helper partagé `extractPdfFromDataUrl`.
- **`transport-client.ts`** — `complete` et `stream` appellent désormais `resolveAttachmentsInMessages` avant de déléguer au plugin, en utilisant `request.modelSettings?.supportsVision ?? profile.supportsVision ?? false`.
- **`client-pure.ts`** — Utilise `extractPdfFromDataUrl` depuis `resolve-attachments.ts` pour éliminer le code dupliqué de parsing PDF.
- **`src/shared/types.ts`** — `Attachment.mimeType` élargi de l'union de MIME images à `string`.

## Décision

Le fix est appliqué à la frontière transport plutôt que par plugin — tous les plugins actuels et futurs en bénéficient automatiquement.

## Hors scope

Le support de la vision (envoi d'images aux modèles multimodaux) via les plugins de transport fera l'objet de PRs dédiées par plugin. Le modèle fallback vision prend cependant correctement le relai lorsqu'il est paramétré.