### PR TITLE
fix(windows): make unit test suite pass on Windows

### DIFF
--- a/src/server/git/worktree-config.test.ts
+++ b/src/server/git/worktree-config.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { join } from 'node:path'
 import { loadWorktreeConfig, saveWorktreeConfig } from './worktree-config.js'
 
 vi.mock('node:fs/promises', () => ({
@@ -58,7 +59,7 @@ describe('saveWorktreeConfig', () => {
 
     expect(mkdir).toHaveBeenCalledWith(expect.stringContaining('.openfox'), { recursive: true })
     expect(writeFile).toHaveBeenCalledWith(
-      expect.stringContaining('.openfox/worktree.json'),
+      expect.stringContaining(join('.openfox', 'worktree.json')),
       JSON.stringify({ ignoredAssets: 'copy', overrides: { node_modules: 'symlink' } }, null, 2) + '\n',
       'utf-8',
     )

--- a/src/server/git/worktree-sync.test.ts
+++ b/src/server/git/worktree-sync.test.ts
@@ -8,6 +8,19 @@ vi.mock('../utils/logger.js', () => ({
   logger: { debug: vi.fn(), warn: vi.fn(), info: vi.fn(), error: vi.fn() },
 }))
 
+/** Symlink creation needs a privilege/Developer Mode on Windows — probe once. */
+const CAN_SYMLINK = (() => {
+  if (process.platform !== 'win32') return true
+  const probe = join(tmpdir(), `wt-symlink-probe-${process.pid}`)
+  try {
+    symlinkSync('probe-target', probe, 'file')
+    rmSync(probe)
+    return true
+  } catch {
+    return false
+  }
+})()
+
 function createProjectStructure(root: string) {
   // Create a realistic project with .gitignore, node_modules, etc.
   mkdirSync(join(root, '.git'))
@@ -17,13 +30,16 @@ function createProjectStructure(root: string) {
   mkdirSync(join(root, 'node_modules', '.bin'), { recursive: true })
   mkdirSync(join(root, 'node_modules', 'some-package'), { recursive: true })
   writeFileSync(join(root, 'node_modules', 'some-package', 'index.js'), 'module.exports = 42')
-  symlinkSync('../some-package/index.js', join(root, 'node_modules', '.bin', 'some-package'))
 
   // Create web/node_modules
   mkdirSync(join(root, 'web', 'node_modules', '.bin'), { recursive: true })
   mkdirSync(join(root, 'web', 'node_modules', 'web-pkg'), { recursive: true })
   writeFileSync(join(root, 'web', 'node_modules', 'web-pkg', 'index.js'), 'module.exports = "web"')
-  symlinkSync('../web-pkg/index.js', join(root, 'web', 'node_modules', '.bin', 'web-pkg'))
+
+  if (CAN_SYMLINK) {
+    symlinkSync('../some-package/index.js', join(root, 'node_modules', '.bin', 'some-package'))
+    symlinkSync('../web-pkg/index.js', join(root, 'web', 'node_modules', '.bin', 'web-pkg'))
+  }
 }
 
 describe('getIgnoredDirectories', () => {
@@ -46,7 +62,7 @@ describe('getIgnoredDirectories', () => {
 })
 
 describe('syncIgnoredAssets', () => {
-  it('copies node_modules preserving symlinks', async () => {
+  it.skipIf(!CAN_SYMLINK)('copies node_modules preserving symlinks', async () => {
     const root = mkdtempSync(join(tmpdir(), 'wt-test-'))
     const worktreePath = join(root, 'worktrees', 'test-branch')
     try {

--- a/src/server/git/worktree.test.ts
+++ b/src/server/git/worktree.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { join, resolve } from 'node:path'
 import {
   getGitBranch,
   listWorktrees,
@@ -200,13 +201,13 @@ describe('ensureWorktreesIgnored', () => {
   it('appends worktrees/ when missing', async () => {
     vi.mocked(readFile).mockResolvedValue('node_modules/\n')
     await ensureWorktreesIgnored(CWD)
-    expect(appendFile).toHaveBeenCalledWith('/tmp/project/.gitignore', 'worktrees/\n')
+    expect(appendFile).toHaveBeenCalledWith(resolve(CWD, '.gitignore'), 'worktrees/\n')
   })
 
   it('handles missing gitignore', async () => {
     vi.mocked(readFile).mockRejectedValue({ code: 'ENOENT' })
     await ensureWorktreesIgnored(CWD)
-    expect(appendFile).toHaveBeenCalledWith('/tmp/project/.gitignore', 'worktrees/\n')
+    expect(appendFile).toHaveBeenCalledWith(resolve(CWD, '.gitignore'), 'worktrees/\n')
   })
 })
 
@@ -223,7 +224,7 @@ describe('ensureWorktree', () => {
       .mockReturnValueOnce(makeMockProc('') as any) // addWorktree -b
 
     const result = await ensureWorktree(CWD, 'feature/test')
-    expect(result.path).toContain('worktrees/feature-test')
+    expect(result.path).toContain(join('worktrees', 'feature-test'))
     expect(result.name).toBe('feature/test')
     expect(mkdir).toHaveBeenCalledWith(expect.stringContaining('worktrees'), { recursive: true })
     expect(spawn).toHaveBeenNthCalledWith(1, 'git', ['check-ref-format', 'refs/heads/feature/test'], expect.any(Object))
@@ -250,7 +251,7 @@ describe('ensureWorktree', () => {
       .mockReturnValueOnce(makeMockProc('main\n') as any) // getGitBranch
 
     const result = await ensureWorktree(CWD, 'existing')
-    expect(result.path).toContain('worktrees/existing')
+    expect(result.path).toContain(join('worktrees', 'existing'))
     // Should not call addWorktree (git worktree add)
     expect(spawn).toHaveBeenCalledTimes(2) // validateRef + getGitBranch
     expect(spawn).toHaveBeenNthCalledWith(1, 'git', ['check-ref-format', 'refs/heads/existing'], expect.any(Object))
@@ -279,7 +280,7 @@ describe('ensureWorktree', () => {
       .mockReturnValueOnce(makeMockProc('') as any) // addWorktree without -b succeeds
 
     const result = await ensureWorktree(CWD, 'existing')
-    expect(result.path).toContain('worktrees/existing')
+    expect(result.path).toContain(join('worktrees', 'existing'))
     expect(spawn).toHaveBeenNthCalledWith(
       4,
       'git',

--- a/src/server/routes/terminals.test.ts
+++ b/src/server/routes/terminals.test.ts
@@ -21,9 +21,9 @@ describe('Terminal Routes', () => {
     })
   })
 
-  afterEach(() => {
+  afterEach(async () => {
     server?.close()
-    terminalManager.killAll()
+    await terminalManager.killAll()
   })
 
   async function json<T>(res: Response): Promise<T> {

--- a/src/server/skills/registry.test.ts
+++ b/src/server/skills/registry.test.ts
@@ -4,9 +4,23 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { mkdtemp, rm, writeFile, mkdir, realpath, readFile, symlink } from 'node:fs/promises'
+import { symlinkSync, rmSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import type { SkillDefinition } from './types.js'
+
+/** Symlink creation needs a privilege/Developer Mode on Windows — probe once. */
+const CAN_SYMLINK = (() => {
+  if (process.platform !== 'win32') return true
+  const probe = join(tmpdir(), `skill-symlink-probe-${process.pid}`)
+  try {
+    symlinkSync('probe-target', probe, 'file')
+    rmSync(probe)
+    return true
+  } catch {
+    return false
+  }
+})()
 
 vi.mock('../db/settings.js', () => {
   const store = new Map<string, string>()
@@ -348,7 +362,7 @@ Custom prompt.
     expect(skills.find((skill) => skill.metadata.id === 'tilde-skill')).toMatchObject({ source: 'selected' })
   })
 
-  it('deduplicates a physical package reached through a directory symlink', async () => {
+  it.skipIf(!CAN_SYMLINK)('deduplicates a physical package reached through a directory symlink', async () => {
     const homeDir = join(tempDir, 'home')
     const globalRoot = join(homeDir, '.agents', 'skills')
     const selectedLink = join(tempDir, 'selected-link')

--- a/src/server/terminal/manager.ts
+++ b/src/server/terminal/manager.ts
@@ -2,6 +2,24 @@ import * as pty from 'node-pty'
 import os from 'node:os'
 import { logger } from '../utils/logger.js'
 import { getPlatformShell } from '../utils/platform.js'
+import { killProcessTree } from '../utils/process-tree.js'
+
+// On Windows, pty.kill() can leave the spawned cmd.exe alive under ConPTY —
+// follow up with a taskkill-based tree kill.
+async function killPty(ptyProcess: pty.IPty): Promise<void> {
+  if (process.platform === 'win32' && ptyProcess.pid) {
+    // Tree-kill first: pty.kill() alone terminates the shell but reparents its
+    // children (taskkill can no longer find them through the dead parent).
+    await killProcessTree(ptyProcess.pid)
+    try {
+      ptyProcess.kill()
+    } catch {
+      // Already gone
+    }
+    return
+  }
+  ptyProcess.kill()
+}
 
 export interface TerminalSession {
   id: string
@@ -119,7 +137,7 @@ class TerminalManager {
     if (!session) {
       return false
     }
-    session.pty.kill()
+    void killPty(session.pty)
     this.sessions.delete(sessionId)
     logger.info('Terminal session killed', { id: sessionId })
     return true
@@ -156,11 +174,10 @@ class TerminalManager {
     }
   }
 
-  killAll(): void {
-    for (const session of this.sessions.values()) {
-      session.pty.kill()
-    }
+  async killAll(): Promise<void> {
+    const kills = Array.from(this.sessions.values()).map((session) => killPty(session.pty))
     this.sessions.clear()
+    await Promise.all(kills)
     logger.info('All terminal sessions killed')
   }
 }

--- a/src/server/terminal/terminal.test.ts
+++ b/src/server/terminal/terminal.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect, afterEach } from 'vitest'
 import { terminalManager } from './manager.js'
 
 describe('TerminalManager', () => {
-  afterEach(() => {
-    terminalManager.killAll()
+  afterEach(async () => {
+    await terminalManager.killAll()
   })
 
   describe('create', () => {

--- a/src/server/tools/path-security.test.ts
+++ b/src/server/tools/path-security.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { mkdir, symlink, rm, writeFile, realpath } from 'node:fs/promises'
+import { symlinkSync, rmSync } from 'node:fs'
 import { join, normalize, resolve } from 'node:path'
 import { tmpdir, homedir } from 'node:os'
 import {
@@ -43,13 +44,40 @@ function mockPlatform(platform: NodeJS.Platform): void {
   Object.defineProperty(process, 'platform', { value: platform, configurable: true })
 }
 
+/**
+ * Canonicalize like the implementation's safeRealpath: realpath when the path
+ * exists, plain resolve otherwise. Lets Unix literals such as /etc/passwd act
+ * as "nonexistent path outside the sandbox" on Windows (e.g. D:\etc\passwd)
+ * instead of crashing the fixtures with ENOENT.
+ */
+async function canonicalOrResolved(path: string): Promise<string> {
+  try {
+    return await realpath(path)
+  } catch {
+    return normalize(resolve(path))
+  }
+}
+
+/** Symlink creation needs a privilege/Developer Mode on Windows — probe once. */
+const CAN_SYMLINK = (() => {
+  if (process.platform !== 'win32') return true
+  const probe = join(tmpdir(), `openfox-symlink-probe-${process.pid}`)
+  try {
+    symlinkSync('probe-target', probe, 'file')
+    rmSync(probe)
+    return true
+  } catch {
+    return false
+  }
+})()
+
 describe('path-security', () => {
   beforeEach(async () => {
     mockPlatform('linux')
     CANONICAL_TMP = await realpath(tmpdir())
-    CANONICAL_PASSWD = await realpath('/etc/passwd')
-    CANONICAL_VAR_LOG_SYSLOG = join(await realpath('/var'), 'log', 'syslog')
-    CANONICAL_ETC_ENV = join(await realpath('/etc'), '.env')
+    CANONICAL_PASSWD = await canonicalOrResolved('/etc/passwd')
+    CANONICAL_VAR_LOG_SYSLOG = join(await canonicalOrResolved('/var'), 'log', 'syslog')
+    CANONICAL_ETC_ENV = join(await canonicalOrResolved('/etc'), '.env')
     // Create test directories
     await mkdir(WORKDIR, { recursive: true })
     await mkdir(OUTSIDE_DIR, { recursive: true })
@@ -194,7 +222,7 @@ describe('path-security', () => {
       })
     })
 
-    describe('symlink resolution', () => {
+    describe.skipIf(!CAN_SYMLINK)('symlink resolution', () => {
       it('allows symlink inside workdir pointing to file inside workdir', async () => {
         const linkPath = join(WORKDIR, 'link-to-file')
         await symlink(join(WORKDIR, 'file.txt'), linkPath)
@@ -343,7 +371,7 @@ describe('path-security', () => {
       it('resolves ~/../../etc/passwd to escape home entirely', () => {
         const paths = extractAbsolutePathsFromCommand('cat ~/../../etc/passwd')
         // With home=/home/user: ~/../../etc = /home/user/../../etc = /etc
-        expect(paths).toContain('/etc/passwd')
+        expect(paths).toContain(normalize(resolve(home, '../../etc/passwd')))
       })
 
       it('handles ~ at start of command', () => {
@@ -720,6 +748,9 @@ describe('path-security', () => {
         const worktreeDir = join(TEST_DIR, 'worktrees', 'my-feature')
         await mkdir(worktreeDir, { recursive: true })
 
+        // Extraction must handle host-shaped paths here (worktreeDir is a real
+        // host path), so undo the global linux platform mock for this test.
+        mockPlatform(REAL_PLATFORM)
         const command = `cd ${worktreeDir} && npx vitest run src/server/providers/plugins/registry.test.ts 2>&1`
         const extractedPaths = extractAbsolutePathsFromCommand(command)
 
@@ -762,6 +793,7 @@ describe('path-security', () => {
         const worktreeDir = join(TEST_DIR, 'worktrees', 'trailing-slash')
         await mkdir(worktreeDir, { recursive: true })
 
+        mockPlatform(REAL_PLATFORM)
         const command = `cd ${worktreeDir}/ && npx vitest run test.ts`
         const extractedPaths = extractAbsolutePathsFromCommand(command)
 
@@ -771,7 +803,7 @@ describe('path-security', () => {
         expect(result.needsConfirmation).toBe(false)
       })
 
-      it('allows cd to worktree path when command uses resolved canonical path', async () => {
+      it.skipIf(!CAN_SYMLINK)('allows cd to worktree path when command uses resolved canonical path', async () => {
         // If workdir is stored as a realpath-resolved path and the command
         // uses the unresolved path (or vice versa), they should still match
         // because isPathWithinSandbox resolves both sides.

--- a/src/server/tools/path-security.ts
+++ b/src/server/tools/path-security.ts
@@ -1,5 +1,5 @@
 import { realpath } from 'node:fs/promises'
-import { resolve, normalize, join, basename, sep } from 'node:path'
+import { resolve, normalize, join, basename, sep, posix, win32 } from 'node:path'
 import { homedir, tmpdir } from 'node:os'
 import type { ServerMessage } from '../../shared/protocol.js'
 import { createChatPathConfirmationMessage } from '../ws/protocol.js'
@@ -232,6 +232,15 @@ function isWindowsAbsolutePath(str: string): boolean {
 }
 
 /**
+ * Normalize an extracted path according to its own shape, not the host
+ * platform: host normalize() would turn "/var/log" into "\var\log" on
+ * Windows, breaking comparisons and the SAFE_PATHS lookup.
+ */
+function normalizeExtracted(path: string): string {
+  return isWindowsAbsolutePath(path) ? win32.normalize(path) : posix.normalize(path)
+}
+
+/**
  * Check if a string is a placeholder marker left by sanitization.
  * These are not real paths and should be skipped.
  */
@@ -280,7 +289,7 @@ export function extractAbsolutePathsFromCommand(command: string): string[] {
   for (const match of fileUrlMatches) {
     const filePath = match[1]
     if (filePath && !isSafePath(filePath)) {
-      paths.push(normalize(filePath))
+      paths.push(normalizeExtracted(filePath))
     }
   }
   sanitized = sanitized.replace(/file:\/\/[^\s'"]+/g, ' __FILEURL__ ')
@@ -317,12 +326,12 @@ export function extractAbsolutePathsFromCommand(command: string): string[] {
 
     // Check for absolute path
     if (isWindowsAbsolutePath(content)) {
-      const resolved = normalize(content)
+      const resolved = normalizeExtracted(content)
       if (!isSafePath(resolved)) {
         paths.push(resolved)
       }
     } else if (!isWindows() && content.startsWith('/')) {
-      const resolved = normalize(content)
+      const resolved = normalizeExtracted(content)
       if (!isSafePath(resolved)) {
         paths.push(resolved)
       }
@@ -350,7 +359,7 @@ export function extractAbsolutePathsFromCommand(command: string): string[] {
     while ((match = winAbsolutePattern.exec(sanitized)) !== null) {
       const candidate = match[1]!
       if (isPlaceholderToken(candidate)) continue
-      const resolved = normalize(candidate)
+      const resolved = normalizeExtracted(candidate)
       if (!isSafePath(resolved)) {
         paths.push(resolved)
       }
@@ -366,7 +375,7 @@ export function extractAbsolutePathsFromCommand(command: string): string[] {
       // Skip if it looks like a regex pattern with metacharacters
       if (looksLikeRegex(candidate)) continue
 
-      const resolved = normalize(candidate)
+      const resolved = normalizeExtracted(candidate)
       // Skip root or empty (e.g. "//" comment lines normalize to "/")
       if (resolved === '/' || resolved === '') continue
       if (!isSafePath(resolved)) {
@@ -439,7 +448,8 @@ export function extractSensitivePathsFromCommand(command: string): string[] {
  * Check if a path is a "safe" device path that doesn't need confirmation
  */
 function isSafePath(path: string): boolean {
-  const normalized = normalize(path)
+  // SAFE_PATHS entries are Unix device paths — posix semantics regardless of host.
+  const normalized = posix.normalize(path)
   return SAFE_PATHS.has(normalized)
 }
 

--- a/src/server/tools/read.test.ts
+++ b/src/server/tools/read.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { resolve } from 'node:path'
 import { readFileTool } from './read.js'
 import { processPdfContent } from './pdf-utils.js'
 import type { ToolContext } from './types.js'
@@ -160,7 +161,7 @@ describe('readFileTool - Image Support', () => {
       expect(result.metadata?.['size']).toBe(mockPngBuffer.length)
       expect(result.metadata?.['base64Data']).toBeDefined()
       expect(result.metadata?.['dataUrl']).toMatch(/^data:image\/png;base64,/)
-      expect(result.metadata?.['path']).toBe('/test/workdir/test.png')
+      expect(result.metadata?.['path']).toBe(resolve('/test/workdir/test.png'))
     })
 
     it('should detect and read a JPEG image file', async () => {
@@ -314,7 +315,7 @@ describe('readFileTool - Image Support', () => {
       expect(result.output).not.toMatch(/^\d+\|/) // No line number prefix
       expect(result.metadata).toBeDefined()
       expect(result.metadata?.['encoding']).toBe('utf-8')
-      expect(result.metadata?.['path']).toBe('/test/workdir/test.ts')
+      expect(result.metadata?.['path']).toBe(resolve('/test/workdir/test.ts'))
       expect(result.metadata?.['startLine']).toBe(2)
       expect(result.metadata?.['endLine']).toBe(3)
     })
@@ -439,7 +440,7 @@ describe('readFileTool - Image Support', () => {
       expect(result.metadata).toBeDefined()
       expect(result.metadata?.['format']).toBe('pdf')
       expect(result.metadata?.['pageCount']).toBe(1)
-      expect(result.metadata?.['path']).toBe('/test/workdir/test.pdf')
+      expect(result.metadata?.['path']).toBe(resolve('/test/workdir/test.pdf'))
     })
 
     it('should return scanned PDF message when no text layer', async () => {

--- a/src/server/tools/shell-streaming.test.ts
+++ b/src/server/tools/shell-streaming.test.ts
@@ -88,16 +88,16 @@ describe('shell tool streaming', () => {
     const startTime = Date.now()
 
     // Command that outputs, waits, then outputs again
-    await runCommandTool.execute({ command: 'echo "first" && sleep 0.1 && echo "second"', timeout: 5000 }, context)
+    await runCommandTool.execute({ command: 'echo "first" && sleep 1 && echo "second"', timeout: 5000 }, context)
 
     // Should have received progress before command completed
     expect(onProgress).toHaveBeenCalled()
 
     // The first progress call should have happened before the sleep completed
-    // (total time > 100ms due to sleep, first call should be < 100ms from start)
+    // (total time > 1s due to sleep, first call should be < 1s from start)
     if (progressTimes.length > 0) {
       const firstProgressTime = progressTimes[0]! - startTime
-      expect(firstProgressTime).toBeLessThan(100) // First output before sleep
+      expect(firstProgressTime).toBeLessThan(1000) // First output before sleep
     }
   })
 
@@ -156,7 +156,7 @@ echo "line 3"
 
     // Start command: echo immediately, then sleep
     const resultPromise = runCommandTool.execute(
-      { command: 'echo "partial output"; sleep 4; echo "never reached"' },
+      { command: 'echo "partial output" && sleep 4 && echo "never reached"' },
       contextWithSignal,
     )
 
@@ -189,7 +189,7 @@ echo "line 3"
     const started = Date.now()
     const resultPromise = runCommandTool.execute(
       {
-        command: `${process.execPath} -e "process.on('SIGINT', () => {}); process.stdout.write('ready\\n'); setInterval(() => {}, 1000)"`,
+        command: `"${process.execPath}" -e "process.on('SIGINT', () => {}); process.stdout.write('ready\\n'); setInterval(() => {}, 1000)"`,
       },
       contextWithSignal,
     )

--- a/src/server/tools/shell.test.ts
+++ b/src/server/tools/shell.test.ts
@@ -140,13 +140,14 @@ describe('runCommandTool truncation with ANSI codes', () => {
 
   it('does not count ANSI escape sequences toward byte limit', async () => {
     // Generate output where ANSI codes make raw string large but visible content is small.
-    // Each line: \033[31m\033[1m\033[4mX\033[0m (28 raw bytes, 1 visible char + \n)
-    // 1800 lines × 28 bytes = 50400 raw (> 50000 maxBytes), but only 3600 visible chars (< 50000)
-    // 1800 lines < 2000 maxLines — so only the byte limit is at risk.
+    // Each line: 9×\033[31m + X + \033[0m + \n = 51 raw bytes, 1 visible char + \n.
+    // 1100 lines × 51 bytes = 56100 raw (> 50000 maxBytes), but only 2200 visible chars (< 50000)
+    // 1100 lines < 2000 maxLines — so only the byte limit is at risk.
     // Without ANSI stripping, this would be truncated. With stripping, it passes.
+    // Uses node (not printf/brace expansion) so the command is portable to Windows shells.
     const result = await runCommandTool.execute(
       {
-        command: `printf '\\033[31m\\033[1m\\033[4mX\\033[0m\\n%.0s' {1..1800}`,
+        command: `node -e "process.stdout.write(('\\u001b[31m'.repeat(9) + 'X\\u001b[0m\\n').repeat(1100))"`,
         timeout: 10000,
       },
       context,
@@ -161,7 +162,7 @@ describe('runCommandTool truncation with ANSI codes', () => {
     // Generate enough visible content to truly exceed the limit
     const result = await runCommandTool.execute(
       {
-        command: `printf 'X%.0s' {1..51000}`,
+        command: `node -e "process.stdout.write('X'.repeat(51000))"`,
         timeout: 10000,
       },
       context,
@@ -179,7 +180,7 @@ describe('runCommandTool truncation with ANSI codes', () => {
     // verifies the output isn't corrupted by ANSI codes near the line limit.
     const result = await runCommandTool.execute(
       {
-        command: `printf '\\033[31mX\\033[0m\\n%.0s' {1..1900}`,
+        command: `node -e "process.stdout.write('\\u001b[31mX\\u001b[0m\\n'.repeat(1900))"`,
         timeout: 10000,
       },
       context,

--- a/src/server/tools/tool-helpers.test.ts
+++ b/src/server/tools/tool-helpers.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
+import { resolve } from 'node:path'
 import { createTool } from './tool-helpers.js'
 import type { ToolContext } from './types.js'
 import { PathAccessDeniedError } from './path-security.js'
@@ -53,7 +54,7 @@ describe('createTool', () => {
 
     // Relative path
     await tool.execute({ path: 'src/file.ts' }, mockContext)
-    expect(resolvedPath).toBe('/test/workdir/src/file.ts')
+    expect(resolvedPath).toBe(resolve('/test/workdir', 'src/file.ts'))
 
     // Absolute path
     await tool.execute({ path: '/absolute/path.ts' }, mockContext)

--- a/src/server/utils/process-tree.test.ts
+++ b/src/server/utils/process-tree.test.ts
@@ -12,10 +12,21 @@ function isAlive(pid: number): boolean {
   }
 }
 
-/** Collect all descendant PIDs via ps */
+/** Collect all descendant PIDs via ps (Unix) or CIM (Windows, where ps does not exist) */
 async function getDescendants(rootPid: number): Promise<number[]> {
+  const [cmd, args] =
+    process.platform === 'win32'
+      ? ([
+          'powershell.exe',
+          [
+            '-NoProfile',
+            '-Command',
+            'Get-CimInstance Win32_Process | ForEach-Object { "$($_.ProcessId) $($_.ParentProcessId)" }',
+          ],
+        ] as const)
+      : (['ps', ['-eo', 'pid=,ppid=']] as const)
   const { stdout } = await new Promise<{ stdout: string }>((resolve, reject) => {
-    execFile('ps', ['-eo', 'pid=,ppid='], { timeout: 5000 }, (err, stdout) => {
+    execFile(cmd, [...args], { timeout: 15000, windowsHide: true }, (err, stdout) => {
       if (err) reject(err)
       else resolve({ stdout })
     })
@@ -58,18 +69,16 @@ describe('terminateProcessTree', () => {
   })
 
   it('kills all descendants of a shell process', async () => {
-    // Spawn a shell that creates multiple child processes
-    const proc = spawn(
-      'bash',
-      [
-        '-c',
-        `sleep 100 &
-       sleep 200 &
-       # Stay alive in foreground
-       sleep 300`,
-      ],
-      { stdio: 'ignore', detached: true },
-    )
+    // Spawn a node process that creates multiple child processes.
+    // node instead of bash so the tree is visible to the host OS on Windows
+    // (a PATH "bash" may be WSL, whose children live outside the host process table).
+    const childScript = [
+      "const { spawn } = require('child_process');",
+      "spawn(process.execPath, ['-e', 'setTimeout(() => {}, 100000)'], { stdio: 'ignore' });",
+      "spawn(process.execPath, ['-e', 'setTimeout(() => {}, 200000)'], { stdio: 'ignore' });",
+      'setInterval(() => {}, 1000);',
+    ].join('\n')
+    const proc = spawn(process.execPath, ['-e', childScript], { stdio: 'ignore', detached: true })
 
     expect(proc.pid).toBeTruthy()
     await sleep(400)

--- a/src/server/utils/process-tree.test.ts
+++ b/src/server/utils/process-tree.test.ts
@@ -56,6 +56,17 @@ async function getDescendants(rootPid: number): Promise<number[]> {
   return descendants
 }
 
+// Node-based process tree: a parent that spawns two long-lived children which
+// inherit the parent's stdio (so pipe-holding scenarios are covered). node
+// instead of bash so the tree is visible to the host OS on Windows (a PATH
+// "bash" may be WSL, whose children live outside the host process table).
+const TREE_SCRIPT = [
+  "const { spawn } = require('child_process');",
+  "spawn(process.execPath, ['-e', 'setTimeout(() => {}, 100000)'], { stdio: 'inherit' });",
+  "spawn(process.execPath, ['-e', 'setTimeout(() => {}, 200000)'], { stdio: 'inherit' });",
+  'setInterval(() => {}, 1000);',
+].join('\n')
+
 describe('terminateProcessTree', () => {
   it('kills a simple sleep process', async () => {
     const proc = spawn('sleep', ['30'], { stdio: 'ignore', detached: true })
@@ -69,16 +80,7 @@ describe('terminateProcessTree', () => {
   })
 
   it('kills all descendants of a shell process', async () => {
-    // Spawn a node process that creates multiple child processes.
-    // node instead of bash so the tree is visible to the host OS on Windows
-    // (a PATH "bash" may be WSL, whose children live outside the host process table).
-    const childScript = [
-      "const { spawn } = require('child_process');",
-      "spawn(process.execPath, ['-e', 'setTimeout(() => {}, 100000)'], { stdio: 'ignore' });",
-      "spawn(process.execPath, ['-e', 'setTimeout(() => {}, 200000)'], { stdio: 'ignore' });",
-      'setInterval(() => {}, 1000);',
-    ].join('\n')
-    const proc = spawn(process.execPath, ['-e', childScript], { stdio: 'ignore', detached: true })
+    const proc = spawn(process.execPath, ['-e', TREE_SCRIPT], { stdio: 'ignore', detached: true })
 
     expect(proc.pid).toBeTruthy()
     await sleep(400)
@@ -142,7 +144,7 @@ describe('terminateProcessTree', () => {
   })
 
   it('kills process group with immediate mode', async () => {
-    const proc = spawn('bash', ['-c', 'sleep 200 & sleep 300'], {
+    const proc = spawn(process.execPath, ['-e', TREE_SCRIPT], {
       stdio: 'ignore',
       detached: true,
     })
@@ -166,7 +168,7 @@ describe('terminateProcessTree', () => {
     // Simulate the pasta scenario: shell spawns a foreground child that
     // holds stdout/stderr pipes open. Process group kill must take down
     // both shell and child so pipes close and the parent gets EOF.
-    const proc = spawn('bash', ['-c', 'sleep 200 & sleep 300'], {
+    const proc = spawn(process.execPath, ['-e', TREE_SCRIPT], {
       stdio: ['ignore', 'pipe', 'pipe'],
       detached: true,
     })

--- a/src/server/utils/shell.test.ts
+++ b/src/server/utils/shell.test.ts
@@ -18,6 +18,16 @@ vi.mock('./platform.js', () => ({
 
 const { spawnShell, spawnShellProcess } = await import('./shell.js')
 
+function withPlatform(platform: NodeJS.Platform, fn: () => void): void {
+  const original = process.platform
+  Object.defineProperty(process, 'platform', { value: platform })
+  try {
+    fn()
+  } finally {
+    Object.defineProperty(process, 'platform', { value: original })
+  }
+}
+
 describe('spawnShell', () => {
   it('passes windowsHide: true and no FORCE_COLOR in spawn options', () => {
     spawnShell('echo hello', { cwd: '/tmp' })
@@ -37,10 +47,20 @@ describe('spawnShell', () => {
     expect(env['FORCE_COLOR']).toBe(process.env['FORCE_COLOR'])
   })
 
-  it('passes detached flag when set', () => {
-    spawnShell('echo hello', { cwd: '/tmp', detached: true })
+  it('passes detached flag when set (non-win32)', () => {
+    withPlatform('linux', () => {
+      spawnShell('echo hello', { cwd: '/tmp', detached: true })
+    })
 
     expect(spawn).toHaveBeenCalledWith('/bin/sh', ['-c', 'echo hello'], expect.objectContaining({ detached: true }))
+  })
+
+  it('ignores detached flag on win32 (visible console + MSYS pipe hangs)', () => {
+    withPlatform('win32', () => {
+      spawnShell('echo hello', { cwd: '/tmp', detached: true })
+    })
+
+    expect(spawn).toHaveBeenCalledWith('/bin/sh', ['-c', 'echo hello'], expect.not.objectContaining({ detached: true }))
   })
 
   it('does not set detached when not requested', () => {
@@ -52,7 +72,9 @@ describe('spawnShell', () => {
 
 describe('spawnShellProcess', () => {
   it('delegates to spawnShell with positional args', () => {
-    spawnShellProcess('echo hello', '/tmp', undefined, true)
+    withPlatform('linux', () => {
+      spawnShellProcess('echo hello', '/tmp', undefined, true)
+    })
 
     expect(spawn).toHaveBeenCalledWith(
       '/bin/sh',

--- a/src/server/utils/shell.ts
+++ b/src/server/utils/shell.ts
@@ -13,12 +13,23 @@ export interface SpawnShellOptions {
 
 export function spawnShell(command: string, options: SpawnShellOptions): ChildProcess {
   const shell = getPlatformShell()
-  return spawn(shell.command, [...shell.args, command], {
+  // cmd.exe: Node's default arg quoting escapes inner double quotes with
+  // backslashes, which cmd does not understand — commands like
+  // node -e "..." silently break. Mimic what Node itself does for
+  // { shell: true }: /d /s /c + the whole command wrapped in quotes,
+  // passed verbatim.
+  const isCmd = shell.command === 'cmd.exe'
+  const args = isCmd ? ['/d', '/s', '/c', `"${command}"`] : [...shell.args, command]
+  return spawn(shell.command, args, {
+    ...(isCmd ? { windowsVerbatimArguments: true } : {}),
     cwd: options.cwd,
     env: { ...process.env },
     stdio: options.stdio ?? ['ignore', 'pipe', 'pipe'],
     windowsHide: true,
-    ...(options.detached ? { detached: true } : {}),
+    // detached is only useful for Unix process-group semantics; on win32 it
+    // spawns a visible console window and makes MSYS binaries (tail, sleep)
+    // hang on pipes. Tree-kill uses taskkill on win32, so detached is unneeded.
+    ...(options.detached && process.platform !== 'win32' ? { detached: true } : {}),
   })
 }
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,9 +6,23 @@ export default defineConfig({
     alias: {
       '@shared': path.resolve(import.meta.dirname, 'src/shared'),
     },
+    // Both the root and web/ trees can end up with their own React copy
+    // (e.g. on Windows dev installs); two copies break hooks in web tests.
+    dedupe: ['react', 'react-dom'],
   },
   test: {
+    // zustand is externalized by default; inline it so the react dedupe below
+    // also applies to its own react import (it would otherwise resolve
+    // web/node_modules/react natively and break hooks).
+    server: {
+      deps: {
+        inline: ['zustand'],
+      },
+    },
     include: ['src/**/*.test.ts', 'web/src/**/*.test.ts', 'web/src/**/*.test.tsx'],
+    // A few tests (init-llm, test-params) flake past the 5s default under
+    // full-suite load on slower machines.
+    testTimeout: 15_000,
     exclude: ['e2e/**', 'node_modules/**'],
     setupFiles: ['vitest-localstorage-mock', './web/src/test-setup.ts'],
     env: {


### PR DESCRIPTION
## Summary

Makes the full unit-test suite pass on Windows and eliminates the suite's visible side effects (orphan `cmd.exe` processes, console popups, MSYS-pipe hangs). About half the failures were product bugs the tests correctly surfaced; the rest was non-portable test code.

**Before / After (Windows 11 / Node 24, after rebase on current develop):**

```
Test Files   20 failed |  171 passed | 1 skipped   ->   193 passed | 1 skipped (194)
Tests       224 failed | 1986 passed | 3 skipped   ->  2235 passed | 11 skipped (2253)
```

## What Changed

**Product fixes**

- `src/server/utils/shell.ts` — `spawnShell()` no longer passes `detached: true` on win32; cmd.exe invocation uses `['/d', '/s', '/c', '"<command>"']` with `windowsVerbatimArguments: true`, matching Node's `{ shell: true }`. Unix keeps `detached: true`, which the process-group kill from #94 relies on.
- `src/server/tools/path-security.ts` — new `normalizeExtracted()` helper normalizes each path by its own shape (`win32.normalize` for drive-letter paths, `posix.normalize` otherwise); `isSafePath()` uses posix semantics for `SAFE_PATHS`. Strict no-op on Linux.
- `src/server/terminal/manager.ts` — tree-kill the shell **before** `pty.kill()`; `killAll()` is now async so test teardown can await it.

**Test changes**

- `src/server/tools/path-security.test.ts` — `canonicalOrResolved()` so Unix literals like `/etc/passwd` keep working as "nonexistent path outside the sandbox" instead of crashing `beforeEach`.
- `src/server/git/worktree-sync.test.ts`, `src/server/skills/registry.test.ts`, `src/server/tools/path-security.test.ts` — `CAN_SYMLINK` probe + `it.skipIf` / `describe.skipIf` (skipped without Developer Mode).
- `src/server/utils/process-tree.test.ts` — descendants via `Get-CimInstance Win32_Process` on win32; all process trees (including the new process-group tests from #94) spawned via a shared node script instead of `bash`: a PATH `bash` may be WSL, whose children live outside the host process table. Same group semantics on Unix.
- Streaming / shell tests — portable commands: `node -e "...repeat(...)"` instead of `printf` + brace expansion, `&&` instead of `;`, quoted `process.execPath`, deadline `sleep 0.1`/<100 ms → `sleep 1`/<1000 ms.

**Config**

- `vitest.config.ts` — `resolve.dedupe: ['react', 'react-dom']`, `server.deps.inline: ['zustand']`, `testTimeout: 15000` for two tests (init-llm, test-params) that flake past 5 s under full-suite load.

## Motivation & Context

I'm mainly on Windows, and every time I open a PR the test suite is not adapted to the platform — example: `npm run test:unit` on a clean `develop` checkout (71d816d) fails massively and the suite has visible side effects on the machine: orphan `cmd.exe` processes, console popups, and error dialogs such as `0x800700e8 (The pipe is being closed)` on MSYS binaries under detached spawn. This made it impossible to validate a PR by a green suite on Windows, which is the direct motivation for this PR.

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing

`npm run test:unit` after rebasing on current develop — `193 passed | 1 skipped` files, `2235 passed | 11 skipped` tests (the 11 skips are symlink tests without Developer Mode; 3 consecutive green runs pre-rebase, 1 post-rebase). `npm run typecheck:server` clean. ESLint + Prettier clean on all touched files. Manual repro: `cmd /c "echo first | tail -3"` via `spawnShell` — hung before, returns instantly now; 0 leaked `cmd.exe` / `tail.exe` after the terminal test files (previously 3–4 per run).

Unix not run locally (Windows dev machine). Every product change branches on `process.platform === 'win32'` or is a posix no-op; deferring to CI.

## Breaking Changes

None. On Linux every change is either platform-branched or a strict no-op (`posix.normalize` ≡ host `normalize`; `killAll()` await only changes timing). Test changes replace hardcoded Unix strings with `join` / `resolve` / `node -e` equivalents that resolve to the same values on Linux.

- [ ] This PR introduces breaking changes

## Related Issues

Rebased on current develop after #94 (process-group kill) landed: the branch originally carried the same `process-tree.ts` immediate-abort fix — now subsumed by #94 and dropped from this diff. The follow-up commit adapts #94's new process-group tests to a node-spawned tree so they pass on Windows too.

## AI-Enhanced Development

- **AI Models:** Claude Fable 5 (via Claude Code) — diagnosis, fixes, and PR text. Every fix was reproduced and verified on a real Windows 11 machine.

## Cache Impact

- **No** — test files, Windows-only runtime branches, and vitest config; no system prompts, tool definitions, or skills touched.

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed

**Key files to review:** `src/server/utils/shell.ts`, `src/server/tools/path-security.ts`, `src/server/terminal/manager.ts`, `vitest.config.ts`

---

<details>
<summary><b>Technical investigation</b> — symptoms, root cause, and fix details</summary>

### Symptoms

Clusters of failures and their errors, verbatim:

- `path-security.test.ts` — 174 failures, all in `beforeEach`:
  ```
  ENOENT: no such file or directory, lstat 'D:\etc\passwd'
  ```
- `process-tree.test.ts`:
  ```
  Error: Command failed: ps -eo pid=,ppid=
  ```
- `worktree-sync.test.ts`, `skills/registry.test.ts`:
  ```
  Error: EPERM: operation not permitted, symlink '..\some-package\index.js' -> '...\node_modules\.bin\some-package'
  ```
- All web component tests (PluginsTab, AdvancedTab, CriteriaEditor, DirectoryBrowser, SkillsModal, ...):
  ```
  TypeError: Cannot read properties of null (reading 'useState')
  ```
- Assorted path-shape failures, e.g.:
  ```
  AssertionError: expected 'D:\tmp\project\worktrees\feature-test' to contain 'worktrees/feature-test'
  ```

### Cause

About half the failures were product bugs the tests correctly exposed; the other half was non-portable test code.

**Product bugs**

1. **`spawnShell()`** (`src/server/utils/shell.ts`) passed `detached: true` through to `spawn()` on win32. A detached child gets its own console (hence the popup windows), and MSYS binaries (`tail`, `sleep` from Git for Windows) hang or fail on their pipes in that configuration — empirically, `cmd /c "echo first | tail -3"` never returns with `detached: true` and completes instantly without it. Nothing needs `detached` on win32: tree-kill goes through `taskkill`, not process groups.
2. **Same function** — Node's default argument quoting escapes inner double quotes with backslashes, which cmd.exe does not understand. Any command containing quotes (e.g. `node -e "..."`) broke silently:
   ```
   '\"C:\Program Files\nodejs\node.exe\"' n'est pas reconnu en tant que commande interne...
   ```
3. **`path-security.ts`** normalized extracted command paths with the **host** `normalize()`, turning `/var/log` into `\var\log` on Windows. Side effect: `isSafePath()` could never match `SAFE_PATHS` entries like `/dev/null` on win32.
4. **`terminal/manager.ts`** — under ConPTY, `pty.kill()` leaves the spawned `cmd.exe` alive, and `killAll()` was fire-and-forget so test workers exited before cleanup finished — orphan cmd.exe accumulated with every run. Killing the shell first also reparents its children out of `taskkill /t`'s reach, so the tree must be killed *before* `pty.kill()`.

**Test-side causes:** hardcoded Unix paths (`/etc/passwd`, `/tmp/project/...`), `realpath()` on paths that do not exist on Windows, unprivileged symlink creation (needs Developer Mode on win32), bash-only syntax (`printf 'X%.0s' {1..N}`, `;` separators), unquoted `process.execPath` (contains a space on Windows), process trees spawned via `bash` (a PATH `bash` may be WSL, whose children are invisible to the host process table), and duplicate React copies between the root and `web/node_modules` trees breaking hooks in every web test (`zustand` is externalized by vitest, so its own `import 'react'` bypassed dedupe — hence `server.deps.inline`).

</details>