### PR TITLE
Feature/mcp timeout

### DIFF
--- a/e2e/mcp.test.ts
+++ b/e2e/mcp.test.ts
@@ -50,7 +50,12 @@ describe('MCP Integration', () => {
   async function fetchMcpServers() {
     const res = await fetch(`${server.url}/api/mcp/servers`)
     const data = (await res.json()) as {
-      servers: Array<{ name: string; status: string; config: { command?: string; transport: string }; tools: Array<{ name: string; enabled: boolean }> }>
+      servers: Array<{
+        name: string
+        status: string
+        config: { command?: string; transport: string; timeout?: number }
+        tools: Array<{ name: string; enabled: boolean }>
+      }>
     }
     return data.servers
   }
@@ -104,9 +109,10 @@ describe('MCP Integration', () => {
     const testServer = servers.find((s) => s.name === 'test-server')
     expect(testServer).toBeDefined()
     expect(testServer!.status).toBe('connected')
-    expect(testServer!.tools).toHaveLength(2)
+    expect(testServer!.tools).toHaveLength(3)
     expect(testServer!.tools.map((t) => t.name)).toContain('greet')
     expect(testServer!.tools.map((t) => t.name)).toContain('add')
+    expect(testServer!.tools.map((t) => t.name)).toContain('slow')
 
     // Cleanup
     await removeMcpServer('test-server')
@@ -209,7 +215,7 @@ describe('MCP Integration', () => {
     const testServer = servers.find((s) => s.name === 'test-server')
     expect(testServer).toBeDefined()
     expect(testServer!.status).toBe('connected')
-    expect(testServer!.tools).toHaveLength(2)
+    expect(testServer!.tools).toHaveLength(3)
   })
 
   it('returns 404 when updating a non-existent MCP server', async () => {
@@ -255,5 +261,47 @@ describe('MCP Integration', () => {
     const servers = await fetchMcpServers()
     const testServer = servers.find((s) => s.name === 'test-server')
     expect(testServer!.status).toBe('connected')
+  })
+
+  it('stores and returns the configured timeout', async () => {
+    const mockServerPath = join(__dirname, 'mock-mcp-server.ts')
+    // Add with timeout via POST body
+    const res = await fetch(`${server.url}/api/mcp/servers`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'timeout-server', command: 'npx', args: ['tsx', mockServerPath], timeout: 30 }),
+    })
+    expect(res.ok).toBe(true)
+    await sleep(1000)
+
+    const servers = await fetchMcpServers()
+    const found = servers.find((s) => s.name === 'timeout-server')
+    expect(found).toBeDefined()
+    expect(found!.config.timeout).toBe(30)
+
+    // Update timeout
+    const updResp = await updateMcpServer('timeout-server', { timeout: 60 })
+    expect(updResp.ok).toBe(true)
+
+    const servers2 = await fetchMcpServers()
+    const found2 = servers2.find((s) => s.name === 'timeout-server')
+    expect(found2!.config.timeout).toBe(60)
+
+    // Cleanup
+    await removeMcpServer('timeout-server')
+  })
+
+  it('rejects timeout of zero', async () => {
+    const mockServerPath = join(__dirname, 'mock-mcp-server.ts')
+    await addMcpServer('zero-timeout', 'npx', ['tsx', mockServerPath])
+    await sleep(500)
+
+    const updResp = await updateMcpServer('zero-timeout', { timeout: 0 })
+    expect(updResp.status).toBe(400)
+    const data = (await updResp.json()) as { error?: string }
+    expect(data.error).toContain('positive')
+
+    // Cleanup
+    await removeMcpServer('zero-timeout')
   })
 })

--- a/e2e/mock-mcp-server.ts
+++ b/e2e/mock-mcp-server.ts
@@ -23,6 +23,15 @@ const tools = [
       required: ['a', 'b'],
     },
   },
+  {
+    name: 'slow',
+    description: 'Responds after a delay (ms)',
+    inputSchema: {
+      type: 'object',
+      properties: { delay: { type: 'number', description: 'Delay in milliseconds' } },
+      required: ['delay'],
+    },
+  },
 ]
 
 let initialized = false
