### PR TITLE
feat: replace native browser dialogs with React Modal components

### DIFF
--- a/web/src/components/DeleteProjectConfirmationModal.tsx
+++ b/web/src/components/DeleteProjectConfirmationModal.tsx
@@ -1,5 +1,4 @@
-import { Modal } from './shared/SelfContainedModal'
-import { Button } from './shared/Button'
+import { ConfirmModal } from './shared/ConfirmModal'
 
 interface DeleteProjectConfirmationModalProps {
   isOpen: boolean
@@ -20,23 +19,20 @@ export function DeleteProjectConfirmationModal({
   }
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose} title="Delete Project" size="sm">
-      <div className="space-y-4">
-        <p className="text-text-secondary">
+    <ConfirmModal
+      isOpen={isOpen}
+      onClose={onClose}
+      onConfirm={handleConfirm}
+      title="Delete Project"
+      confirmLabel="Delete"
+      confirmVariant="danger"
+      message={
+        <>
           This will permanently delete the project{' '}
           <span className="font-semibold text-text-primary">{projectName}</span> and all its sessions from OpenFox. The
           project files on disk will remain untouched.
-        </p>
-
-        <div className="flex justify-end gap-2">
-          <Button variant="secondary" onClick={onClose}>
-            Cancel
-          </Button>
-          <Button variant="danger" onClick={handleConfirm}>
-            Delete
-          </Button>
-        </div>
-      </div>
-    </Modal>
+        </>
+      }
+    />
   )
 }

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -6,6 +6,9 @@ import type { SessionSummary } from '@shared/types.js'
 import { ProjectSettingsModal } from '../settings/ProjectSettingsModal'
 import { DropdownMenu } from '../shared/DropdownMenu'
 import { CloseButton } from '../shared/CloseButton'
+import { ConfirmModal } from '../shared/ConfirmModal'
+import { Modal } from '../shared/Modal'
+import { ModalFooter } from '../shared/ModalFooter'
 import { EllipsisIcon, SpinIcon } from '../shared/icons'
 import { groupSessionsByDate, formatDateHeader, formatTime } from '../../lib/format-date.js'
 
