### PR TITLE
fix(mcp): strip outputSchema to prevent AJV validation failure on broken refs

### DIFF
--- a/src/server/mcp/manager.test.ts
+++ b/src/server/mcp/manager.test.ts
@@ -32,7 +32,11 @@ vi.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
   }),
 }))
 
-const mockTransportInstance = {
+const mockTransportInstance: {
+  start: ReturnType<typeof vi.fn>
+  close: ReturnType<typeof vi.fn>
+  onmessage?: ((message: unknown) => void) | undefined
+} = {
   start: vi.fn().mockResolvedValue(undefined),
   close: vi.fn().mockResolvedValue(undefined),
 }
@@ -43,7 +47,11 @@ vi.mock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
   }),
 }))
 
-const mockHttpTransportInstance = {
+const mockHttpTransportInstance: {
+  start: ReturnType<typeof vi.fn>
+  close: ReturnType<typeof vi.fn>
+  onmessage?: ((message: unknown) => void) | undefined
+} = {
   start: vi.fn().mockResolvedValue(undefined),
   close: vi.fn().mockResolvedValue(undefined),
 }
@@ -128,6 +136,57 @@ describe('McpManager', () => {
       const server = manager.getServer('test')
       expect(server!.tools.find((t) => t.name === 'write_file')!.enabled).toBe(false)
       expect(server!.tools.find((t) => t.name === 'get_weather')!.enabled).toBe(true)
+    })
+
+    it('should strip outputSchema from tool list responses to prevent AJV validation failure on broken $ref', async () => {
+      await manager.addServer('test-server', {
+        transport: 'stdio',
+        command: 'node',
+      })
+
+      // The interceptor is now installed on mockTransportInstance via Object.defineProperty.
+      // Simulate the SDK setting onmessage — this triggers the setter, which wraps our handler.
+      const sdkHandler = vi.fn()
+      mockTransportInstance.onmessage = sdkHandler
+
+      // Retrieve the wrapped function (the getter returns the closure-wrapped version)
+      const wrappedHandler = mockTransportInstance.onmessage as (msg: unknown) => void
+
+      // Simulate a tools/list response with outputSchema containing broken $ref
+      const toolsListMessage = {
+        jsonrpc: '2.0',
+        id: 1,
+        result: {
+          tools: [
+            {
+              name: 'stitch_tool',
+              description: 'A tool with broken outputSchema',
+              inputSchema: { type: 'object' },
+              outputSchema: { type: 'object', $ref: '#/$defs/ScreenInstance' },
+            },
+            {
+              name: 'clean_tool',
+              description: 'A tool without outputSchema',
+              inputSchema: { type: 'object' },
+            },
+          ],
+        },
+      }
+
+      wrappedHandler(toolsListMessage)
+
+      // SDK handler should have been called
+      expect(sdkHandler).toHaveBeenCalledWith(toolsListMessage)
+
+      // outputSchema should be stripped from the tool that had it
+      expect((toolsListMessage.result.tools[0] as any).outputSchema).toBeUndefined()
+      // Tool without outputSchema is unaffected
+      expect((toolsListMessage.result.tools[1] as any).outputSchema).toBeUndefined()
+
+      // Non-tool-list messages pass through unchanged
+      const nonToolMessage = { jsonrpc: '2.0', id: 2, result: { serverInfo: { name: 'test' } } }
+      wrappedHandler(nonToolMessage)
+      expect(sdkHandler).toHaveBeenCalledWith(nonToolMessage)
     })
   })
 

--- a/src/server/mcp/manager.ts
+++ b/src/server/mcp/manager.ts
@@ -84,6 +84,30 @@ export class McpManager {
       }
 
       if (!transport) throw new Error('Failed to create transport')
+
+      // Intercept onmessage to remove outputSchema from tool definitions.
+      // Some servers (like Stitch) include outputSchema with broken references (e.g. $defs/ScreenInstance),
+      // which causes AJV validation in the MCP SDK to crash and fail to load any tools.
+      let sdkOnMessage: ((message: any) => void) | undefined = undefined
+      Object.defineProperty(transport, 'onmessage', {
+        get() {
+          return sdkOnMessage
+        },
+        set(fn) {
+          sdkOnMessage = (message: any) => {
+            if (message && message.result && Array.isArray(message.result.tools)) {
+              for (const tool of message.result.tools) {
+                if (tool.outputSchema) {
+                  delete tool.outputSchema
+                }
+              }
+            }
+            fn?.(message)
+          }
+        },
+        configurable: true,
+      })
+
       await client.connect(transport)
 
       const { tools: mcpTools } = await client.listTools()

--- a/src/server/mcp/manager.ts
+++ b/src/server/mcp/manager.ts
@@ -88,16 +88,17 @@ export class McpManager {
       // Intercept onmessage to remove outputSchema from tool definitions.
       // Some servers (like Stitch) include outputSchema with broken references (e.g. $defs/ScreenInstance),
       // which causes AJV validation in the MCP SDK to crash and fail to load any tools.
-      let sdkOnMessage: ((message: any) => void) | undefined = undefined
+      let sdkOnMessage: ((message: unknown) => void) | undefined = undefined
       Object.defineProperty(transport, 'onmessage', {
         get() {
           return sdkOnMessage
         },
         set(fn) {
-          sdkOnMessage = (message: any) => {
-            if (message && message.result && Array.isArray(message.result.tools)) {
-              for (const tool of message.result.tools) {
-                if (tool.outputSchema) {
+          sdkOnMessage = (message: unknown) => {
+            const msg = message as { result?: { tools?: Array<{ outputSchema?: unknown }> } }
+            if (msg && msg.result && Array.isArray(msg.result.tools)) {
+              for (const tool of msg.result.tools) {
+                if (tool && tool.outputSchema) {
                   delete tool.outputSchema
                 }
               }


### PR DESCRIPTION
### Summary

This PR fixes a critical issue where MCP servers (most notably the Google Stitch MCP server) fail to register because they include broken `$ref` pointers (such as `#/$defs/ScreenInstance`) inside their `outputSchema` without defining the corresponding `$defs` object. 

Since the `@modelcontextprotocol/sdk` client uses AJV to validate the response schema of the `tools/list` RPC method, these broken references cause the validation to crash and abort the entire connection process, resulting in `0 tools loaded`.

**Solution**:
We intercept incoming RPC messages at the transport level (`onmessage` getter/setter) and strip the `outputSchema` field from the tool objects. This allows the schemas to pass AJV validation successfully. This is completely safe, as neither OpenFox nor the underlying LLMs require `outputSchema` (they only use `inputSchema` to structure tool calls).

### AI-Enhanced Development

Tell what models helped shape this PR:

- **AI Models:** Gemini 3.5 Flash

### Cache Impact

Does this PR affect anything cached — system prompts, tool definitions, skills, or other context?

- **No** 
