### PR TITLE
feat (settings) : allow removing keyboard shortcuts

### DIFF
--- a/web/src/components/settings/tabs/KeybindingsTab.tsx
+++ b/web/src/components/settings/tabs/KeybindingsTab.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
-import { XCloseSmallIcon } from '../../shared/icons'
+import { XCloseSmallIcon, ReloadIcon } from '../../shared/icons'
 import { SETTINGS_KEYS } from '../../../stores/settings'
 import { useSettingsStoreState } from '../useSettingsStore'
 import {
@@ -10,21 +10,31 @@ import {
   type KeyBinding,
 } from '../../../lib/keybindings'
 
+function isDefaultBinding(binding: KeyBinding | null, defaultBinding: KeyBinding | null): boolean {
+  if (binding === null && defaultBinding === null) return true
+  if (binding === null || defaultBinding === null) return false
+  return JSON.stringify(binding) === JSON.stringify(defaultBinding)
+}
+
 function KeybindingRow({
   label,
   binding,
+  defaultBinding,
   isRecording,
   onStartRecording,
   onBindingRecorded,
   onClear,
+  onReset,
   onCancelRecording,
 }: {
   label: string
   binding: KeyBinding | null
+  defaultBinding: KeyBinding | null
   isRecording: boolean
   onStartRecording: () => void
   onBindingRecorded: (binding: KeyBinding) => void
   onClear: () => void
+  onReset: () => void
   onCancelRecording: () => void
 }) {
   const ref = useRef<HTMLDivElement>(null)
@@ -47,6 +57,14 @@ function KeybindingRow({
       }
 
       if (MODIFIERS.has(e.key)) {
+        const now = Date.now()
+        if (e.key === lastKeyRef.current && now - lastPressRef.current < 400) {
+          onBindingRecorded({ type: 'double-press', key: e.key, threshold: 300 })
+          return
+        }
+        lastPressRef.current = now
+        lastKeyRef.current = e.key
+
         if (e.ctrlKey && !pendingModifiers.includes('ctrl')) pendingModifiers.push('ctrl')
         if (e.metaKey && !pendingModifiers.includes('meta')) pendingModifiers.push('meta')
         if (e.altKey && !pendingModifiers.includes('alt')) pendingModifiers.push('alt')
@@ -122,6 +140,17 @@ function KeybindingRow({
                 <XCloseSmallIcon className="w-3.5 h-3.5" />
               </button>
             )}
+            {!isDefaultBinding(binding, defaultBinding) && (
+              <button
+                type="button"
+                onClick={onReset}
+                title="Reset to default"
+                aria-label={`Reset ${label} to default`}
+                className="p-1 text-text-muted rounded hover:text-accent-primary hover:bg-bg-tertiary transition-colors"
+              >
+                <ReloadIcon className="w-3.5 h-3.5" />
+              </button>
+            )}
           </>
         )}
       </div>
@@ -136,13 +165,24 @@ export function KeybindingsTab() {
   const config = parseKeybindings(raw)
   const [recording, setRecording] = useState<string | null>(null)
 
-  const actions: Array<{ id: string; label: string; binding: KeyBinding | null }> = [
-    { id: 'terminalToggle', label: 'Toggle Terminal', binding: config.terminalToggle },
-    { id: 'quickAction', label: 'Quick Action', binding: config.quickAction },
+  const actions: Array<{ id: string; label: string; binding: KeyBinding | null; defaultBinding: KeyBinding | null }> = [
+    {
+      id: 'terminalToggle',
+      label: 'Toggle Terminal',
+      binding: config.terminalToggle,
+      defaultBinding: DEFAULT_KEYBINDINGS.terminalToggle,
+    },
+    {
+      id: 'quickAction',
+      label: 'Quick Action',
+      binding: config.quickAction,
+      defaultBinding: DEFAULT_KEYBINDINGS.quickAction,
+    },
     ...config.agentSwitching.map((b, i) => ({
       id: `agentSwitching.${i}`,
       label: `Switch to Agent ${i + 1}`,
       binding: b,
+      defaultBinding: DEFAULT_KEYBINDINGS.agentSwitching[i] ?? null,
     })),
   ]
 
@@ -204,10 +244,12 @@ export function KeybindingsTab() {
               key={action.id}
               label={action.label}
               binding={action.binding}
+              defaultBinding={action.defaultBinding}
               isRecording={recording === action.id}
               onStartRecording={() => handleStartRecording(action.id)}
               onBindingRecorded={handleBindingRecorded}
               onClear={() => updateBinding(action.id, null)}
+              onReset={() => updateBinding(action.id, action.defaultBinding)}
               onCancelRecording={() => setRecording(null)}
             />
           ))}

--- a/web/src/components/settings/tabs/KeybindingsTab.tsx
+++ b/web/src/components/settings/tabs/KeybindingsTab.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
+import { XCloseSmallIcon } from '../../shared/icons'
 import { SETTINGS_KEYS } from '../../../stores/settings'
 import { useSettingsStoreState } from '../useSettingsStore'
 import {
@@ -15,13 +16,15 @@ function KeybindingRow({
   isRecording,
   onStartRecording,
   onBindingRecorded,
+  onClear,
   onCancelRecording,
 }: {
   label: string
-  binding: KeyBinding
+  binding: KeyBinding | null
   isRecording: boolean
   onStartRecording: () => void
   onBindingRecorded: (binding: KeyBinding) => void
+  onClear: () => void
   onCancelRecording: () => void
 }) {
   const ref = useRef<HTMLDivElement>(null)
@@ -100,13 +103,26 @@ function KeybindingRow({
         {isRecording ? (
           <span className="text-xs text-accent-primary font-medium animate-pulse">Press shortcut...</span>
         ) : (
-          <button
-            type="button"
-            onClick={onStartRecording}
-            className="px-2 py-0.5 text-xs font-mono bg-bg-tertiary text-text-secondary rounded border border-border hover:border-accent-primary hover:text-accent-primary transition-colors"
-          >
-            {formatKeybinding(binding)}
-          </button>
+          <>
+            <button
+              type="button"
+              onClick={onStartRecording}
+              className="px-2 py-0.5 text-xs font-mono bg-bg-tertiary text-text-secondary rounded border border-border hover:border-accent-primary hover:text-accent-primary transition-colors"
+            >
+              {binding ? formatKeybinding(binding) : 'None'}
+            </button>
+            {binding && (
+              <button
+                type="button"
+                onClick={onClear}
+                title="Remove shortcut"
+                aria-label={`Remove shortcut for ${label}`}
+                className="p-1 text-text-muted rounded hover:text-accent-error hover:bg-bg-tertiary transition-colors"
+              >
+                <XCloseSmallIcon className="w-3.5 h-3.5" />
+              </button>
+            )}
+          </>
         )}
       </div>
     </div>
@@ -120,7 +136,7 @@ export function KeybindingsTab() {
   const config = parseKeybindings(raw)
   const [recording, setRecording] = useState<string | null>(null)
 
-  const actions: Array<{ id: string; label: string; binding: KeyBinding }> = [
+  const actions: Array<{ id: string; label: string; binding: KeyBinding | null }> = [
     { id: 'terminalToggle', label: 'Toggle Terminal', binding: config.terminalToggle },
     { id: 'quickAction', label: 'Quick Action', binding: config.quickAction },
     ...config.agentSwitching.map((b, i) => ({
@@ -134,25 +150,31 @@ export function KeybindingsTab() {
     setRecording(id)
   }
 
+  const updateBinding = useCallback(
+    (id: string, value: KeyBinding | null) => {
+      const updated = parseKeybindings(raw)
+
+      if (id.startsWith('agentSwitching.')) {
+        const index = parseInt(id.split('.')[1]!, 10)
+        updated.agentSwitching[index] = value
+      } else if (id === 'terminalToggle') {
+        updated.terminalToggle = value
+      } else if (id === 'quickAction') {
+        updated.quickAction = value
+      }
+
+      setSetting(SETTINGS_KEYS.KEYBINDINGS, JSON.stringify(updated))
+    },
+    [raw, setSetting],
+  )
+
   const handleBindingRecorded = useCallback(
     (newBinding: KeyBinding) => {
       if (!recording) return
-      const current = parseKeybindings(raw)
-      const updated = structuredClone(current)
-
-      if (recording.startsWith('agentSwitching.')) {
-        const index = parseInt(recording.split('.')[1]!, 10)
-        updated.agentSwitching[index] = newBinding
-      } else if (recording === 'terminalToggle') {
-        updated.terminalToggle = newBinding
-      } else if (recording === 'quickAction') {
-        updated.quickAction = newBinding
-      }
-
       setRecording(null)
-      setSetting(SETTINGS_KEYS.KEYBINDINGS, JSON.stringify(updated))
+      updateBinding(recording, newBinding)
     },
-    [recording, raw, setSetting],
+    [recording, updateBinding],
   )
 
   const handleReset = () => {
@@ -185,6 +207,7 @@ export function KeybindingsTab() {
               isRecording={recording === action.id}
               onStartRecording={() => handleStartRecording(action.id)}
               onBindingRecorded={handleBindingRecorded}
+              onClear={() => updateBinding(action.id, null)}
               onCancelRecording={() => setRecording(null)}
             />
           ))}

--- a/web/src/hooks/useKeybindings.ts
+++ b/web/src/hooks/useKeybindings.ts
@@ -108,13 +108,17 @@ export function useChordBinding(binding: ChordBinding | undefined, onActivate: (
   }, [binding])
 }
 
-export function useBinding(binding: KeyBinding | undefined, onActivate: () => void, options?: { capture?: boolean }) {
+export function useBinding(
+  binding: KeyBinding | null | undefined,
+  onActivate: () => void,
+  options?: { capture?: boolean },
+) {
   useDoublePressBinding(binding && isDoublePress(binding) ? binding : undefined, onActivate, options)
   useChordBinding(binding && isChord(binding) ? binding : undefined, onActivate)
 }
 
 export function useAgentSwitchingBindings(
-  bindings: KeyBinding[],
+  bindings: (KeyBinding | null)[],
   agents: Array<{ id: string }>,
   onSwitch: (agentId: string) => void,
 ) {

--- a/web/src/lib/keybindings.test.ts
+++ b/web/src/lib/keybindings.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { parseKeybindings, DEFAULT_KEYBINDINGS } from './keybindings'
+
+describe('parseKeybindings', () => {
+  it('returns defaults for empty or invalid input', () => {
+    expect(parseKeybindings(undefined)).toEqual(DEFAULT_KEYBINDINGS)
+    expect(parseKeybindings('not json')).toEqual(DEFAULT_KEYBINDINGS)
+  })
+
+  it('falls back to defaults for missing keys', () => {
+    const config = parseKeybindings('{}')
+    expect(config.terminalToggle).toEqual(DEFAULT_KEYBINDINGS.terminalToggle)
+    expect(config.quickAction).toEqual(DEFAULT_KEYBINDINGS.quickAction)
+  })
+
+  it('preserves explicit null (disabled shortcut) instead of restoring defaults', () => {
+    const config = parseKeybindings(JSON.stringify({ terminalToggle: null, quickAction: null }))
+    expect(config.terminalToggle).toBeNull()
+    expect(config.quickAction).toBeNull()
+    expect(config.agentSwitching).toEqual(DEFAULT_KEYBINDINGS.agentSwitching)
+  })
+
+  it('preserves null entries in agentSwitching', () => {
+    const config = parseKeybindings(
+      JSON.stringify({ agentSwitching: [null, { type: 'chord', key: '2', modifiers: ['ctrl'] }] }),
+    )
+    expect(config.agentSwitching[0]).toBeNull()
+    expect(config.agentSwitching[1]).toEqual({ type: 'chord', key: '2', modifiers: ['ctrl'] })
+  })
+})

--- a/web/src/lib/keybindings.ts
+++ b/web/src/lib/keybindings.ts
@@ -12,10 +12,11 @@ export type ChordBinding = {
 
 export type KeyBinding = DoublePressBinding | ChordBinding
 
+// null = shortcut explicitly disabled by the user
 export interface KeybindingsConfig {
-  terminalToggle: KeyBinding
-  quickAction: KeyBinding
-  agentSwitching: KeyBinding[]
+  terminalToggle: KeyBinding | null
+  quickAction: KeyBinding | null
+  agentSwitching: (KeyBinding | null)[]
 }
 
 export const KEYBINDINGS_SETTING_KEY = 'keybindings'
@@ -35,10 +36,13 @@ export function parseKeybindings(json: string | undefined | null): KeybindingsCo
   if (!json) return structuredClone(DEFAULT_KEYBINDINGS)
   try {
     const parsed = JSON.parse(json) as Partial<KeybindingsConfig>
+    // explicit null = disabled shortcut, only undefined falls back to defaults
+    const orDefault = <K extends keyof KeybindingsConfig>(key: K): KeybindingsConfig[K] =>
+      parsed[key] === undefined ? structuredClone(DEFAULT_KEYBINDINGS[key]) : parsed[key]
     return {
-      terminalToggle: parsed.terminalToggle ?? structuredClone(DEFAULT_KEYBINDINGS.terminalToggle),
-      quickAction: parsed.quickAction ?? structuredClone(DEFAULT_KEYBINDINGS.quickAction),
-      agentSwitching: parsed.agentSwitching ?? structuredClone(DEFAULT_KEYBINDINGS.agentSwitching),
+      terminalToggle: orDefault('terminalToggle'),
+      quickAction: orDefault('quickAction'),
+      agentSwitching: orDefault('agentSwitching'),
     }
   } catch {
     return structuredClone(DEFAULT_KEYBINDINGS)


### PR DESCRIPTION
## Summary

Adds the ability to remove a keyboard shortcut in Settings → Keybindings. Until now every action always had a binding: the default double-Ctrl (terminal) and double-Shift (quick action) fire accidentally all the time while typing (e.g. releasing Shift twice when writing capitals opens the Quick Action panel). Each shortcut row now has a ✕ button that disables the binding (`null`), shows "None", and can be re-recorded or restored via "Reset to defaults" at any time.

## Preview
<img width="400" height="250" alt="image" src="https://github.com/user-attachments/assets/dca91760-8d76-403a-b2dc-470ca952bada" />
<img width="400" height="250" alt="image" src="https://github.com/user-attachments/assets/99e03b3c-f2b1-4bac-88ee-ab2f9bb333cd" />



## What Changed

### Added

- `web/src/lib/keybindings.test.ts` — unit tests for `parseKeybindings`: defaults for missing/invalid input, explicit `null` preserved (not silently replaced by defaults), `null` entries allowed in `agentSwitching`.

### Modified

- `web/src/lib/keybindings.ts` — `KeybindingsConfig` fields are now `KeyBinding | null` (`null` = explicitly disabled); `parseKeybindings` distinguishes a missing key (falls back to default) from an explicit `null` (kept as-is), which is the core of the fix — the previous `??` fallback would have resurrected the default binding.
- `web/src/hooks/useKeybindings.ts` — `useBinding` and `useAgentSwitchingBindings` accept `null` bindings; the existing `if (!binding)` guards already make a disabled shortcut a no-op, so no listener is registered.
- `web/src/components/settings/tabs/KeybindingsTab.tsx` — clear (✕) button per row (existing `XCloseSmallIcon`), "None" label for disabled bindings, and the record/clear write paths factored into a single `updateBinding(id, value)` helper.

## Motivation & Context

This one was driving me crazy. 

The default bindings are bare-modifier double-presses (double Ctrl, double Shift). When typing normally — especially capitals or Ctrl-based editing shortcuts — they trigger constantly, toggling the terminal or opening Quick Action mid-sentence. There was no way to turn them off: the settings UI only allowed replacing a binding with another one, and any binding stored as `null` would have been silently reset to the default by `parseKeybindings`.

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing

- `npx vitest run web/src/lib/keybindings.test.ts` — 4/4 pass.
- `npm run typecheck` — clean (server + web).
- `npm run test:unit` — all web tests pass. 15 pre-existing failures on this Windows machine, unrelated to this diff (reproduced on a clean tree): `src/server/dev-server/inspect-proxy.test.ts` scans ports above 65535 when the mock target gets an ephemeral port near the top of the Windows range (`getAvailablePort` probes `proxyBase + 200` without clamping → `RangeError`), plus one `process-tree` flake.
- Manual: settings → remove Toggle Terminal and Quick Action shortcuts → rows show "None", double-Ctrl / double-Shift no longer trigger anything; re-recording a shortcut and "Reset to defaults" both restore behavior; disabled state survives reload (server-persisted setting).

## Breaking Changes

None. 
Existing stored configs never contain `null` (the UI could not produce it), and missing keys still fall back to defaults exactly as before.

- [ ] This PR introduces breaking changes

## Related Issues

None.

## AI-Enhanced Development

- **AI Models:** Claude Fable 5 (via Claude Code) — implementation and tests by AI, behavior specified and manually verified by a human on Windows 11.

## Cache Impact

- **No** — web settings UI and client-side keybinding parsing only; no system prompts, tool definitions, skills, or other cached context are touched.

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed

**Key files to review:** `web/src/lib/keybindings.ts` (null-vs-undefined semantics), `web/src/components/settings/tabs/KeybindingsTab.tsx`, `web/src/hooks/useKeybindings.ts`

---

<details>
<summary><b>Technical investigation</b> — why "just don't set it" wasn't possible</summary>

### Symptoms

While typing regular text (capital letters, Ctrl-based shortcuts), the terminal panel or the Quick Action UI opens unprompted — the double-press detectors for bare `Shift`/`Control` fire on ordinary typing rhythm.

### Cause

1. `KeybindingsConfig` (`web/src/lib/keybindings.ts`) typed every action as a non-nullable `KeyBinding`, so the settings UI could only ever *replace* a binding, never remove it.
2. Even if a client wrote `null` into the stored JSON, `parseKeybindings` used `parsed.x ?? DEFAULT`, and `null ?? DEFAULT` evaluates to the default — a disabled binding would silently resurrect on the next parse.

### Fix

`null` is now a first-class value meaning "disabled": `parseKeybindings` only falls back to defaults on `undefined` (key absent), the runtime hooks skip `null` bindings (no listener registered), and the settings UI exposes a clear button plus a "None" state. Recording over "None" or "Reset to defaults" restores a binding.

</details>