@@ -18,6 +21,10 @@ interface SidebarProps {
 export function Sidebar({ projectId, isOpen = true, onClose }: SidebarProps) {
   const [, navigate] = useLocation()
   const [showSettings, setShowSettings] = useState(false)
+  const [sessionToDelete, setSessionToDelete] = useState<string | null>(null)
+  const [sessionToRename, setSessionToRename] = useState<string | null>(null)
+  const [renameValue, setRenameValue] = useState('')
+  const [showDeleteAll, setShowDeleteAll] = useState(false)
 
   const sessions = useSessionStore((state) => state.sessions)
   const currentSession = useSessionStore((state) => state.currentSession)
@@ -60,31 +67,42 @@ export function Sidebar({ projectId, isOpen = true, onClose }: SidebarProps) {
 
   const handleDeleteSession = (sessionId: string, e?: React.MouseEvent) => {
     e?.stopPropagation()
-    if (confirm('Delete this session?')) {
-      deleteSession(sessionId)
-      // If deleting current session, navigate to project root
-      if (currentSession?.id === sessionId) {
-        navigate(`/p/${projectId}`)
-      }
+    setSessionToDelete(sessionId)
+  }
+
+  const handleConfirmDeleteSession = () => {
+    if (!sessionToDelete) return
+    deleteSession(sessionToDelete)
+    if (currentSession?.id === sessionToDelete) {
+      navigate(`/p/${projectId}`)
     }
+    setSessionToDelete(null)
   }
 
   const handleRenameSession = (sessionId: string, e?: React.MouseEvent) => {
     e?.stopPropagation()
     const session = sessions.find((s) => s.id === sessionId)
     const currentTitle = session?.title ?? sessionId.slice(0, 6)
-    const newTitle = prompt('Rename session:', currentTitle)
-    if (newTitle !== null && newTitle.trim() !== '') {
-      const renameSession = useSessionStore.getState().renameSession
-      renameSession(sessionId, newTitle.trim())
-    }
+    setRenameValue(currentTitle)
+    setSessionToRename(sessionId)
+  }
+
+  const handleConfirmRename = () => {
+    if (!sessionToRename || renameValue.trim() === '') return
+    const renameSession = useSessionStore.getState().renameSession
+    renameSession(sessionToRename, renameValue.trim())
+    setSessionToRename(null)
+    setRenameValue('')
   }
 
   const handleDeleteAllSessions = () => {
-    if (confirm('Delete all sessions in this project? This cannot be undone.')) {
-      deleteAllSessions(projectId)
-      navigate(`/p/${projectId}`)
-    }
+    setShowDeleteAll(true)
+  }
+
+  const handleConfirmDeleteAll = () => {
+    deleteAllSessions(projectId)
+    navigate(`/p/${projectId}`)
+    setShowDeleteAll(false)
   }
 
   return (
@@ -140,6 +158,60 @@ export function Sidebar({ projectId, isOpen = true, onClose }: SidebarProps) {
         {currentProject && (
           <ProjectSettingsModal isOpen={showSettings} onClose={() => setShowSettings(false)} project={currentProject} />
         )}
+
+        <ConfirmModal
+          isOpen={sessionToDelete !== null}
+          onClose={() => setSessionToDelete(null)}
+          onConfirm={handleConfirmDeleteSession}
+          title="Delete session?"
+          message="This session will be permanently deleted."
+          confirmLabel="Delete session"
+          confirmVariant="danger"
+        />
+
+        <ConfirmModal
+          isOpen={showDeleteAll}
+          onClose={() => setShowDeleteAll(false)}
+          onConfirm={handleConfirmDeleteAll}
+          title="Delete all sessions?"
+          message="Delete all sessions in this project? This cannot be undone."
+          confirmLabel="Delete all"
+          confirmVariant="danger"
+        />
+
+        <Modal
+          isOpen={sessionToRename !== null}
+          onClose={() => {
+            setSessionToRename(null)
+            setRenameValue('')
+          }}
+          title="Rename session"
+          size="sm"
+          footer={
+            <ModalFooter
+              onCancel={() => {
+                setSessionToRename(null)
+                setRenameValue('')
+              }}
+              onSave={handleConfirmRename}
+              saving={false}
+              saveDisabled={renameValue.trim() === ''}
+              saveLabel="Rename"
+            />
+          }
+        >
+          <input
+            type="text"
+            value={renameValue}
+            onChange={(e) => setRenameValue(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') handleConfirmRename()
+            }}
+            onFocus={(e) => e.target.select()}
+            className="w-full px-3 py-2 text-sm text-text-primary bg-bg-tertiary border border-border rounded focus:outline-none focus:ring-1 focus:ring-accent-primary"
+            autoFocus
+          />
+        </Modal>
 
         <div className="flex-1 overflow-y-auto">
           {projectSessions.length === 0 ? (

--- a/web/src/components/settings/SkillLibraryPanel.test.tsx
+++ b/web/src/components/settings/SkillLibraryPanel.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 
 import { fireEvent, render, screen } from '@testing-library/react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { SkillLibraryPanel } from './SkillLibraryPanel'
 
 vi.mock('../shared/DirectoryBrowser', () => ({
@@ -11,10 +11,6 @@ vi.mock('../shared/DirectoryBrowser', () => ({
 }))
 
 describe('SkillLibraryPanel', () => {
-  beforeEach(() => {
-    window.confirm = vi.fn(() => true)
-  })
-
   it('shows the default global folder and lets it be changed', () => {
     const onSelect = vi.fn()
     render(
@@ -36,6 +32,7 @@ describe('SkillLibraryPanel', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Change folder' }))
     fireEvent.click(screen.getByRole('button', { name: 'Select mocked folder' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Trust folder' }))
     expect(onSelect).toHaveBeenCalledWith('/Users/test/Shared Skills')
   })
 })

--- a/web/src/components/settings/SkillLibraryPanel.tsx
+++ b/web/src/components/settings/SkillLibraryPanel.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { Button } from '../shared/Button'
+import { ConfirmModal } from '../shared/ConfirmModal'
 import { DirectoryBrowser } from '../shared/DirectoryBrowser'
 import { packageFromDataTransfer, packageFromFileList, type DroppedSkillPackage } from './skill-package-drop'
 
@@ -28,23 +29,30 @@ export function SkillLibraryPanel({
   const [choosing, setChoosing] = useState(false)
   const [installing, setInstalling] = useState(false)
   const [error, setError] = useState('')
+  const [pendingPath, setPendingPath] = useState<string | null>(null)
+  const [confirmingPath, setConfirmingPath] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
 
   useEffect(() => {
     inputRef.current?.setAttribute('webkitdirectory', '')
   }, [])
 
-  const choose = async (path: string) => {
-    const trusted = window.confirm(
-      'Skills may contain instructions and scripts. Select this folder for discovery without executing package content?',
-    )
-    if (!trusted) return
-    const result = await onSelect(path)
+  const choose = (path: string) => {
+    setPendingPath(path)
+  }
+
+  const handleConfirmPath = async () => {
+    if (!pendingPath || confirmingPath) return
+    setConfirmingPath(true)
+    const result = await onSelect(pendingPath)
     if (result && !result.success) {
       setError(result.error ?? 'Cannot use selected folder.')
+      setConfirmingPath(false)
       return
     }
+    setPendingPath(null)
     setChoosing(false)
+    setConfirmingPath(false)
   }
 
   const install = async (skillPackage: DroppedSkillPackage) => {
@@ -131,6 +139,16 @@ export function SkillLibraryPanel({
           onClose={() => setChoosing(false)}
         />
       )}
+
+      <ConfirmModal
+        isOpen={pendingPath !== null}
+        onClose={() => setPendingPath(null)}
+        onConfirm={handleConfirmPath}
+        title="Trust this folder?"
+        message="Skills may contain instructions and scripts. Select this folder for discovery without executing package content?"
+        confirmLabel="Trust folder"
+        disabled={confirmingPath}
+      />
     </section>
   )
 }

--- a/web/src/components/settings/tabs/PluginsTab.test.tsx
+++ b/web/src/components/settings/tabs/PluginsTab.test.tsx
@@ -29,9 +29,7 @@ const REGISTRY_RESPONSE = {
 }
 
 const INSTALLED_RESPONSE = {
-  installed: [
-    { name: 'openfox-chatgpt', version: 'v1.0.0' },
-  ],
+  installed: [{ name: 'openfox-chatgpt', version: 'v1.0.0' }],
 }
 
 function createJsonResponse(data: unknown, status = 200): Response {
@@ -149,9 +147,12 @@ describe('PluginsTab', () => {
     await userEvent.setup().click(installButtons[0]!)
 
     await waitFor(() => {
-      expect(mockFetch).toHaveBeenCalledWith('/api/plugins/install', expect.objectContaining({
-        method: 'POST',
-      }))
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/api/plugins/install',
+        expect.objectContaining({
+          method: 'POST',
+        }),
+      )
     })
   })
 
@@ -167,15 +168,20 @@ describe('PluginsTab', () => {
     })
 
     mockFetch.mockResolvedValueOnce(createJsonResponse({ success: true }))
-    vi.spyOn(window, 'confirm').mockReturnValue(true)
 
     const removeButton = screen.getByRole('button', { name: 'Remove' })
     await userEvent.setup().click(removeButton)
 
+    const confirmButtons = screen.getAllByRole('button', { name: 'Remove' })
+    await userEvent.setup().click(confirmButtons[1]!)
+
     await waitFor(() => {
-      expect(mockFetch).toHaveBeenCalledWith('/api/plugins/openfox-chatgpt', expect.objectContaining({
-        method: 'DELETE',
-      }))
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/api/plugins/openfox-chatgpt',
+        expect.objectContaining({
+          method: 'DELETE',
+        }),
+      )
     })
   })
 })

--- a/web/src/components/settings/tabs/PluginsTab.tsx
+++ b/web/src/components/settings/tabs/PluginsTab.tsx
@@ -262,7 +262,7 @@ function PluginCard({
         onClose={() => setShowRemoveConfirm(false)}
         onConfirm={handleConfirmRemove}
         title={`Remove "${plugin.displayName}"?`}
-        message={`Remove "${plugin.displayName}" plugin?`}
+        message={`Remove the "${plugin.displayName}" plugin from your installation.`}
         confirmLabel="Remove"
         confirmVariant="danger"
         disabled={removing}

--- a/web/src/components/settings/tabs/PluginsTab.tsx
+++ b/web/src/components/settings/tabs/PluginsTab.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import { authFetch } from '../../../lib/api'
 import { Button } from '../../shared/Button'
+import { ConfirmModal } from '../../shared/ConfirmModal'
 
 const STORAGE_KEY = 'openfox_user_plugins'
 
@@ -117,6 +118,8 @@ function PluginCard({
   const [updating, setUpdating] = useState(false)
   const [errorMsg, setErrorMsg] = useState('')
   const [localVersion, setLocalVersion] = useState<string | null>(installedVersion)
+  const [showRemoveConfirm, setShowRemoveConfirm] = useState(false)
+  const [removing, setRemoving] = useState(false)
 
   useEffect(() => {
     setLocalVersion(installedVersion)
@@ -150,7 +153,11 @@ function PluginCard({
   }
 
   const handleRemove = async () => {
-    if (!window.confirm(`Remove "${plugin.displayName}"?`)) return
+    setShowRemoveConfirm(true)
+  }
+
+  const handleConfirmRemove = async () => {
+    setRemoving(true)
     try {
       const res = await authFetch(`/api/plugins/${plugin.name}`, { method: 'DELETE' })
       if (res.ok) {
@@ -160,6 +167,8 @@ function PluginCard({
     } catch {
       // ignore
     }
+    setRemoving(false)
+    setShowRemoveConfirm(false)
   }
 
   const handleUpdate = async () => {
@@ -247,6 +256,17 @@ function PluginCard({
           )}
         </div>
       </div>
+
+      <ConfirmModal
+        isOpen={showRemoveConfirm}
+        onClose={() => setShowRemoveConfirm(false)}
+        onConfirm={handleConfirmRemove}
+        title={`Remove "${plugin.displayName}"?`}
+        message={`Remove "${plugin.displayName}" plugin?`}
+        confirmLabel="Remove"
+        confirmVariant="danger"
+        disabled={removing}
+      />
     </div>
   )
 }

--- a/web/src/components/settings/tabs/PluginsTab.tsx
+++ b/web/src/components/settings/tabs/PluginsTab.tsx
@@ -152,7 +152,7 @@ function PluginCard({
     }
   }
 
-  const handleRemove = async () => {
+  const handleRemove = () => {
     setShowRemoveConfirm(true)
   }
 

--- a/web/src/components/shared/ConfirmModal.test.tsx
+++ b/web/src/components/shared/ConfirmModal.test.tsx
@@ -1,0 +1,145 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ConfirmModal } from './ConfirmModal'
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('ConfirmModal', () => {
+  it('renders title and message', () => {
+    render(
+      <ConfirmModal
+        isOpen={true}
+        onClose={vi.fn()}
+        onConfirm={vi.fn()}
+        title="Delete item?"
+        message="This will permanently delete the item."
+        confirmLabel="Delete"
+        confirmVariant="danger"
+      />,
+    )
+
+    expect(screen.getByText('Delete item?')).toBeDefined()
+    expect(screen.getByText('This will permanently delete the item.')).toBeDefined()
+    expect(screen.getByText('Delete')).toBeDefined()
+    expect(screen.getByText('Cancel')).toBeDefined()
+  })
+
+  it('does not render when isOpen is false', () => {
+    render(
+      <ConfirmModal
+        isOpen={false}
+        onClose={vi.fn()}
+        onConfirm={vi.fn()}
+        title="Delete item?"
+        message="This will permanently delete the item."
+      />,
+    )
+
+    expect(screen.queryByText('Delete item?')).toBeNull()
+  })
+
+  it('calls onConfirm when confirm button is clicked', async () => {
+    const onConfirm = vi.fn()
+    render(
+      <ConfirmModal
+        isOpen={true}
+        onClose={vi.fn()}
+        onConfirm={onConfirm}
+        title="Delete item?"
+        message="This will permanently delete the item."
+        confirmLabel="Delete"
+        confirmVariant="danger"
+      />,
+    )
+
+    await userEvent.setup().click(screen.getByRole('button', { name: 'Delete' }))
+    expect(onConfirm).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onClose when cancel button is clicked', async () => {
+    const onClose = vi.fn()
+    render(
+      <ConfirmModal
+        isOpen={true}
+        onClose={onClose}
+        onConfirm={vi.fn()}
+        title="Delete item?"
+        message="This will permanently delete the item."
+      />,
+    )
+
+    await userEvent.setup().click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('disables buttons when disabled prop is true', () => {
+    render(
+      <ConfirmModal
+        isOpen={true}
+        onClose={vi.fn()}
+        onConfirm={vi.fn()}
+        title="Delete item?"
+        message="This will permanently delete the item."
+        disabled={true}
+      />,
+    )
+
+    const confirmButton = screen.getByRole('button', { name: 'Confirm' })
+    const cancelButton = screen.getByRole('button', { name: 'Cancel' })
+    expect(confirmButton).toBeDisabled()
+    expect(cancelButton).toBeDisabled()
+  })
+
+  it('renders with ReactNode message', () => {
+    render(
+      <ConfirmModal
+        isOpen={true}
+        onClose={vi.fn()}
+        onConfirm={vi.fn()}
+        title="Delete Project"
+        message={
+          <>
+            Delete <span className="font-semibold">My Project</span>?
+          </>
+        }
+      />,
+    )
+
+    expect(screen.getByText('My Project')).toBeDefined()
+  })
+
+  it('uses default label and variant when not specified', () => {
+    render(
+      <ConfirmModal
+        isOpen={true}
+        onClose={vi.fn()}
+        onConfirm={vi.fn()}
+        title="Test"
+        message="Test message"
+      />,
+    )
+
+    expect(screen.getByRole('button', { name: 'Confirm' })).toBeDefined()
+  })
+
+  it('renders with danger variant', () => {
+    render(
+      <ConfirmModal
+        isOpen={true}
+        onClose={vi.fn()}
+        onConfirm={vi.fn()}
+        title="Delete?"
+        message="Confirm deletion"
+        confirmLabel="Delete"
+        confirmVariant="danger"
+      />,
+    )
+
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeDefined()
+  })
+})

--- a/web/src/components/shared/ConfirmModal.tsx
+++ b/web/src/components/shared/ConfirmModal.tsx
@@ -1,0 +1,40 @@
+import { Modal } from './SelfContainedModal'
+import { Button } from './Button'
+
+interface ConfirmModalProps {
+  isOpen: boolean
+  onClose: () => void
+  onConfirm: () => void
+  title: string
+  message: string
+  confirmLabel?: string
+  confirmVariant?: 'danger' | 'primary'
+  disabled?: boolean
+}
+
+export function ConfirmModal({
+  isOpen,
+  onClose,
+  onConfirm,
+  title,
+  message,
+  confirmLabel = 'Confirm',
+  confirmVariant = 'primary',
+  disabled = false,
+}: ConfirmModalProps) {
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title={title} size="sm">
+      <div className="space-y-4">
+        <p className="text-text-secondary">{message}</p>
+        <div className="flex justify-end gap-2">
+          <Button variant="secondary" onClick={onClose} disabled={disabled}>
+            Cancel
+          </Button>
+          <Button variant={confirmVariant} onClick={onConfirm} disabled={disabled} autoFocus>
+            {confirmLabel}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  )
+}

--- a/web/src/components/shared/ConfirmModal.tsx
+++ b/web/src/components/shared/ConfirmModal.tsx
@@ -1,4 +1,5 @@
-import { Modal } from './SelfContainedModal'
+import type { ReactNode } from 'react'
+import { Modal } from './Modal'
 import { Button } from './Button'
 
 interface ConfirmModalProps {
@@ -6,7 +7,7 @@ interface ConfirmModalProps {
   onClose: () => void
   onConfirm: () => void
   title: string
-  message: string
+  message: ReactNode
   confirmLabel?: string
   confirmVariant?: 'danger' | 'primary'
   disabled?: boolean

--- a/web/src/components/shared/ConfirmModal.tsx
+++ b/web/src/components/shared/ConfirmModal.tsx
@@ -26,7 +26,7 @@ export function ConfirmModal({
   return (
     <Modal isOpen={isOpen} onClose={onClose} title={title} size="sm">
       <div className="space-y-4">
-        <p className="text-text-secondary">{message}</p>
+        <div className="text-text-secondary">{message}</div>
         <div className="flex justify-end gap-2">
           <Button variant="secondary" onClick={onClose} disabled={disabled}>
             Cancel


### PR DESCRIPTION
### Résumé

Remplacement des 5 appels natifs `confirm()`/`prompt()` par des modales React modernes réutilisables basées sur le composant `Modal` existant. Un nouveau composant `ConfirmModal` est introduit pour standardiser les dialogues de confirmation.

### Changements

- **Nouveau composant :** `web/src/components/shared/ConfirmModal.tsx` — modale de confirmation réutilisable avec boutons Cancel/Confirm, autoFocus et protection double-clic
- **Sidebar :** remplacement de `confirm()` pour la suppression de session, `confirm()` pour la suppression de toutes les sessions, et `prompt()` pour le renommage (avec saisie clavier)
- **PluginsTab :** remplacement de `window.confirm()` pour la suppression de plugin avec protection contre les soumissions doubles (`disabled`)
- **SkillLibraryPanel :** remplacement de `window.confirm()` pour la confirmation de dossier de confiance avec protection double-clic
- **DeleteProjectConfirmationModal :** refactorisé pour utiliser `ConfirmModal`, supprimant la duplication de code
- **Tests :** nouveau `ConfirmModal.test.tsx` (8 tests), mise à jour des tests existants pour interagir avec les modales, suppression des mocks `window.confirm` obsolètes

### AI-Enhanced Development

- **AI Models :** DeepSeek V4 Flash

### Cache Impact

- **Non**