@@ -91,6 +100,18 @@ function handleMessage(raw: string) {
           isError: false,
         },
       })
+    } else if (params.name === 'slow') {
+      const delay = Number(params.arguments?.delay ?? 1000)
+      setTimeout(async () => {
+        sendMessage({
+          jsonrpc: '2.0',
+          id: msg.id,
+          result: {
+            content: [{ type: 'text', text: `Slept for ${delay}ms` }],
+            isError: false,
+          },
+        })
+      }, delay)
     } else {
       sendMessage({
         jsonrpc: '2.0',

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -122,6 +122,7 @@ const mcpServerSchema = z.object({
   headers: z.record(z.string(), z.string()).optional(),
   disabledTools: z.array(z.string()).optional(),
   cachedTools: z.array(cachedToolSchema).optional(),
+  timeout: z.number().optional(),
 })
 
 const llmConfigSchema = z.object({

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -122,7 +122,7 @@ const mcpServerSchema = z.object({
   headers: z.record(z.string(), z.string()).optional(),
   disabledTools: z.array(z.string()).optional(),
   cachedTools: z.array(cachedToolSchema).optional(),
-  timeout: z.number().optional(),
+  timeout: z.number().positive().optional(),
 })
 
 const llmConfigSchema = z.object({

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1897,7 +1897,7 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
   })
 
   app.post('/api/mcp/servers/test', async (req, res) => {
-    const { name, transport, command, args, env, url, headers } = req.body as {
+    const { name, transport, command, args, env, url, headers, timeout } = req.body as {
       name?: string
       transport?: string
       command?: string
@@ -1905,6 +1905,7 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
       env?: Record<string, string>
       url?: string
       headers?: Record<string, string>
+      timeout?: number
     }
     if (transport !== undefined && transport !== 'stdio' && transport !== 'http') {
       return res.status(400).json({ error: `Invalid transport '${transport}'. Must be 'stdio' or 'http'.` })
@@ -1914,6 +1915,9 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
     }
     if (transport === 'http' && !url) {
       return res.status(400).json({ error: 'url is required for http transport' })
+    }
+    if (timeout !== undefined && (typeof timeout !== 'number' || timeout < 0)) {
+      return res.status(400).json({ error: 'timeout must be a non-negative number' })
     }
     try {
       const testManager = new McpManager()
@@ -1925,6 +1929,7 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
         ...(env && Object.keys(env).length > 0 ? { env } : {}),
         ...(url ? { url } : {}),
         ...(headers && Object.keys(headers).length > 0 ? { headers } : {}),
+        ...(timeout !== undefined ? { timeout } : {}),
       }
       await testManager.addServer(name ?? 'test', testConfig)
       const server = testManager.getServer(name ?? 'test')
@@ -1940,7 +1945,7 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
   })
 
   app.post('/api/mcp/servers', async (req, res) => {
-    const { name, transport, command, args, env, url, headers } = req.body as {
+    const { name, transport, command, args, env, url, headers, timeout } = req.body as {
       name?: string
       transport?: string
       command?: string
@@ -1948,12 +1953,16 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
       env?: Record<string, string>
       url?: string
       headers?: Record<string, string>
+      timeout?: number
     }
     if (!name) {
       return res.status(400).json({ error: 'name is required' })
     }
     if (transport !== undefined && transport !== 'stdio' && transport !== 'http') {
       return res.status(400).json({ error: `Invalid transport '${transport}'. Must be 'stdio' or 'http'.` })
+    }
+    if (timeout !== undefined && (typeof timeout !== 'number' || timeout < 0)) {
+      return res.status(400).json({ error: 'timeout must be a non-negative number' })
     }
     try {
       const resolvedTransport: 'stdio' | 'http' = transport === 'http' ? 'http' : 'stdio'
@@ -1964,6 +1973,7 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
         ...(env && Object.keys(env).length > 0 ? { env } : {}),
         ...(url ? { url } : {}),
         ...(headers && Object.keys(headers).length > 0 ? { headers } : {}),
+        ...(timeout !== undefined ? { timeout } : {}),
       }
       await mcpManager.addServer(name, serverCfg)
       const server = mcpManager.getServer(name)
@@ -2005,7 +2015,7 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
     }
 
     const body = req.body as Record<string, unknown>
-    const { transport: rawTransport, command, args, env, url, headers } = body
+    const { transport: rawTransport, command, args, env, url, headers, timeout } = body
 
     if (rawTransport !== undefined && rawTransport !== 'stdio' && rawTransport !== 'http') {
       return res.status(400).json({ error: `Invalid transport '${String(rawTransport)}'. Must be 'stdio' or 'http'.` })
@@ -2037,6 +2047,9 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
     ) {
       return res.status(400).json({ error: 'headers must be a string/string object' })
     }
+    if (timeout !== undefined && (typeof timeout !== 'number' || timeout < 0)) {
+      return res.status(400).json({ error: 'timeout must be a non-negative number' })
+    }
 
     try {
       const { loadGlobalConfig, saveGlobalConfig } = await import('../cli/config.js')
@@ -2055,6 +2068,7 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
         ...(env !== undefined ? { env: env as Record<string, string> } : {}),
         ...(url !== undefined ? { url: url as string } : {}),
         ...(headers !== undefined ? { headers: headers as Record<string, string> } : {}),
+        ...(timeout !== undefined ? { timeout: timeout as number } : {}),
       }
 
       const { error: updateError } = await applyMcpServerUpdate({

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1916,8 +1916,8 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
     if (transport === 'http' && !url) {
       return res.status(400).json({ error: 'url is required for http transport' })
     }
-    if (timeout !== undefined && (typeof timeout !== 'number' || timeout < 0)) {
-      return res.status(400).json({ error: 'timeout must be a non-negative number' })
+    if (timeout !== undefined && (typeof timeout !== 'number' || timeout <= 0)) {
+      return res.status(400).json({ error: 'timeout must be a positive number' })
     }
     try {
       const testManager = new McpManager()
@@ -1961,8 +1961,8 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
     if (transport !== undefined && transport !== 'stdio' && transport !== 'http') {
       return res.status(400).json({ error: `Invalid transport '${transport}'. Must be 'stdio' or 'http'.` })
     }
-    if (timeout !== undefined && (typeof timeout !== 'number' || timeout < 0)) {
-      return res.status(400).json({ error: 'timeout must be a non-negative number' })
+    if (timeout !== undefined && (typeof timeout !== 'number' || timeout <= 0)) {
+      return res.status(400).json({ error: 'timeout must be a positive number' })
     }
     try {
       const resolvedTransport: 'stdio' | 'http' = transport === 'http' ? 'http' : 'stdio'
@@ -2047,8 +2047,8 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
     ) {
       return res.status(400).json({ error: 'headers must be a string/string object' })
     }
-    if (timeout !== undefined && (typeof timeout !== 'number' || timeout < 0)) {
-      return res.status(400).json({ error: 'timeout must be a non-negative number' })
+    if (timeout !== undefined && (typeof timeout !== 'number' || timeout <= 0)) {
+      return res.status(400).json({ error: 'timeout must be a positive number' })
     }
 
     try {

--- a/src/server/mcp/manager.test.ts
+++ b/src/server/mcp/manager.test.ts
@@ -228,6 +228,27 @@ describe('McpManager', () => {
       expect(result.success).toBe(false)
       expect(result.error).toContain('not found')
     })
+
+    it('should time out if the tool call takes longer than the configured timeout', async () => {
+      mockClientInstance.callTool.mockImplementation(
+        () =>
+          new Promise((resolve) =>
+            setTimeout(() => resolve({ content: [{ type: 'text', text: 'Late weather' }], isError: false }), 100),
+          ),
+      )
+      try {
+        await manager.addServer('timeout-server', { transport: 'stdio', command: 'node', timeout: 0.02 }) // 20ms timeout
+
+        const result = await manager.callTool('timeout-server', 'get_weather', {})
+        expect(result.success).toBe(false)
+        expect(result.error).toContain('timed out')
+      } finally {
+        mockClientInstance.callTool.mockImplementation(async () => ({
+          content: [{ type: 'text', text: 'Sunny, 72°F' }],
+          isError: false,
+        }))
+      }
+    })
   })
 
   describe('setToolEnabled', () => {

--- a/src/server/mcp/manager.ts
+++ b/src/server/mcp/manager.ts
@@ -225,7 +225,27 @@ export class McpManager {
 
     if (!entry.client) return { success: false, error: `MCP server '${serverName}' is not connected` }
     try {
-      const result = await entry.client.callTool({ name: toolName, arguments: args })
+      const timeout = entry.config.timeout
+      const requestOptions = timeout !== undefined && timeout > 0 ? { timeout: timeout * 1000 } : undefined
+      let result
+      if (timeout !== undefined && timeout > 0) {
+        let timer: NodeJS.Timeout | undefined
+        const timeoutPromise = new Promise<never>((_, reject) => {
+          timer = setTimeout(() => {
+            reject(new Error(`MCP tool call timed out after ${timeout} seconds`))
+          }, timeout * 1000)
+        })
+        try {
+          result = await Promise.race([
+            entry.client.callTool({ name: toolName, arguments: args }, undefined, requestOptions),
+            timeoutPromise,
+          ])
+        } finally {
+          if (timer) clearTimeout(timer)
+        }
+      } else {
+        result = await entry.client.callTool({ name: toolName, arguments: args })
+      }
       const content = result.content as Array<{ type: string; text?: string }>
       const textParts = content.filter((c) => c.type === 'text').map((c) => c.text)
       return { success: !result.isError, output: textParts.join('\n') }

--- a/src/server/mcp/types.ts
+++ b/src/server/mcp/types.ts
@@ -16,6 +16,7 @@ export interface McpServerConfig {
   headers?: Record<string, string>
   disabledTools?: string[]
   cachedTools?: CachedToolInfo[]
+  timeout?: number
 }
 
 export interface McpServerState {

--- a/src/server/mcp/update-server.ts
+++ b/src/server/mcp/update-server.ts
@@ -8,6 +8,7 @@ export interface McpServerPatch {
   env?: Record<string, string>
   url?: string
   headers?: Record<string, string>
+  timeout?: number
 }
 
 export interface ApplyMcpServerUpdateOptions {
@@ -35,6 +36,7 @@ export function buildUpdatedServerConfig(
   const mergedUrl = patch.url !== undefined ? patch.url : transportChanged ? undefined : existing.config.url
   const mergedHeaders =
     patch.headers !== undefined ? patch.headers : transportChanged ? undefined : existing.config.headers
+  const mergedTimeout = patch.timeout !== undefined ? patch.timeout : existing.config.timeout
 
   if (resolvedTransport === 'http' && !mergedUrl) {
     return { serverCfg: {} as McpServerConfig, error: 'url is required for http transport' }
@@ -50,6 +52,7 @@ export function buildUpdatedServerConfig(
     ...(mergedEnv && Object.keys(mergedEnv).length > 0 ? { env: mergedEnv } : {}),
     ...(mergedUrl ? { url: mergedUrl } : {}),
     ...(mergedHeaders && Object.keys(mergedHeaders).length > 0 ? { headers: mergedHeaders } : {}),
+    ...(mergedTimeout !== undefined ? { timeout: mergedTimeout } : {}),
     ...(persistedCfg?.disabledTools && persistedCfg.disabledTools.length > 0
       ? { disabledTools: persistedCfg.disabledTools }
       : {}),

--- a/src/server/mcp/update-server.ts
+++ b/src/server/mcp/update-server.ts
@@ -38,6 +38,10 @@ export function buildUpdatedServerConfig(
     patch.headers !== undefined ? patch.headers : transportChanged ? undefined : existing.config.headers
   const mergedTimeout = patch.timeout !== undefined ? patch.timeout : existing.config.timeout
 
+  if (patch.timeout !== undefined && (typeof patch.timeout !== 'number' || patch.timeout <= 0)) {
+    return { serverCfg: {} as McpServerConfig, error: 'timeout must be a positive number' }
+  }
+
   if (resolvedTransport === 'http' && !mergedUrl) {
     return { serverCfg: {} as McpServerConfig, error: 'url is required for http transport' }
   }

--- a/src/server/tools/mcp-config.ts
+++ b/src/server/tools/mcp-config.ts
@@ -18,6 +18,7 @@ interface McpConfigArgs {
   headers?: Record<string, string>
   toolName?: string
   enabled?: boolean
+  timeout?: number
 }
 
 let mcpManagerForTools: McpManager | null = null
@@ -102,6 +103,10 @@ export const mcpConfigTool: Tool = createTool<McpConfigArgs>(
           enabled: {
             type: 'boolean',
             description: 'Whether the tool should be enabled (required for: toggle-tool)',
+          },
+          timeout: {
+            type: 'number',
+            description: 'Timeout in seconds for MCP tool calls (optional)',
           },
         },
         required: ['action'],
@@ -191,6 +196,7 @@ export const mcpConfigTool: Tool = createTool<McpConfigArgs>(
         ...(args.env && Object.keys(args.env).length > 0 ? { env: args.env } : {}),
         ...(args.url ? { url: args.url } : {}),
         ...(args.headers && Object.keys(args.headers).length > 0 ? { headers: args.headers } : {}),
+        ...(args.timeout !== undefined ? { timeout: args.timeout } : {}),
       }
 
       await persistAndRebuild((mcpServers) => {
@@ -221,6 +227,7 @@ export const mcpConfigTool: Tool = createTool<McpConfigArgs>(
         ...(args.env !== undefined ? { env: args.env } : {}),
         ...(args.url !== undefined ? { url: args.url } : {}),
         ...(args.headers !== undefined ? { headers: args.headers } : {}),
+        ...(args.timeout !== undefined ? { timeout: args.timeout } : {}),
       }
 
       const { error: updateError } = await applyMcpServerUpdate({

--- a/src/server/tools/mcp-config.ts
+++ b/src/server/tools/mcp-config.ts
@@ -188,6 +188,9 @@ export const mcpConfigTool: Tool = createTool<McpConfigArgs>(
       } else if (!args.command) {
         return helpers.error('command is required for stdio transport')
       }
+      if (args.timeout !== undefined && (typeof args.timeout !== 'number' || args.timeout <= 0)) {
+        return helpers.error('timeout must be a positive number')
+      }
 
       const serverCfg: McpServerConfig = {
         transport: args.transport ?? 'stdio',

--- a/web/src/components/settings/tabs/ToolsTab.tsx
+++ b/web/src/components/settings/tabs/ToolsTab.tsx
@@ -32,6 +32,7 @@ interface McpFormData {
   env: string
   url: string
   headers: string
+  timeout: string
 }
 
 interface McpServerFormFieldsProps {
@@ -117,6 +118,12 @@ function McpServerFormFields({ formData, onChange }: McpServerFormFieldsProps) {
           </div>
         </>
       )}
+      <FormField
+        label="Timeout (seconds)"
+        value={formData.timeout}
+        onChange={(v) => onChange({ ...formData, timeout: v })}
+        placeholder="optional, e.g. 30"
+      />
     </>
   )
 }
@@ -138,6 +145,7 @@ interface McpServerState {
     env?: Record<string, string>
     url?: string
     headers?: Record<string, string>
+    timeout?: number
   }
   status: 'connected' | 'disconnected' | 'error'
   tools: McpToolInfo[]
@@ -333,6 +341,7 @@ export function ToolsTab() {
     env: '',
     url: '',
     headers: '',
+    timeout: '',
   })
   const [formError, setFormError] = useState('')
   const [mcpError, setMcpError] = useState('')
@@ -372,6 +381,12 @@ export function ToolsTab() {
   function validateTransportFields(): string | null {
     if (formData.transport === 'stdio' && !formData.command) return 'Command is required for stdio transport'
     if (formData.transport === 'http' && !formData.url) return 'URL is required for HTTP transport'
+    if (formData.timeout) {
+      const parsed = parseInt(formData.timeout, 10)
+      if (isNaN(parsed) || parsed < 0) {
+        return 'Timeout must be a non-negative number'
+      }
+    }
     return null
   }
 
@@ -387,6 +402,12 @@ export function ToolsTab() {
       body.url = formData.url
       body.headers = parseKeyValueLines(formData.headers)
     }
+    if (formData.timeout) {
+      const parsed = parseInt(formData.timeout, 10)
+      if (!isNaN(parsed)) {
+        body.timeout = parsed
+      }
+    }
     return body
   }
 
@@ -398,6 +419,7 @@ export function ToolsTab() {
     env: '',
     url: '',
     headers: '',
+    timeout: '',
   }
 
   const handleAdd = async () => {
@@ -450,6 +472,7 @@ export function ToolsTab() {
             .map(([k, v]) => `${k}=${v}`)
             .join('\n')
         : '',
+      timeout: server.config.timeout !== undefined ? String(server.config.timeout) : '',
     })
     setFormError('')
     setEditingServer(server.name)

--- a/web/src/components/settings/tabs/ToolsTab.tsx
+++ b/web/src/components/settings/tabs/ToolsTab.tsx
@@ -382,9 +382,9 @@ export function ToolsTab() {
     if (formData.transport === 'stdio' && !formData.command) return 'Command is required for stdio transport'
     if (formData.transport === 'http' && !formData.url) return 'URL is required for HTTP transport'
     if (formData.timeout) {
-      const parsed = parseInt(formData.timeout, 10)
-      if (isNaN(parsed) || parsed < 0) {
-        return 'Timeout must be a non-negative number'
+      const parsed = parseFloat(formData.timeout)
+      if (isNaN(parsed) || parsed <= 0) {
+        return 'Timeout must be a positive number'
       }
     }
     return null
@@ -403,8 +403,8 @@ export function ToolsTab() {
       body.headers = parseKeyValueLines(formData.headers)
     }
     if (formData.timeout) {
-      const parsed = parseInt(formData.timeout, 10)
-      if (!isNaN(parsed)) {
+      const parsed = parseFloat(formData.timeout)
+      if (!isNaN(parsed) && parsed > 0) {
         body.timeout = parsed
       }
     }
@@ -832,6 +832,9 @@ export function ToolsTab() {
                     </div>
                   )}
                   {server.config.url && <div className="text-xs text-text-muted font-mono">{server.config.url}</div>}
+                  {server.config.timeout !== undefined && (
+                    <div className="text-xs text-text-muted">Timeout: {server.config.timeout}s</div>
+                  )}
                   {server.tools.length === 0 ? (
                     <div className="text-xs text-text-muted">No tools available</div>
                   ) : (


### PR DESCRIPTION
### Summary

This PR adds the capability to define and enforce a custom request timeout (in seconds) for individual Model Context Protocol (MCP) servers. 

**Why:**
This feature is specifically needed to allow larger timeouts (e.g. 600 seconds / 10 minutes) for heavy-duty MCP integrations like Google Stitch (for example, when running long-running operations like `generate_screen_from_text` which easily exceed the default 60s SDK request timeout).

Key changes include:
- **Backend & Configuration**: Added `timeout` field to `McpServerConfig` interface, `mcpServerSchema` (Zod validation), `McpServerPatch` schema, and REST API handlers (`POST /api/mcp/servers/test`, `POST /api/mcp/servers`, and `PUT /api/mcp/servers/:name`).
- **Execution & Timeout Handling**: Updated `callTool` inside `McpManager` to wrap the MCP tool call request using both a promise-based race timeout and passing the `timeout` option directly to the MCP SDK's `client.callTool(..., ..., { timeout })` to prevent the SDK's default 60s timeout from triggering early.
- **Frontend UI**: Integrated a new "Timeout (seconds)" input field into the settings panel forms (`ToolsTab.tsx`) when adding or editing MCP servers.
- **Tests**: Created a unit test to verify that tool executions correctly timeout and reject when exceeding the configured limit.

### AI-Enhanced Development

Tell what models helped shape this PR:

- **AI Models:** Gemini 3.5 Flash

### Cache Impact

Does this PR affect anything cached — system prompts, tool definitions, skills, or other context?

- **Yes**
  - Tool definitions and system prompts are affected since MCP configuration schemas and tool parameter configurations now include the new `timeout` parameter. Changing MCP server configuration triggers a reload and updates the registered system tools.
