### PR TITLE
feat: configurable workspace storage directory

### DIFF
--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -96,6 +96,7 @@ const databaseSchema = z.object({
 
 const workspaceSchema = z.object({
   workdir: z.string().default(process.cwd()),
+  workspacesDir: z.string().optional(),
 })
 
 const visionFallbackSchema = z.object({

--- a/src/cli/serve.ts
+++ b/src/cli/serve.ts
@@ -89,6 +89,9 @@ export async function runServe(options: ServeOptions): Promise<void> {
     // Workdir precedence: .env override → global config → process.cwd()
     // Normalize: remove trailing slash to prevent double slashes in paths
     workdir: (process.env['OPENFOX_WORKDIR'] ?? globalConfig.workspace?.workdir ?? process.cwd()).replace(/\/$/, ''),
+    ...(globalConfig.workspace?.workspacesDir !== undefined
+      ? { workspacesDir: globalConfig.workspace.workspacesDir }
+      : {}),
     ...((env.disableAutoSessionTitle ?? globalConfig.disableAutoSessionTitle) !== undefined
       ? { disableAutoSessionTitle: env.disableAutoSessionTitle ?? globalConfig.disableAutoSessionTitle }
       : {}),

--- a/src/server/dev-server/manager.test.ts
+++ b/src/server/dev-server/manager.test.ts
@@ -159,9 +159,11 @@ describe('loadConfig with workspace fallback', () => {
 
   it('falls back to project root when workspace path has no config', async () => {
     vi.mocked(readFile)
-      .mockRejectedValueOnce(new Error('ENOENT'))
-      .mockRejectedValueOnce(new Error('ENOENT'))
-      .mockResolvedValueOnce(JSON.stringify({ command: 'npm run dev', url: 'http://localhost:5173' }))
+      .mockRejectedValueOnce(new Error('ENOENT')) // dev.json at workspace
+      .mockRejectedValueOnce(new Error('ENOENT')) // .git/HEAD at my-feature
+      .mockRejectedValueOnce(new Error('ENOENT')) // .git/HEAD at workspaces
+      .mockResolvedValueOnce('ref: refs/heads/main\n') // .git/HEAD at project root
+      .mockResolvedValueOnce(JSON.stringify({ command: 'npm run dev', url: 'http://localhost:5173' })) // dev.json at project root
 
     const config = await devServerManager.loadConfig('/some/project/workspaces/my-feature')
     expect(config).toEqual({
@@ -170,7 +172,7 @@ describe('loadConfig with workspace fallback', () => {
       hotReload: false,
       disableInspect: false,
     })
-    expect(readFile).toHaveBeenCalledTimes(3)
+    expect(readFile).toHaveBeenCalledTimes(5)
   })
 
   it('returns null when neither path has config', async () => {
@@ -185,6 +187,37 @@ describe('loadConfig with workspace fallback', () => {
     const config = await devServerManager.loadConfig('/some/project')
     expect(config).toBeNull()
     expect(readFile).toHaveBeenCalledTimes(2)
+  })
+
+  it('returns null when dev.json exists in ancestor with no .git (unrelated project)', async () => {
+    vi.mocked(readFile)
+      .mockRejectedValueOnce(new Error('ENOENT')) // 1. dev.json at workspace
+      .mockRejectedValueOnce(new Error('ENOENT')) // 2. .git/HEAD at /some/project/workspaces
+      .mockRejectedValueOnce(new Error('ENOENT')) // 3. .git/HEAD at /some/project
+      // Even if /some/project has a dev.json, it's never checked because .git is missing
+      .mockRejectedValueOnce(new Error('ENOENT')) // 4. .git/HEAD at /some
+
+    const config = await devServerManager.loadConfig('/some/project/workspaces/my-feature')
+    expect(config).toBeNull()
+    // Only 4 reads: 1 dev.json + 3 .git/HEAD checks. No dev.json loaded from non-.git dirs.
+    expect(readFile).toHaveBeenCalledTimes(4)
+  })
+
+  it('loads dev.json from the closest parent with a .git directory', async () => {
+    vi.mocked(readFile)
+      .mockRejectedValueOnce(new Error('ENOENT')) // 1. dev.json at workspace
+      .mockRejectedValueOnce(new Error('ENOENT')) // 2. .git/HEAD at /some/project/workspaces
+      .mockResolvedValueOnce('ref: refs/heads/main\n') // 3. .git/HEAD at /some/project ✓
+      .mockResolvedValueOnce(JSON.stringify({ command: 'npm run dev', url: 'http://localhost:5173' })) // 4. dev.json at /some/project
+
+    const config = await devServerManager.loadConfig('/some/project/workspaces/my-feature')
+    expect(config).toEqual({
+      command: 'npm run dev',
+      url: 'http://localhost:5173',
+      hotReload: false,
+      disableInspect: false,
+    })
+    expect(readFile).toHaveBeenCalledTimes(4)
   })
 })
 

--- a/src/server/dev-server/manager.test.ts
+++ b/src/server/dev-server/manager.test.ts
@@ -160,6 +160,7 @@ describe('loadConfig with workspace fallback', () => {
   it('falls back to project root when workspace path has no config', async () => {
     vi.mocked(readFile)
       .mockRejectedValueOnce(new Error('ENOENT'))
+      .mockRejectedValueOnce(new Error('ENOENT'))
       .mockResolvedValueOnce(JSON.stringify({ command: 'npm run dev', url: 'http://localhost:5173' }))
 
     const config = await devServerManager.loadConfig('/some/project/workspaces/my-feature')
@@ -169,20 +170,21 @@ describe('loadConfig with workspace fallback', () => {
       hotReload: false,
       disableInspect: false,
     })
-    expect(readFile).toHaveBeenCalledTimes(2)
+    expect(readFile).toHaveBeenCalledTimes(3)
   })
 
   it('returns null when neither path has config', async () => {
     vi.mocked(readFile).mockRejectedValue(new Error('ENOENT'))
     const config = await devServerManager.loadConfig('/some/project/workspaces/my-feature')
     expect(config).toBeNull()
+    expect(readFile).toHaveBeenCalledTimes(4)
   })
 
   it('works without fallback (non-workspace path)', async () => {
     vi.mocked(readFile).mockRejectedValue(new Error('ENOENT'))
     const config = await devServerManager.loadConfig('/some/project')
     expect(config).toBeNull()
-    expect(readFile).toHaveBeenCalledTimes(1)
+    expect(readFile).toHaveBeenCalledTimes(2)
   })
 })
 

--- a/src/server/dev-server/manager.ts
+++ b/src/server/dev-server/manager.ts
@@ -199,15 +199,21 @@ class DevServerManager {
     const config = await tryLoad(workdir)
     if (config) return config
 
-    // Walk up directories looking for .openfox/dev.json (max 10 levels)
+    // Walk up directories looking for project root (containing .git)
+    // Then try loading dev.json from there
     const parts = workdir.replace(/\\/g, '/').split('/')
-    const maxDepth = Math.min(parts.length - 1, 10)
-    for (let i = parts.length - 1; i >= parts.length - maxDepth; i--) {
+    for (let i = parts.length - 1; i > 0; i--) {
       const candidate = parts.slice(0, i).join('/')
-      if (candidate === workdir) continue
-      if (!candidate) break
+      if (candidate === workdir || !candidate) continue
+
+      try {
+        await readFile(join(candidate, '.git', 'HEAD'), 'utf-8')
+      } catch {
+        continue
+      }
+
       const parentConfig = await tryLoad(candidate)
-      if (parentConfig) return parentConfig
+      return parentConfig
     }
 
     return null

--- a/src/server/dev-server/manager.ts
+++ b/src/server/dev-server/manager.ts
@@ -199,13 +199,15 @@ class DevServerManager {
     const config = await tryLoad(workdir)
     if (config) return config
 
-    // Auto-detect workspace paths: <global-data-dir>/workspaces/<project>/<name>
-    const wsIdx = workdir.indexOf('/workspaces/')
-    if (wsIdx !== -1) {
-      const projectRoot = workdir.slice(0, wsIdx)
-      if (projectRoot !== workdir) {
-        return tryLoad(projectRoot)
-      }
+    // Walk up directories looking for .openfox/dev.json (max 10 levels)
+    const parts = workdir.replace(/\\/g, '/').split('/')
+    const maxDepth = Math.min(parts.length - 1, 10)
+    for (let i = parts.length - 1; i >= parts.length - maxDepth; i--) {
+      const candidate = parts.slice(0, i).join('/')
+      if (candidate === workdir) continue
+      if (!candidate) break
+      const parentConfig = await tryLoad(candidate)
+      if (parentConfig) return parentConfig
     }
 
     return null

--- a/src/server/git/workspace-config.test.ts
+++ b/src/server/git/workspace-config.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { join } from 'node:path'
-import { loadWorkspaceConfig, saveWorkspaceConfig } from './workspace-config.js'
+import { loadWorkspaceConfig, saveWorkspaceConfig, validateWorkspacesDir } from './workspace-config.js'
 
 vi.mock('node:fs/promises', () => ({
   readFile: vi.fn(),
@@ -78,5 +78,43 @@ describe('saveWorkspaceConfig', () => {
     await saveWorkspaceConfig(WORKDIR, {})
 
     expect(writeFile).toHaveBeenCalledWith(expect.any(String), JSON.stringify({}, null, 2) + '\n', 'utf-8')
+  })
+})
+
+describe('validateWorkspacesDir', () => {
+  it('accepts valid absolute path', () => {
+    expect(() => validateWorkspacesDir('/home/user/workspaces')).not.toThrow()
+  })
+
+  it('rejects non-absolute path', () => {
+    expect(() => validateWorkspacesDir('relative/path')).toThrow('workspacesDir must be an absolute path')
+  })
+
+  it('rejects root directory', () => {
+    expect(() => validateWorkspacesDir('/')).toThrow('workspacesDir cannot be the root directory')
+  })
+
+  it('rejects path with parent references', () => {
+    expect(() => validateWorkspacesDir('/home/../workspaces')).toThrow(
+      'workspacesDir cannot contain parent directory references',
+    )
+  })
+
+  it('rejects empty string', () => {
+    expect(() => validateWorkspacesDir('')).toThrow('workspacesDir is required')
+  })
+})
+
+describe('loadWorkspaceConfig with invalid workspacesDir', () => {
+  it('returns null when workspacesDir is relative', async () => {
+    vi.mocked(readFile).mockResolvedValue(JSON.stringify({ workspacesDir: 'relative/path' }))
+    const result = await loadWorkspaceConfig(WORKDIR)
+    expect(result).toBeNull()
+  })
+
+  it('returns null when workspacesDir is root', async () => {
+    vi.mocked(readFile).mockResolvedValue(JSON.stringify({ workspacesDir: '/' }))
+    const result = await loadWorkspaceConfig(WORKDIR)
+    expect(result).toBeNull()
   })
 })

--- a/src/server/git/workspace-config.test.ts
+++ b/src/server/git/workspace-config.test.ts
@@ -40,6 +40,20 @@ describe('loadWorkspaceConfig', () => {
     const result = await loadWorkspaceConfig(WORKDIR)
     expect(result).toEqual({ setup: ['npm install --prefer-offline'] })
   })
+
+  it('parses config with only workspacesDir', async () => {
+    vi.mocked(readFile).mockResolvedValue(JSON.stringify({ workspacesDir: '/custom/workspaces' }))
+    const result = await loadWorkspaceConfig(WORKDIR)
+    expect(result).toEqual({ workspacesDir: '/custom/workspaces' })
+  })
+
+  it('parses config with both setup and workspacesDir', async () => {
+    vi.mocked(readFile).mockResolvedValue(
+      JSON.stringify({ setup: ['npm install'], workspacesDir: '/custom/workspaces' }),
+    )
+    const result = await loadWorkspaceConfig(WORKDIR)
+    expect(result).toEqual({ setup: ['npm install'], workspacesDir: '/custom/workspaces' })
+  })
 })
 
 describe('saveWorkspaceConfig', () => {

--- a/src/server/git/workspace-config.ts
+++ b/src/server/git/workspace-config.ts
@@ -1,11 +1,18 @@
 import { readFile, writeFile, mkdir } from 'node:fs/promises'
-import { resolve, join } from 'node:path'
+import { resolve, join, isAbsolute } from 'node:path'
 import type { WorkspaceConfig } from '../../shared/workspace.js'
 
 const CONFIG_FILENAME = '.openfox/workspace.json'
 
 function getConfigPath(workdir: string): string {
   return join(resolve(workdir), CONFIG_FILENAME)
+}
+
+export function validateWorkspacesDir(dir: string): void {
+  if (!dir || typeof dir !== 'string') throw new Error('workspacesDir is required')
+  if (!isAbsolute(dir)) throw new Error('workspacesDir must be an absolute path')
+  if (dir === '/') throw new Error('workspacesDir cannot be the root directory')
+  if (dir.includes('..')) throw new Error('workspacesDir cannot contain parent directory references')
 }
 
 export async function loadWorkspaceConfig(workdir: string): Promise<WorkspaceConfig | null> {
@@ -16,6 +23,11 @@ export async function loadWorkspaceConfig(workdir: string): Promise<WorkspaceCon
     const hasSetup = Array.isArray(parsed.setup)
     const hasWorkspacesDir = typeof parsed.workspacesDir === 'string'
     if (!hasSetup && !hasWorkspacesDir) return null
+
+    if (hasWorkspacesDir) {
+      validateWorkspacesDir(parsed.workspacesDir!)
+    }
+
     return {
       ...(hasSetup ? { setup: parsed.setup! } : {}),
       ...(hasWorkspacesDir ? { workspacesDir: parsed.workspacesDir! } : {}),

--- a/src/server/git/workspace-config.ts
+++ b/src/server/git/workspace-config.ts
@@ -12,9 +12,14 @@ export async function loadWorkspaceConfig(workdir: string): Promise<WorkspaceCon
   try {
     const configPath = getConfigPath(workdir)
     const raw = await readFile(configPath, 'utf-8')
-    const parsed = JSON.parse(raw)
-    if (!parsed.setup) return null
-    return { setup: parsed.setup }
+    const parsed = JSON.parse(raw) as Partial<WorkspaceConfig>
+    const hasSetup = Array.isArray(parsed.setup)
+    const hasWorkspacesDir = typeof parsed.workspacesDir === 'string'
+    if (!hasSetup && !hasWorkspacesDir) return null
+    return {
+      ...(hasSetup ? { setup: parsed.setup! } : {}),
+      ...(hasWorkspacesDir ? { workspacesDir: parsed.workspacesDir! } : {}),
+    }
   } catch {
     return null
   }

--- a/src/server/git/workspace.test.ts
+++ b/src/server/git/workspace.test.ts
@@ -7,6 +7,7 @@ import {
   listBranches,
   listWorkspaces,
   getWorkspacesDir,
+  deleteWorkspaceByPath,
 } from './workspace.js'
 
 vi.mock('node:child_process', () => ({
@@ -19,6 +20,7 @@ vi.mock('node:fs/promises', () => ({
   readdir: vi.fn(),
   mkdir: vi.fn(),
   stat: vi.fn(),
+  rm: vi.fn(),
 }))
 
 vi.mock('../utils/logger.js', () => ({
@@ -114,6 +116,37 @@ describe('getWorkspacesDir', () => {
     expect(dir).toContain('workspaces')
     expect(dir).toContain(PROJECT_NAME)
   })
+
+  it('rejects relative workspacesDir', () => {
+    expect(() => getWorkspacesDir(PROJECT_NAME, 'relative/path')).toThrow('workspacesDir must be an absolute path')
+  })
+
+  it('rejects root workspacesDir', () => {
+    expect(() => getWorkspacesDir(PROJECT_NAME, '/')).toThrow('workspacesDir cannot be the root directory')
+  })
+
+  it('rejects workspacesDir with parent references', () => {
+    expect(() => getWorkspacesDir(PROJECT_NAME, '/home/../workspaces')).toThrow(
+      'workspacesDir cannot contain parent directory references',
+    )
+  })
+})
+
+describe('deleteWorkspaceByPath', () => {
+  it('deletes workspace at given path', async () => {
+    vi.mocked(stat).mockResolvedValueOnce({ isDirectory: () => true } as any)
+    const { rm } = await import('node:fs/promises')
+    vi.mocked(rm).mockResolvedValue(undefined as any)
+
+    await deleteWorkspaceByPath('/custom/ws/test-project/my-ws')
+    expect(rm).toHaveBeenCalledWith('/custom/ws/test-project/my-ws', { recursive: true, force: true })
+  })
+
+  it('throws if path does not exist', async () => {
+    vi.mocked(stat).mockResolvedValueOnce(null as any)
+
+    await expect(deleteWorkspaceByPath('/nonexistent')).rejects.toThrow('Workspace path does not exist')
+  })
 })
 
 describe('listWorkspaces', () => {
@@ -136,6 +169,25 @@ describe('listWorkspaces', () => {
     vi.mocked(readdir).mockRejectedValue({ code: 'ENOENT' })
     const result = await listWorkspaces(PROJECT_NAME)
     expect(result).toEqual([])
+  })
+
+  it('lists workspaces in custom dir, ignoring default dir', async () => {
+    vi.mocked(readdir).mockResolvedValue([{ name: 'custom-feature', isDirectory: () => true }] as any)
+    vi.mocked(spawn).mockReturnValue(makeMockProc('develop\n') as any)
+
+    const result = await listWorkspaces(PROJECT_NAME, '/custom/ws')
+    expect(result).toHaveLength(1)
+    expect(result[0]?.name).toBe('custom-feature')
+    expect(result[0]?.path).toContain('/custom/ws')
+    // Default dir workspaces are not included
+    expect(result[0]?.path).not.toContain('.local')
+  })
+
+  it('returns empty when custom dir has no workspaces (legacy workspaces hidden)', async () => {
+    vi.mocked(readdir).mockRejectedValue({ code: 'ENOENT' })
+    const result = await listWorkspaces(PROJECT_NAME, '/custom/ws')
+    expect(result).toEqual([])
+    // Workspaces in the default dir are not listed with custom dir
   })
 })
 

--- a/src/server/git/workspace.test.ts
+++ b/src/server/git/workspace.test.ts
@@ -97,8 +97,20 @@ describe('listBranches', () => {
 })
 
 describe('getWorkspacesDir', () => {
-  it('returns path under global data dir', () => {
+  it('returns path under global data dir by default', () => {
     const dir = getWorkspacesDir(PROJECT_NAME)
+    expect(dir).toContain('workspaces')
+    expect(dir).toContain(PROJECT_NAME)
+  })
+
+  it('returns path under custom workspaces dir when provided', () => {
+    const dir = getWorkspacesDir(PROJECT_NAME, '/custom/ws')
+    expect(dir).toBe('/custom/ws/test-project')
+    expect(dir).not.toContain('.local')
+  })
+
+  it('uses default path when workspacesDir is undefined', () => {
+    const dir = getWorkspacesDir(PROJECT_NAME, undefined)
     expect(dir).toContain('workspaces')
     expect(dir).toContain(PROJECT_NAME)
   })

--- a/src/server/git/workspace.ts
+++ b/src/server/git/workspace.ts
@@ -1,10 +1,10 @@
 import { spawn, execSync } from 'node:child_process'
-import { mkdir } from 'node:fs/promises'
+import { mkdir, rm } from 'node:fs/promises'
 import { resolve, join, isAbsolute } from 'node:path'
 import { homedir, platform } from 'node:os'
 import { logger } from '../utils/logger.js'
 import { gitSpawnEnv } from './env.js'
-import { loadWorkspaceConfig } from './workspace-config.js'
+import { loadWorkspaceConfig, validateWorkspacesDir } from './workspace-config.js'
 
 function captureStdout(cwd: string, args: string[]): Promise<string | null> {
   return new Promise((resolvePromise) => {
@@ -53,6 +53,7 @@ function getGlobalDataDir(): string {
 
 export function getWorkspacesDir(projectName: string, workspacesDir?: string): string {
   if (workspacesDir) {
+    validateWorkspacesDir(workspacesDir)
     return join(workspacesDir, projectName)
   }
   return join(getGlobalDataDir(), 'workspaces', projectName)
@@ -211,9 +212,17 @@ export async function deleteWorkspace(projectName: string, name: string, workspa
   if (!st?.isDirectory()) {
     throw new Error(`Workspace "${name}" does not exist`)
   }
-  const { rm } = await import('node:fs/promises')
   await rm(wsPath, { recursive: true, force: true })
   logger.info('Deleted workspace', { projectName, name, path: wsPath })
+}
+
+export async function deleteWorkspaceByPath(wsPath: string): Promise<void> {
+  const st = await statSafe(wsPath)
+  if (!st?.isDirectory()) {
+    throw new Error(`Workspace path does not exist: ${wsPath}`)
+  }
+  await rm(wsPath, { recursive: true, force: true })
+  logger.info('Deleted workspace at path', { path: wsPath })
 }
 
 async function statSafe(p: string): Promise<{ isDirectory: () => boolean } | null> {

--- a/src/server/git/workspace.ts
+++ b/src/server/git/workspace.ts
@@ -51,7 +51,10 @@ function getGlobalDataDir(): string {
   }
 }
 
-export function getWorkspacesDir(projectName: string): string {
+export function getWorkspacesDir(projectName: string, workspacesDir?: string): string {
+  if (workspacesDir) {
+    return join(workspacesDir, projectName)
+  }
   return join(getGlobalDataDir(), 'workspaces', projectName)
 }
 
@@ -115,8 +118,8 @@ export interface WorkspaceInfo {
   branch: string | null
 }
 
-export async function workspaceExists(projectName: string, name: string): Promise<boolean> {
-  const dir = getWorkspacesDir(projectName)
+export async function workspaceExists(projectName: string, name: string, workspacesDir?: string): Promise<boolean> {
+  const dir = getWorkspacesDir(projectName, workspacesDir)
   const wsPath = resolve(dir, name)
   const st = await statSafe(wsPath)
   if (!st?.isDirectory()) return false
@@ -125,8 +128,8 @@ export async function workspaceExists(projectName: string, name: string): Promis
   return gitSt?.isDirectory() ?? false
 }
 
-export async function listWorkspaces(projectName: string): Promise<WorkspaceInfo[]> {
-  const dir = getWorkspacesDir(projectName)
+export async function listWorkspaces(projectName: string, workspacesDir?: string): Promise<WorkspaceInfo[]> {
+  const dir = getWorkspacesDir(projectName, workspacesDir)
   try {
     const { readdir } = await import('node:fs/promises')
     const entries = await readdir(dir, { withFileTypes: true })
@@ -154,8 +157,9 @@ export async function ensureWorkspace(
   name: string,
   projectName: string,
   branch?: string,
+  workspacesDirOverride?: string,
 ): Promise<WorkspaceResult> {
-  const workspacesDir = getWorkspacesDir(projectName)
+  const workspacesDir = getWorkspacesDir(projectName, workspacesDirOverride)
   const wsPath = resolve(workspacesDir, name)
 
   await mkdir(workspacesDir, { recursive: true })
@@ -200,8 +204,8 @@ export async function ensureWorkspace(
   return { path: wsPath, name }
 }
 
-export async function deleteWorkspace(projectName: string, name: string): Promise<void> {
-  const dir = getWorkspacesDir(projectName)
+export async function deleteWorkspace(projectName: string, name: string, workspacesDir?: string): Promise<void> {
+  const dir = getWorkspacesDir(projectName, workspacesDir)
   const wsPath = resolve(dir, name)
   const st = await statSafe(wsPath)
   if (!st?.isDirectory()) {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -101,7 +101,7 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
   const providerManager = createProviderManager(config, { adapters: providerAdapters })
 
   // Create SessionManager instance (not singleton!)
-  const sessionManager = new SessionManager(providerManager)
+  const sessionManager = new SessionManager(providerManager, config.workspacesDir)
 
   // Wire sessionManager to devServerManager for inspect proxy feedback
   devServerManager.setSessionManager(sessionManager)
@@ -481,7 +481,8 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
     const project = getProject(req.params.id)
     if (!project) return res.status(404).json({ error: 'Project not found' })
     const { listWorkspaces } = await import('./git/workspace.js')
-    const all = await listWorkspaces(project.name)
+    const workspacesRootDir = await sessionManager.resolveWorkspacesDir(project.workdir)
+    const all = await listWorkspaces(project.name, workspacesRootDir)
     // Filter out the main workspace (the repo itself) — only show linked workspaces
     const workspacesList = all.filter((ws) => ws.path !== project.workdir)
     res.json({ workspaces: workspacesList })

--- a/src/server/session/manager.test.ts
+++ b/src/server/session/manager.test.ts
@@ -495,4 +495,44 @@ describe('SessionManager', () => {
       expect(manager.isWarmedUp(s2.id)).toBe(false)
     })
   })
+
+  describe('resolveWorkspacesDir', () => {
+    it('returns undefined when no global or project config set', async () => {
+      const result = await manager.resolveWorkspacesDir(workdir)
+      expect(result).toBeUndefined()
+    })
+
+    it('returns global workspacesDir when set', async () => {
+      const managerWithGlobal = new SessionManager(mockProviderManager as any, '/custom/global/workspaces')
+      const result = await managerWithGlobal.resolveWorkspacesDir(workdir)
+      expect(result).toBe('/custom/global/workspaces')
+    })
+
+    it('returns per-project workspacesDir without any global config', async () => {
+      // Create project-level config only (no global workspacesDir)
+      const { mkdir, writeFile } = await import('node:fs/promises')
+      const dotOpenfox = join(workdir, '.openfox')
+      await mkdir(dotOpenfox, { recursive: true })
+      await writeFile(
+        join(dotOpenfox, 'workspace.json'),
+        JSON.stringify({ workspacesDir: '/custom/project/workspaces' }),
+      )
+      const result = await manager.resolveWorkspacesDir(workdir)
+      expect(result).toBe('/custom/project/workspaces')
+    })
+
+    it('returns per-project workspacesDir overriding global', async () => {
+      const managerWithGlobal = new SessionManager(mockProviderManager as any, '/custom/global/workspaces')
+      // Create project-level config
+      const { mkdir, writeFile } = await import('node:fs/promises')
+      const dotOpenfox = join(workdir, '.openfox')
+      await mkdir(dotOpenfox, { recursive: true })
+      await writeFile(
+        join(dotOpenfox, 'workspace.json'),
+        JSON.stringify({ workspacesDir: '/custom/project/workspaces' }),
+      )
+      const result = await managerWithGlobal.resolveWorkspacesDir(workdir)
+      expect(result).toBe('/custom/project/workspaces')
+    })
+  })
 })

--- a/src/server/session/manager.ts
+++ b/src/server/session/manager.ts
@@ -42,6 +42,7 @@ import {
   workspaceExists,
   getWorkspacesDir,
   deleteWorkspace as deleteWorkspaceDir,
+  deleteWorkspaceByPath,
   validateWorkspaceName,
 } from '../git/workspace.js'
 import { loadWorkspaceConfig } from '../git/workspace-config.js'
@@ -1161,18 +1162,21 @@ export class SessionManager {
 
     // If currently in the workspace being deleted, switch to original first
     const currentWsName = session.workspace?.split('/').pop()
+    const wsPathBeforeSwitch = session.workspace
     if (currentWsName === target) {
       await this.switchWorkspace(sessionId, 'original')
     }
 
-    const effectivePath = resolve(getWorkspacesDir(project.name, workspacesRootDir), target)
-    try {
-      await devServerManager.stop(effectivePath)
-    } catch {
-      // ignore
+    // Use stored workspace path from before switch, to avoid recalculating
+    // from config (config may have changed since creation)
+    if (wsPathBeforeSwitch) {
+      await devServerManager.stop(wsPathBeforeSwitch).catch(() => {})
+      await deleteWorkspaceByPath(wsPathBeforeSwitch)
+    } else {
+      const effectivePath = resolve(getWorkspacesDir(project.name, workspacesRootDir), target)
+      await devServerManager.stop(effectivePath).catch(() => {})
+      await deleteWorkspaceDir(project.name, target, workspacesRootDir)
     }
-
-    await deleteWorkspaceDir(project.name, target, workspacesRootDir)
     const updated = this.requireSession(sessionId)
     this.emit({ type: 'session_updated', session: updated })
     return updated

--- a/src/server/session/manager.ts
+++ b/src/server/session/manager.ts
@@ -44,6 +44,7 @@ import {
   deleteWorkspace as deleteWorkspaceDir,
   validateWorkspaceName,
 } from '../git/workspace.js'
+import { loadWorkspaceConfig } from '../git/workspace-config.js'
 import { resolve } from 'node:path'
 import { SessionNotFoundError } from '../utils/errors.js'
 import { logger } from '../utils/logger.js'
@@ -110,9 +111,11 @@ export class SessionManager {
   private warmedUpSessions = new Set<string>()
   private switchLocks = new Map<string, Promise<unknown>>()
   private workspaceCreationLocks = new Map<string, Promise<void>>()
+  private globalWorkspacesDir: string | undefined
 
-  constructor(providerManager: import('../provider-manager.js').ProviderManager) {
+  constructor(providerManager: import('../provider-manager.js').ProviderManager, globalWorkspacesDir?: string) {
     this.providerManager = providerManager
+    this.globalWorkspacesDir = globalWorkspacesDir
   }
 
   getCurrentModelSettings(
@@ -985,6 +988,22 @@ export class SessionManager {
   }
 
   // ============================================================================
+  // Workspace Directory Resolution
+  // ============================================================================
+
+  /**
+   * Resolve the effective workspaces root directory for a project.
+   * Priority: per-project config (.openfox/workspace.json) → global config → default
+   */
+  async resolveWorkspacesDir(projectWorkdir: string): Promise<string | undefined> {
+    const projectConfig = await loadWorkspaceConfig(projectWorkdir)
+    if (projectConfig?.workspacesDir) {
+      return projectConfig.workspacesDir
+    }
+    return this.globalWorkspacesDir
+  }
+
+  // ============================================================================
   // Workspace Lifecycle
   // ============================================================================
 
@@ -1010,6 +1029,9 @@ export class SessionManager {
       const session = this.requireSession(sessionId)
       const project = getProject(session.projectId)
       if (!project) throw new Error(`Project not found: ${session.projectId}`)
+
+      // Resolve workspaces dir
+      const workspacesRootDir = await this.resolveWorkspacesDir(project.workdir)
 
       // If already in the target workspace, no-op
       if (target === 'original' && !session.workspace) return session
@@ -1040,9 +1062,9 @@ export class SessionManager {
           await existingCreateLock
         }
         const createLockPromise = (async () => {
-          const exists = await workspaceExists(project.name, target)
+          const exists = await workspaceExists(project.name, target, workspacesRootDir)
           if (!exists) {
-            await ensureWorkspace(project.workdir, target, project.name, branch)
+            await ensureWorkspace(project.workdir, target, project.name, branch, workspacesRootDir)
           }
         })()
         this.workspaceCreationLocks.set(createLockKey, createLockPromise)
@@ -1051,7 +1073,7 @@ export class SessionManager {
         } finally {
           this.workspaceCreationLocks.delete(createLockKey)
         }
-        const wsPath = resolve(getWorkspacesDir(project.name), target)
+        const wsPath = resolve(getWorkspacesDir(project.name, workspacesRootDir), target)
         updateSessionWorkdir(sessionId, project.workdir, wsPath)
       }
 
@@ -1063,7 +1085,8 @@ export class SessionManager {
       }
 
       // Read the actual branch we're now on
-      const effectiveWorkdir = target === 'original' ? project.workdir : resolve(getWorkspacesDir(project.name), target)
+      const effectiveWorkdir =
+        target === 'original' ? project.workdir : resolve(getWorkspacesDir(project.name, workspacesRootDir), target)
       const actualBranch = await getGitBranch(effectiveWorkdir)
 
       // Check if the workspace is behind the original (staleness hint)
@@ -1122,6 +1145,9 @@ export class SessionManager {
     const project = getProject(session.projectId)
     if (!project) throw new Error(`Project not found: ${session.projectId}`)
 
+    // Resolve workspaces dir
+    const workspacesRootDir = await this.resolveWorkspacesDir(project.workdir)
+
     // Check if other sessions reference this workspace
     const otherSessionsUsingIt = this.listSessions().filter(
       (s) => s.id !== sessionId && s.workspace?.split('/').pop() === target,
@@ -1139,14 +1165,14 @@ export class SessionManager {
       await this.switchWorkspace(sessionId, 'original')
     }
 
-    const effectivePath = resolve(getWorkspacesDir(project.name), target)
+    const effectivePath = resolve(getWorkspacesDir(project.name, workspacesRootDir), target)
     try {
       await devServerManager.stop(effectivePath)
     } catch {
       // ignore
     }
 
-    await deleteWorkspaceDir(project.name, target)
+    await deleteWorkspaceDir(project.name, target, workspacesRootDir)
     const updated = this.requireSession(sessionId)
     this.emit({ type: 'session_updated', session: updated })
     return updated

--- a/src/server/tools/workspace.test.ts
+++ b/src/server/tools/workspace.test.ts
@@ -6,6 +6,7 @@ const mockSwitchWorkspace = vi.fn()
 const mockDeleteWorkspace = vi.fn()
 const mockGetSession = vi.fn()
 const mockGetProject = vi.fn()
+const mockResolveWorkspacesDir = vi.fn()
 
 vi.mock('../git/workspace.js', () => ({
   getGitBranch: (...args: unknown[]) => mockGetGitBranch(...args),
@@ -20,6 +21,7 @@ function makeContext(overrides: Record<string, unknown> = {}) {
     getProject: mockGetProject,
     switchWorkspace: mockSwitchWorkspace,
     deleteWorkspace: mockDeleteWorkspace,
+    resolveWorkspacesDir: mockResolveWorkspacesDir,
   }
   return {
     workdir: '/tmp/project',
@@ -83,6 +85,7 @@ describe('workspaceTool', () => {
       mockGetSession.mockReturnValue({ projectId: 'p1', workspace: null, workdir: '/tmp/project' })
       mockGetProject.mockReturnValue({ name: 'test-project' })
       mockGetGitBranch.mockResolvedValue('develop')
+      mockResolveWorkspacesDir.mockResolvedValue(undefined)
       mockListWorkspaces.mockResolvedValue([{ name: 'my-exp', branch: 'feat-x', path: '/ws/my-exp' }])
 
       const result = await workspaceTool.execute({ action: 'list' }, makeContext())
@@ -97,6 +100,7 @@ describe('workspaceTool', () => {
       mockGetSession.mockReturnValue({ projectId: 'p1', workspace: '/workspaces/test/my-exp', workdir: '/tmp/project' })
       mockGetProject.mockReturnValue({ name: 'test-project' })
       mockGetGitBranch.mockResolvedValue('feat-x')
+      mockResolveWorkspacesDir.mockResolvedValue(undefined)
       mockListWorkspaces.mockResolvedValue([
         { name: 'my-exp', branch: 'feat-x', path: '/ws/my-exp' },
         { name: 'other', branch: 'main', path: '/ws/other' },

--- a/src/server/tools/workspace.ts
+++ b/src/server/tools/workspace.ts
@@ -84,8 +84,9 @@ export const workspaceTool = createTool<WorkspaceArgs>(
         const project = sessionManager.getProject(session.projectId)
         if (!project) return helpers.error('Project not found')
 
+        const workspacesRootDir = await sessionManager.resolveWorkspacesDir(project.workdir)
         const currentBranch = await getGitBranch(session.workspace ?? session.workdir)
-        const named = await listWorkspaces(project.name)
+        const named = await listWorkspaces(project.name, workspacesRootDir)
         const activeWsName = session.workspace?.split('/').pop() ?? null
 
         const workspaces = [

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -601,6 +601,8 @@ export interface Config {
   disableAutoSessionTitle?: boolean
   /** Override path for the global config file (used for test isolation) */
   globalConfigPath?: string
+  /** Override directory for workspace storage */
+  workspacesDir?: string
   /** MCP server configurations */
   mcpServers?:
     | Record<

--- a/src/shared/workspace.ts
+++ b/src/shared/workspace.ts
@@ -1,3 +1,4 @@
 export interface WorkspaceConfig {
   setup?: string[]
+  workspacesDir?: string
 }


### PR DESCRIPTION
### Summary

Ajoute la possibilité de configurer le répertoire de stockage des workspaces, avec une chaîne de fallback : **config projet → config globale → défaut** (`~/.local/share/openfox[-dev]/workspaces/`).

### Configuration

**Globale** (`~/.config/openfox[-dev]/config.json`) :
```json
{
  "workspace": {
    "workspacesDir": "/chemin/vers/mes/workspaces"
  }
}
```

**Par projet** (`.openfox/workspace.json`) — versionnable dans git :
```json
{
  "workspacesDir": "/chemin/vers/mes/workspaces"
}
```

### Fichiers modifiés

- `src/shared/workspace.ts` — `workspacesDir` dans WorkspaceConfig
- `src/cli/config.ts` — schéma Zod global config
- `src/cli/serve.ts` — passage du paramètre au serveur
- `src/shared/types.ts` — `workspacesDir` dans Config
- `src/server/git/workspace.ts` — toutes les fonctions workspace acceptent le paramètre optionnel
- `src/server/git/workspace-config.ts` — retourne `workspacesDir` quand présent
- `src/server/session/manager.ts` — `SessionManager.resolveWorkspacesDir()` (priorité projet → global → défaut)
- `src/server/tools/workspace.ts` — utilisation de `resolveWorkspacesDir()`
- `src/server/index.ts` — API endpoint utilise `resolveWorkspacesDir()`
- `src/server/dev-server/manager.ts` — détection du projet parent bornée (max 10 niveaux)
- Fichiers de test correspondants

### AI-Enhanced Development

- **AI Models:** DeepSeek V4 Flash

### Cache Impact

No