### PR TITLE
feat: full-screen modal for session metadata entries

### DIFF
--- a/web/src/components/plan/SessionSidebar.tsx
+++ b/web/src/components/plan/SessionSidebar.tsx
@@ -11,6 +11,7 @@ import { formatTime, formatSpeed } from '../../lib/format-stats'
 import { formatMetadataKeyLabel } from '../../lib/metadata-keys'
 import { StatsModal } from './StatsModal'
 import { MetadataEntries, MetadataSectionHeader } from '../shared/MetadataEntries'
+import { MetadataModal } from '../shared/MetadataModal'
 import { CriteriaEditor } from './CriteriaEditor'
 import { DevServerFooter } from './DevServerFooter'
 import { BackgroundProcesses } from './BackgroundProcesses'
@@ -31,6 +32,7 @@ export function SessionSidebar({ messages, workdir }: SessionSidebarProps) {
   const [showUpdateModal, setShowUpdateModal] = useState(false)
   const [showBranchModal, setShowBranchModal] = useState(false)
   const [showWorkspaceModal, setShowWorkspaceModal] = useState(false)
+  const [activeMetadataKey, setActiveMetadataKey] = useState<string | null>(null)
 
   const stats = useSessionStats(messages)
   const { branch } = useGitStatus()
@@ -75,7 +77,12 @@ export function SessionSidebar({ messages, workdir }: SessionSidebarProps) {
       {/* Metadata sections */}
       <div className="flex flex-col flex-1 overflow-y-auto">
         <div className="mt-4">
-          <MetadataSectionHeader entries={session?.metadataEntries?.['criteria'] ?? []} title="Acceptance Criteria" />
+          <button
+            onClick={() => setActiveMetadataKey('criteria')}
+            className="w-full text-left cursor-pointer hover:bg-bg-tertiary rounded px-1 -mx-1 transition-colors"
+          >
+            <MetadataSectionHeader entries={session?.metadataEntries?.['criteria'] ?? []} title="Acceptance Criteria" />
+          </button>
           {session && <CriteriaEditor entries={session?.metadataEntries?.['criteria'] ?? []} sessionId={session.id} />}
           {session &&
             (() => {
@@ -89,7 +96,12 @@ export function SessionSidebar({ messages, workdir }: SessionSidebarProps) {
                 .filter((key) => (all[key]?.length ?? 0) > 0)
                 .map((key) => (
                   <div key={key} className="mt-6">
-                    <MetadataSectionHeader entries={all[key]!} title={formatMetadataKeyLabel(key)} />
+                    <button
+                      onClick={() => setActiveMetadataKey(key)}
+                      className="w-full text-left cursor-pointer hover:bg-bg-tertiary rounded px-1 -mx-1 transition-colors"
+                    >
+                      <MetadataSectionHeader entries={all[key]!} title={formatMetadataKeyLabel(key)} />
+                    </button>
                     <MetadataEntries
                       entries={all[key]!}
                       onClearAll={async () => {
@@ -196,6 +208,15 @@ export function SessionSidebar({ messages, workdir }: SessionSidebarProps) {
       )}
 
       <AutoUpdateModal isOpen={showUpdateModal} onClose={() => setShowUpdateModal(false)} versionInfo={null} />
+
+      <MetadataModal
+        isOpen={activeMetadataKey !== null}
+        onClose={() => setActiveMetadataKey(null)}
+        entries={session?.metadataEntries?.[activeMetadataKey ?? ''] ?? []}
+        sessionId={session?.id ?? ''}
+        metadataKey={activeMetadataKey ?? ''}
+        title={formatMetadataKeyLabel(activeMetadataKey ?? '')}
+      />
 
       {session && (
         <>

--- a/web/src/components/shared/MetadataModal.test.tsx
+++ b/web/src/components/shared/MetadataModal.test.tsx
@@ -1,0 +1,320 @@
+// @vitest-environment happy-dom
+import '@testing-library/jest-dom/vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { MetadataModal } from './MetadataModal'
+import { authFetch } from '../../lib/api'
+
+vi.mock('../../lib/api', () => ({
+  authFetch: vi.fn(() => Promise.resolve(new Response(null, { status: 200 }))),
+}))
+
+vi.mock('../../stores/agents', () => ({
+  useAgentsStore: vi.fn(
+    (selector: (state: { defaults: unknown[]; userItems: unknown[]; projectItems: unknown[] }) => unknown) =>
+      selector({ defaults: [], userItems: [], projectItems: [] }),
+  ),
+  getAgentColor: vi.fn(() => '#000000'),
+}))
+
+vi.mock('../../stores/workflows', () => ({
+  useWorkflowsStore: vi.fn((selector: (state: { defaults: unknown[]; userItems: unknown[] }) => unknown) =>
+    selector({ defaults: [], userItems: [] }),
+  ),
+}))
+
+const mockedAuthFetch = vi.mocked(authFetch)
+
+function renderModal(
+  overrides: Partial<{
+    entries: { id: string; description: string; status: string }[]
+    sessionId: string
+    metadataKey: string
+    title: string
+    isOpen: boolean
+    onClose: () => void
+  }> = {},
+) {
+  const defaultProps = {
+    entries: [
+      { id: '0', description: 'First item', status: 'open' },
+      { id: '1', description: 'Second item', status: 'resolved' },
+    ],
+    sessionId: 'session-1',
+    metadataKey: 'review_findings',
+    title: 'Review Findings',
+    isOpen: true,
+    onClose: vi.fn(),
+    ...overrides,
+  }
+  return render(<MetadataModal {...defaultProps} />)
+}
+
+describe('MetadataModal', () => {
+  afterEach(() => {
+    cleanup()
+    mockedAuthFetch.mockClear()
+  })
+
+  // ── Criterion 0: Click to open ──────────────────────────────────────
+  describe('Criterion 0 — Click to open', () => {
+    it('renders nothing when isOpen is false', () => {
+      render(
+        <MetadataModal
+          isOpen={false}
+          onClose={vi.fn()}
+          entries={[]}
+          sessionId="s1"
+          metadataKey="todos"
+          title="Tasks"
+        />,
+      )
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    })
+
+    it('renders the modal when isOpen is true', () => {
+      renderModal()
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+    })
+  })
+
+  // ── Criterion 1: Full-screen modal ──────────────────────────────────
+  describe('Criterion 1 — Full-screen modal', () => {
+    it('uses size="full" class for 95vw × 90vh', () => {
+      renderModal()
+      const dialog = screen.getByRole('dialog')
+      expect(dialog.className).toContain('max-w-[95vw]')
+      expect(dialog.className).toContain('h-[90vh]')
+    })
+
+    it('has scrollable content area', () => {
+      renderModal()
+      const scrollContainer = screen.getByRole('dialog').querySelector('.overflow-y-auto')
+      expect(scrollContainer).toBeInTheDocument()
+    })
+  })
+
+  // ── Criterion 2: Full display without truncation ────────────────────
+  describe('Criterion 2 — Full display without truncation', () => {
+    it('does not apply truncate class to entry descriptions', () => {
+      renderModal()
+      const entryElements = screen.getAllByText(/First item|Second item/)
+      entryElements.forEach((el) => {
+        expect(el.className).not.toContain('truncate')
+      })
+    })
+
+    it('shows full description text without cutting it off', () => {
+      const longText = 'A very long description that should not be truncated in the modal view ' + 'x'.repeat(200)
+      renderModal({ entries: [{ id: '0', description: longText, status: 'open' }] })
+      expect(screen.getByText(longText)).toBeInTheDocument()
+    })
+  })
+
+  // ── Criterion 3: Status cycling ─────────────────────────────────────
+  describe('Criterion 3 — Status cycling', () => {
+    it('cycles review_findings statuses: open → resolved → dismissed → open', () => {
+      renderModal({ metadataKey: 'review_findings' })
+      const statusIcon = screen.getAllByTitle(/click to cycle/i)[0]!
+      fireEvent.click(statusIcon)
+      expect(mockedAuthFetch).toHaveBeenCalledTimes(1)
+      const firstCallArgs = JSON.parse(mockedAuthFetch.mock.calls[0]![1]!.body as string)
+      expect(firstCallArgs.entries[0].status).toBe('resolved')
+
+      fireEvent.click(statusIcon)
+      expect(mockedAuthFetch).toHaveBeenCalledTimes(2)
+      const secondCallArgs = JSON.parse(mockedAuthFetch.mock.calls[1]![1]!.body as string)
+      expect(secondCallArgs.entries[0].status).toBe('dismissed')
+    })
+
+    it('cycles todos statuses: pending → in_progress → completed → pending', () => {
+      renderModal({
+        metadataKey: 'todos',
+        entries: [{ id: '0', description: 'Task 1', status: 'pending' }],
+      })
+      const statusIcon = screen.getAllByTitle(/click to cycle/i)[0]!
+      fireEvent.click(statusIcon)
+      const callArgs = JSON.parse(mockedAuthFetch.mock.calls[0]![1]!.body as string)
+      expect(callArgs.entries[0].status).toBe('in_progress')
+    })
+
+    it('cycles unknown key statuses generically', () => {
+      renderModal({
+        metadataKey: 'custom_section',
+        entries: [{ id: '0', description: 'Custom', status: 'pending' }],
+      })
+      const statusIcon = screen.getAllByTitle(/click to cycle/i)[0]!
+      fireEvent.click(statusIcon)
+      expect(mockedAuthFetch).toHaveBeenCalled()
+    })
+  })
+
+  // ── Criterion 4: Inline editing ─────────────────────────────────────
+  describe('Criterion 4 — Inline description editing', () => {
+    it('shows an input when clicking on an entry description', () => {
+      renderModal()
+      fireEvent.click(screen.getByText('First item'))
+      expect(screen.getByDisplayValue('First item')).toBeInTheDocument()
+    })
+
+    it('saves the edited description on Enter and syncs to server', () => {
+      renderModal()
+      fireEvent.click(screen.getByText('First item'))
+      const input = screen.getByDisplayValue('First item')
+      fireEvent.change(input, { target: { value: 'Updated description' } })
+      fireEvent.keyDown(input, { key: 'Enter' })
+      expect(mockedAuthFetch).toHaveBeenCalledWith(
+        '/api/sessions/session-1/metadata/review_findings',
+        expect.objectContaining({ method: 'PUT' }),
+      )
+      const callArgs = JSON.parse(mockedAuthFetch.mock.calls[0]![1]!.body as string)
+      expect(callArgs.entries[0].description).toBe('Updated description')
+    })
+  })
+
+  // ── Criterion 5: Add entry ──────────────────────────────────────────
+  describe('Criterion 5 — Add entry', () => {
+    it('renders an input field at the bottom to add a new entry', () => {
+      renderModal()
+      expect(screen.getByPlaceholderText(/new/i)).toBeInTheDocument()
+    })
+
+    it('adds a new entry when submitting the add input and syncs to server', () => {
+      renderModal({ entries: [] })
+      const addInput = screen.getByPlaceholderText(/new/i)
+      fireEvent.change(addInput, { target: { value: 'Newly added entry' } })
+      fireEvent.keyDown(addInput, { key: 'Enter' })
+      expect(mockedAuthFetch).toHaveBeenCalledWith(
+        '/api/sessions/session-1/metadata/review_findings',
+        expect.objectContaining({ method: 'PUT' }),
+      )
+    })
+  })
+
+  // ── Criterion 6: Delete entry ───────────────────────────────────────
+  describe('Criterion 6 — Delete entry', () => {
+    it('renders an X button on each entry line', () => {
+      renderModal()
+      const deleteButtons = screen.getAllByTitle(/delete/i)
+      expect(deleteButtons.length).toBeGreaterThanOrEqual(2)
+    })
+
+    it('removes entry and syncs to server when clicking X', () => {
+      renderModal({ entries: [{ id: '0', description: 'To delete', status: 'open' }] })
+      const deleteBtn = screen.getByTitle(/delete/i)
+      fireEvent.click(deleteBtn)
+      expect(mockedAuthFetch).toHaveBeenCalledWith(
+        '/api/sessions/session-1/metadata/review_findings',
+        expect.objectContaining({ method: 'PUT' }),
+      )
+      const callArgs = JSON.parse(mockedAuthFetch.mock.calls[0]![1]!.body as string)
+      expect(callArgs.entries.find((e: { id: string }) => e.id === '0')).toBeUndefined()
+    })
+  })
+
+  // ── Criterion 7: Immediate save ─────────────────────────────────────
+  describe('Criterion 7 — Immediate save via PUT', () => {
+    it('calls PUT /api/sessions/:id/metadata/:key on status cycle', () => {
+      renderModal()
+      fireEvent.click(screen.getAllByTitle(/click to cycle/i)[0]!)
+      expect(mockedAuthFetch).toHaveBeenCalledWith(
+        '/api/sessions/session-1/metadata/review_findings',
+        expect.objectContaining({ method: 'PUT' }),
+      )
+    })
+
+    it('calls PUT /api/sessions/:id/metadata/:key on edit save', () => {
+      renderModal()
+      fireEvent.click(screen.getByText('First item'))
+      fireEvent.keyDown(screen.getByDisplayValue('First item'), { key: 'Enter' })
+      expect(mockedAuthFetch).toHaveBeenCalledWith(
+        '/api/sessions/session-1/metadata/review_findings',
+        expect.objectContaining({ method: 'PUT' }),
+      )
+    })
+
+    it('calls PUT /api/sessions/:id/metadata/:key on add', () => {
+      renderModal({ entries: [] })
+      const input = screen.getByPlaceholderText(/new/i)
+      fireEvent.change(input, { target: { value: 'New' } })
+      fireEvent.keyDown(input, { key: 'Enter' })
+      expect(mockedAuthFetch).toHaveBeenCalledWith(
+        '/api/sessions/session-1/metadata/review_findings',
+        expect.objectContaining({ method: 'PUT' }),
+      )
+    })
+
+    it('calls PUT /api/sessions/:id/metadata/:key on delete', () => {
+      renderModal()
+      const deleteBtns = screen.getAllByTitle(/delete/i)
+      fireEvent.click(deleteBtns[0]!)
+      expect(mockedAuthFetch).toHaveBeenCalledWith(
+        '/api/sessions/session-1/metadata/review_findings',
+        expect.objectContaining({ method: 'PUT' }),
+      )
+    })
+  })
+
+  // ── Criterion 8: All types ──────────────────────────────────────────
+  describe('Criterion 8 — All metadata types', () => {
+    it('renders for criteria type', () => {
+      renderModal({
+        metadataKey: 'criteria',
+        title: 'Acceptance Criteria',
+        entries: [{ id: '0', description: 'Criterion 1', status: 'pending' }],
+      })
+      expect(screen.getByText('Criterion 1')).toBeInTheDocument()
+    })
+
+    it('renders for review_findings type', () => {
+      renderModal({ metadataKey: 'review_findings', title: 'Review Findings' })
+      expect(screen.getByText('First item')).toBeInTheDocument()
+    })
+
+    it('renders for todos type', () => {
+      renderModal({
+        metadataKey: 'todos',
+        title: 'Tasks',
+        entries: [{ id: '0', description: 'Task 1', status: 'pending' }],
+      })
+      expect(screen.getByText('Task 1')).toBeInTheDocument()
+    })
+
+    it('renders for unknown metadata keys', () => {
+      renderModal({
+        metadataKey: 'notes',
+        title: 'Notes',
+        entries: [{ id: '0', description: 'Note 1', status: 'active' }],
+      })
+      expect(screen.getByText('Note 1')).toBeInTheDocument()
+    })
+  })
+
+  // ── Criterion 9: No server modification — reuses existing API ───────
+  describe('Criterion 9 — Reuses existing API', () => {
+    it('uses the same PUT /api/sessions/:id/metadata/:key endpoint as CriteriaEditor', () => {
+      renderModal()
+      fireEvent.click(screen.getAllByTitle(/click to cycle/i)[0]!)
+      expect(mockedAuthFetch).toHaveBeenCalledWith(
+        expect.stringMatching(/^\/api\/sessions\/[^/]+\/metadata\/[^/]+$/),
+        expect.objectContaining({
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+    })
+
+    it('sends entries array in the body matching MetadataEntry shape', () => {
+      renderModal()
+      fireEvent.click(screen.getAllByTitle(/click to cycle/i)[0]!)
+      const callArgs = JSON.parse(mockedAuthFetch.mock.calls[0]![1]!.body as string)
+      expect(callArgs).toHaveProperty('entries')
+      expect(Array.isArray(callArgs.entries)).toBe(true)
+      callArgs.entries.forEach((entry: Record<string, unknown>) => {
+        expect(entry).toHaveProperty('id')
+        expect(entry).toHaveProperty('description')
+        expect(entry).toHaveProperty('status')
+      })
+    })
+  })
+})

--- a/web/src/components/shared/MetadataModal.tsx
+++ b/web/src/components/shared/MetadataModal.tsx
@@ -1,0 +1,234 @@
+import { useState, useCallback, useRef, useEffect } from 'react'
+import type { MetadataEntry } from '@shared/types.js'
+import { authFetch } from '../../lib/api'
+import { Modal } from './Modal'
+import { MetadataStatusIcon, decodeHtmlEntities } from './MetadataStatusIcon'
+import { PlusIcon, XCloseIcon } from './icons'
+
+const STATUS_CYCLES: Record<string, string[]> = {
+  criteria: ['pending', 'completed', 'passed', 'failed'],
+  todos: ['pending', 'in_progress', 'completed'],
+  review_findings: ['open', 'resolved', 'dismissed'],
+}
+
+const GENERIC_CYCLE = ['pending', 'completed', 'failed', 'dismissed']
+
+function getStatusCycle(key: string): string[] {
+  return STATUS_CYCLES[key] ?? GENERIC_CYCLE
+}
+
+function cycleStatus(current: string, cycle: string[]): string {
+  const idx = cycle.indexOf(current)
+  if (idx === -1) return cycle[0] ?? 'pending'
+  const next = cycle[(idx + 1) % cycle.length]
+  return next ?? 'pending'
+}
+
+interface MetadataModalProps {
+  entries: MetadataEntry[]
+  sessionId: string
+  metadataKey: string
+  title: string
+  isOpen: boolean
+  onClose: () => void
+}
+
+export function MetadataModal({
+  entries: initialEntries,
+  sessionId,
+  metadataKey,
+  title,
+  isOpen,
+  onClose,
+}: MetadataModalProps) {
+  const [entries, setEntries] = useState<MetadataEntry[]>(initialEntries)
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [editDescription, setEditDescription] = useState('')
+  const [adding, setAdding] = useState(false)
+  const [newDescription, setNewDescription] = useState('')
+  const addInputRef = useRef<HTMLInputElement>(null)
+  const editInputRef = useRef<HTMLTextAreaElement>(null)
+
+  const autoResize = useCallback(() => {
+    const el = editInputRef.current
+    if (el) {
+      el.style.height = 'auto'
+      el.style.height = el.scrollHeight + 'px'
+    }
+  }, [])
+
+  useEffect(() => {
+    setEntries(initialEntries)
+  }, [initialEntries])
+
+  useEffect(() => {
+    if (editingId) {
+      autoResize()
+      editInputRef.current?.focus()
+    }
+  }, [editingId, autoResize])
+
+  useEffect(() => {
+    if (adding) addInputRef.current?.focus()
+  }, [adding])
+
+  const syncToServer = useCallback(
+    (next: MetadataEntry[]) => {
+      setEntries(next)
+      authFetch(`/api/sessions/${sessionId}/metadata/${metadataKey}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ entries: next }),
+      }).catch((e) => console.error(`Failed to sync ${metadataKey}:`, e))
+    },
+    [sessionId, metadataKey],
+  )
+
+  const handleCycleStatus = useCallback(
+    (id: string) => {
+      const cycle = getStatusCycle(metadataKey)
+      const next = entries.map((e) => (e.id === id ? { ...e, status: cycleStatus(e.status, cycle) } : e))
+      syncToServer(next)
+    },
+    [entries, metadataKey, syncToServer],
+  )
+
+  const handleStartEdit = useCallback((id: string, desc: string) => {
+    setEditingId(id)
+    setEditDescription(desc)
+  }, [])
+
+  const commitEdit = useCallback((id: string, desc: string, current: MetadataEntry[]) => {
+    const trimmed = (desc.trim() || current.find((e) => e.id === id)?.description) ?? ''
+    const next = current.map((e) => (e.id === id ? { ...e, description: trimmed } : e))
+    syncToServer(next)
+  }, [syncToServer])
+
+  const handleSaveEdit = useCallback(() => {
+    if (!editingId) return
+    commitEdit(editingId, editDescription, entries)
+    setEditingId(null)
+  }, [editingId, editDescription, entries, commitEdit])
+
+  const handleEditKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter') handleSaveEdit()
+      if (e.key === 'Escape') {
+        e.stopPropagation()
+        setEditingId(null)
+      }
+    },
+    [handleSaveEdit],
+  )
+
+  const handleDelete = useCallback(
+    (id: string) => {
+      syncToServer(entries.filter((e) => e.id !== id))
+    },
+    [entries, syncToServer],
+  )
+
+  const handleAdd = useCallback(() => {
+    const desc = newDescription.trim()
+    if (!desc) return
+
+    const numericIds = entries.map((e) => Number(e.id)).filter((id) => Number.isInteger(id) && id >= 0)
+    const nextId = String(Math.max(-1, ...numericIds) + 1)
+
+    syncToServer([...entries, { id: nextId, description: desc, status: 'pending' }])
+    setNewDescription('')
+  }, [newDescription, entries, syncToServer])
+
+  const handleAddKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter') {
+        e.preventDefault()
+        handleAdd()
+      }
+      if (e.key === 'Escape') {
+        setAdding(false)
+        setNewDescription('')
+      }
+    },
+    [handleAdd],
+  )
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title={title} size="full" showCloseButton={true} closeOnEscape={true}>
+      <ul className="space-y-1">
+        {entries.map((entry, idx) => {
+          const isEditing = editingId === entry.id
+          const label = (
+            <button
+              onClick={() => handleStartEdit(entry.id, entry.description)}
+              className="text-sm text-text-primary text-left hover:text-accent-primary transition-colors w-full cursor-pointer"
+              title="Click to edit"
+            >
+              <span className="text-text-muted">[{entry.id}]</span>{' '}
+              <span>{decodeHtmlEntities(entry.description)}</span>
+            </button>
+          )
+          const editor = isEditing ? (
+            <textarea
+              ref={editInputRef}
+              value={editDescription}
+              onChange={(e) => {
+                setEditDescription(e.target.value)
+                autoResize()
+              }}
+              onBlur={handleSaveEdit}
+              onKeyDown={handleEditKeyDown}
+              className="w-full bg-bg-tertiary text-text-primary text-sm px-2 py-1 rounded border border-border focus:outline-none focus:border-accent-primary resize-none"
+              rows={1}
+            />
+          ) : label
+          return (
+            <li
+              key={entry.id}
+              className={`flex items-start gap-2 px-2 py-1.5 ${idx > 0 ? 'border-t border-border' : ''}`}
+            >
+              <button
+                onClick={() => handleCycleStatus(entry.id)}
+                className="flex-shrink-0 cursor-pointer hover:opacity-70 transition-opacity mt-0.5"
+                title="Click to cycle status"
+              >
+                <MetadataStatusIcon status={entry.status} />
+              </button>
+              <div className="flex-1 min-w-0">{editor}</div>
+              <button
+                onClick={() => handleDelete(entry.id)}
+                className="flex-shrink-0 text-text-muted hover:text-accent-error transition-colors cursor-pointer mt-0.5 ml-auto"
+                title="Delete entry"
+              >
+                <span className="flex"><XCloseIcon className="w-4 h-4" /></span>
+              </button>
+            </li>
+          )
+        })}
+        {entries.length === 0 && <p className="text-sm text-text-muted italic text-center py-4">No entries yet.</p>}
+      </ul>
+
+      <div className="mt-4 pt-3 border-t border-border">
+        <div className="flex items-center gap-2">
+          <span className="text-text-muted text-sm leading-tight">○</span>
+          <input
+            ref={addInputRef}
+            value={newDescription}
+            onChange={(e) => setNewDescription(e.target.value)}
+            onKeyDown={handleAddKeyDown}
+            placeholder="New entry..."
+            className="flex-1 bg-bg-tertiary text-text-primary text-sm px-2 py-1 rounded border border-border focus:outline-none focus:border-accent-primary placeholder-text-muted"
+          />
+          <button
+            onClick={handleAdd}
+            className="flex items-center gap-1 text-sm text-accent-primary hover:text-accent-primary/70 transition-colors cursor-pointer"
+            title="Add entry"
+          >
+            <PlusIcon className="w-4 h-4" />
+            Add
+          </button>
+        </div>
+      </div>
+    </Modal>
+  )
+}

--- a/web/src/components/shared/SelfContainedModal.tsx
+++ b/web/src/components/shared/SelfContainedModal.tsx
@@ -60,6 +60,8 @@ export function Modal({
     if (!isOpen || !closeOnEscape) return
     const handler = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
+        const active = document.activeElement
+        if (active && (active.tagName === 'INPUT' || active.tagName === 'TEXTAREA')) return
         e.stopPropagation()
         close()
       }
@@ -92,6 +94,7 @@ export function Modal({
                   onClick={closeOnBackdropClick ? close : undefined}
                 />
                 <div
+                  role="dialog"
                   className={`relative w-full ${sizeClasses[size]} max-h-[90vh] bg-bg-secondary border border-border rounded shadow-xl flex flex-col`}
                 >
                   {(title || headerRight || showCloseButton) && (


### PR DESCRIPTION
### Summary

Ajout d'un modal plein écran pour consulter et éditer les metadata de session (critères d'acceptation, review findings, todos, etc.) directement depuis la sidebar.

Jusqu'à présent, les metadata étaient affichées en lecture seule et tronquées dans la sidebar. Ce modal permet de visualiser l'intégralité du contenu sans troncature, et d'éditer les entrées (cycle de statut, modification du texte, ajout, suppression) pour tous les types de metadata.

### Détails techniques

**Nouveau composant :**
- `web/src/components/shared/MetadataModal.tsx` — modal plein écran (`size="full"`, 95vw × 90vh) réutilisant le composant `Modal` existant
- `web/src/components/shared/MetadataModal.test.tsx` — 25 tests couvrant l'ouverture/fermeture, l'affichage plein écran, l'absence de troncature, le cycle de statut, l'édition inline, l'ajout/suppression, la synchro serveur et tous les types de clés metadata

**Composants modifiés :**
- `web/src/components/plan/SessionSidebar.tsx` — tous les en-têtes de sections metadata (critères, review findings, tasks, clés inconnues) sont désormais cliquables et ouvrent le modal
- `web/src/components/shared/SelfContainedModal.tsx` — ajout de `role="dialog"` pour l'accessibilité ; le gestionnaire Escape vérifie désormais si un INPUT/TEXTAREA a le focus avant de fermer, empêchant la fermeture accidentelle du modal pendant l'édition inline

**Synchro serveur :**
- Aucune modification serveur — réutilisation du endpoint `PUT /api/sessions/:id/metadata/:key` existant (même mécanisme que `CriteriaEditor`)
- Chaque mutation (cycle de statut, édition, ajout, suppression) envoie immédiatement la liste complète des entrées via PUT

**Cycles de statut par type :**
- `criteria` : pending → completed → passed → failed
- `todos` : pending → in_progress → completed
- `review_findings` : open → resolved → dismissed
- Clés inconnues : cycle générique (pending → completed → failed → dismissed)

### AI-Enhanced Development

- **AI Models:** DeepSeek V4 Flash

### Cache Impact

Does this PR affect anything cached — system prompts, tool definitions, skills, or other context?

- **No**