### PR TITLE
fix(e2e): vitest finds no test files on Windows (backslashes in glob)

### DIFF
--- a/e2e/vitest.config.ts
+++ b/e2e/vitest.config.ts
@@ -2,8 +2,10 @@ import { defineConfig } from 'vitest/config'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-const __dirname = dirname(fileURLToPath(import.meta.url))
-const rootDir = resolve(__dirname, '..')
+// Globs require forward slashes; on Windows dirname/resolve produce backslashes,
+// which tinyglobby treats as escape characters (include matches nothing).
+const __dirname = dirname(fileURLToPath(import.meta.url)).replace(/\\/g, '/')
+const rootDir = resolve(__dirname, '..').replace(/\\/g, '/')
 
 const CI_MULTIPLIER = process.env['CI'] === 'true' ? 10 : 1
 


### PR DESCRIPTION
## Summary

On Windows, the e2e suite never runs: vitest exits immediately with "No test files found". The include glob is built from `__dirname`, which contains backslashes on Windows, and the glob matcher treats them as escape characters. This PR normalizes the paths to forward slashes so the suite is discovered on every platform.

```
Before (Windows):  No test files found, exiting with code 1
After  (Windows):  44 test files discovered and executed
```

## What Changed

### Modified
- `e2e/vitest.config.ts` — normalize `__dirname` and `rootDir` to forward slashes before they are interpolated into the `include` and `coverage` globs.

## Motivation & Context

Running `npm test` (or committing — the pre-commit hook runs the full suite) on Windows fails in the e2e phase before a single test executes:

```
 RUN  v4.1.2 D:/github/Openfox
No test files found, exiting with code 1
include: D:\github\Openfox\e2e/*.test.ts
```

Part of the ongoing Windows compatibility review (follow-up to #97, which fixed the unit suite on Windows).

## How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing

- Windows 11: `npx vitest run --config e2e/vitest.config.ts` — before: exits 1 with "No test files found"; after: 44 test files discovered and executed.
- Note: with discovery fixed, 19 e2e tests currently fail on Windows for unrelated pre-existing reasons (e.g. path-separator assertions like `expect(...).toContain('worktrees/feature-test-worktree')` vs backslash paths). Those are a separate follow-up; none of them are caused by this change.
- Unix/CI: paths already use forward slashes, so this is a no-op there — deferring to CI.

## Breaking Changes

None. Config-only change, behavior on POSIX platforms is byte-identical.
- [ ] This PR introduces breaking changes

## Related Issues

Follow-up to #97 (Windows unit test suite). A future PR will address the 19 Windows-specific e2e test failures this change reveals.

## AI-Enhanced Development

- **AI Models:** Claude Fable 5 (via Claude Code) — diagnosis and fix by AI; reproduced and verified on a real Windows 11 machine by a human.

## Cache Impact

- **No** — test tooling config only; no system prompts, tool definitions, skills, or runtime context are touched.

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have added tests that prove my fix/feature works (config fix; proof is the suite being discovered at all)
- [x] New and existing tests pass locally (unit suite; see e2e note above)
- [ ] I have updated documentation if needed

**Key files to review:** `e2e/vitest.config.ts`

---

<details>
<summary><b>Technical investigation</b> — symptoms, root cause, and fix details</summary>

### Symptoms

```
 RUN  v4.1.2 D:/github/Openfox
No test files found, exiting with code 1
include: D:\github\Openfox\e2e/*.test.ts
exclude:  **/node_modules/**, **/.git/**
```

### Cause

1. `e2e/vitest.config.ts` builds its `include` pattern as `` `${__dirname}/*.test.ts` ``. On Windows, `dirname(fileURLToPath(import.meta.url))` returns `D:\github\Openfox\e2e` with backslashes.
2. Vitest's glob matcher (tinyglobby) treats `\` as an escape character inside patterns, so `D:\github\Openfox\e2e/*.test.ts` matches nothing and the run exits with code 1.
3. `rootDir` feeds the `coverage.include`/`exclude` globs and has the same problem, so both are normalized with `.replace(/\\/g, '/')`. Forward slashes are valid path separators on Windows, so this is safe everywhere.

</details>