### PR TITLE
fix(terminal): use active workspace path as terminal default directory

### DIFF
--- a/web/src/components/terminal/TerminalDrawer.tsx
+++ b/web/src/components/terminal/TerminalDrawer.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useRef, useCallback } from 'react'
 import { useTerminalStore } from '../../stores/terminal'
 import { useProjectStore } from '../../stores/project'
+import { useSessionStore } from '../../stores/session/store'
 import { TerminalPane } from './TerminalPane'
 import { PlusSquareIcon, XCloseIcon } from '../shared/icons'
 import { focusChatTextarea } from '../../lib/focusChatTextarea'
@@ -23,6 +24,7 @@ export function TerminalDrawer({ isOpen, onClose }: TerminalDrawerProps) {
   const setWorkdir = useTerminalStore((state) => state.setWorkdir)
   const fetchSessions = useTerminalStore((state) => state.fetchSessions)
   const currentProject = useProjectStore((state) => state.currentProject)
+  const currentSession = useSessionStore((state) => state.currentSession)
   const [isLoading, setIsLoading] = useState(true)
   const terminalRef = useRef<HTMLDivElement>(null)
   const justOpenedRef = useRef(false)
@@ -33,10 +35,11 @@ export function TerminalDrawer({ isOpen, onClose }: TerminalDrawerProps) {
   }, [onClose])
 
   useEffect(() => {
-    if (currentProject?.workdir) {
-      setWorkdir(currentProject.workdir)
+    const workdir = currentSession?.workspace ?? currentProject?.workdir
+    if (workdir) {
+      setWorkdir(workdir)
     }
-  }, [currentProject?.workdir, setWorkdir])
+  }, [currentSession?.workspace, currentProject?.workdir, setWorkdir])
 
   useEffect(() => {
     if (isOpen) {
@@ -50,9 +53,9 @@ export function TerminalDrawer({ isOpen, onClose }: TerminalDrawerProps) {
   useEffect(() => {
     if (isOpen && sessions.length === 0 && !isLoading && !hasAutoCreatedForOpenCycleRef.current) {
       hasAutoCreatedForOpenCycleRef.current = true
-      createSession(undefined, currentProject?.id)
+      createSession(undefined, currentSession?.projectId ?? currentProject?.id)
     }
-  }, [isOpen, sessions.length, isLoading, createSession, currentProject?.id])
+  }, [isOpen, sessions.length, isLoading, createSession, currentSession?.projectId, currentProject?.id])
 
   useEffect(() => {
     if (isOpen) {
@@ -107,7 +110,7 @@ export function TerminalDrawer({ isOpen, onClose }: TerminalDrawerProps) {
           <h3 className="text-sm font-semibold text-text-primary">Terminal</h3>
           <div className="flex items-center gap-2">
             <button
-              onClick={() => createSession(undefined, currentProject?.id)}
+              onClick={() => createSession(undefined, currentSession?.projectId ?? currentProject?.id)}
               className="p-2 rounded hover:bg-bg-tertiary text-text-muted hover:text-text-primary transition-colors"
               title="New terminal"
             >
@@ -131,7 +134,7 @@ export function TerminalDrawer({ isOpen, onClose }: TerminalDrawerProps) {
               <div className="text-center">
                 <p className="mb-4">No terminal sessions</p>
                 <button
-                  onClick={() => createSession(undefined, currentProject?.id)}
+                  onClick={() => createSession(undefined, currentSession?.projectId ?? currentProject?.id)}
                   className="px-4 py-2 bg-accent-primary/25 text-text-primary rounded hover:bg-accent-primary/40 transition-colors"
                 >
                   Create Terminal

--- a/web/src/components/terminal/TerminalDrawer.workspace.test.tsx
+++ b/web/src/components/terminal/TerminalDrawer.workspace.test.tsx
@@ -1,0 +1,167 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { cleanup, render } from '@testing-library/react'
+
+// ---------------------------------------------------------------------------
+// Mock focusChatTextarea — harmless in test env but we avoid any side effects
+// ---------------------------------------------------------------------------
+vi.mock('../../lib/focusChatTextarea', () => ({
+  focusChatTextarea: vi.fn(),
+}))
+
+// ---------------------------------------------------------------------------
+// Shared mock helpers — referenced by vi.mock factories below
+// ---------------------------------------------------------------------------
+const mockCreateSession = vi.fn()
+const mockKillSession = vi.fn()
+const mockSetWorkdir = vi.fn()
+const mockFetchSessions = vi.fn().mockResolvedValue(undefined)
+const mockSessions: unknown[] = []
+
+const useTerminalStoreMock = vi.fn()
+const useProjectStoreMock = vi.fn()
+const useSessionStoreMock = vi.fn()
+
+// ---------------------------------------------------------------------------
+// Store mocks — hoisted before imports via vi.mock
+// ---------------------------------------------------------------------------
+vi.mock('../../stores/terminal', () => ({
+  useTerminalStore: (selector: (s: unknown) => unknown) => useTerminalStoreMock(selector),
+}))
+
+vi.mock('../../stores/project', () => ({
+  useProjectStore: (selector: (s: unknown) => unknown) => useProjectStoreMock(selector),
+}))
+
+vi.mock('../../stores/session/store', () => ({
+  useSessionStore: (selector: (s: unknown) => unknown) => useSessionStoreMock(selector),
+}))
+
+// ---------------------------------------------------------------------------
+// Import after mocks are in place
+// ---------------------------------------------------------------------------
+import { TerminalDrawer } from './TerminalDrawer'
+
+describe('TerminalDrawer workspace integration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setupDefaultMocks()
+  })
+
+  afterEach(cleanup)
+
+  // -----------------------------------------------------------------------
+  // Helper: default store state (no session, no project)
+  // -----------------------------------------------------------------------
+  function setupDefaultMocks() {
+    useTerminalStoreMock.mockImplementation((selector: (s: Record<string, unknown>) => unknown) =>
+      selector({
+        createSession: mockCreateSession,
+        killSession: mockKillSession,
+        sessions: mockSessions,
+        setWorkdir: mockSetWorkdir,
+        fetchSessions: mockFetchSessions,
+      }),
+    )
+
+    useProjectStoreMock.mockImplementation((selector: (s: Record<string, unknown>) => unknown) =>
+      selector({
+        currentProject: null,
+      }),
+    )
+
+    useSessionStoreMock.mockImplementation((selector: (s: Record<string, unknown>) => unknown) =>
+      selector({
+        currentSession: null,
+      }),
+    )
+  }
+
+  // -----------------------------------------------------------------------
+  // Criterion 0+1+2: Import useSessionStore, read currentSession, and
+  // use currentSession?.workspace as workdir when available
+  // -----------------------------------------------------------------------
+  it('should use currentSession.workspace as workdir when workspace is set', () => {
+    useSessionStoreMock.mockImplementation((selector: (s: Record<string, unknown>) => unknown) =>
+      selector({
+        currentSession: { id: 's1', projectId: 'p1', workspace: '/workspace/path' },
+      }),
+    )
+
+    useProjectStoreMock.mockImplementation((selector: (s: Record<string, unknown>) => unknown) =>
+      selector({
+        currentProject: { id: 'p1', workdir: '/project/workdir' },
+      }),
+    )
+
+    render(<TerminalDrawer isOpen={true} onClose={vi.fn()} />)
+
+    expect(mockSetWorkdir).toHaveBeenCalledWith('/workspace/path')
+    expect(mockSetWorkdir).toHaveBeenCalledTimes(1)
+  })
+
+  // -----------------------------------------------------------------------
+  // Criterion 2: Fall back to currentProject.workdir when workspace absent
+  // -----------------------------------------------------------------------
+  it('should fall back to currentProject.workdir when currentSession.workspace is undefined', () => {
+    useSessionStoreMock.mockImplementation((selector: (s: Record<string, unknown>) => unknown) =>
+      selector({
+        currentSession: { id: 's1', projectId: 'p1' },
+      }),
+    )
+
+    useProjectStoreMock.mockImplementation((selector: (s: Record<string, unknown>) => unknown) =>
+      selector({
+        currentProject: { id: 'p1', workdir: '/project/workdir' },
+      }),
+    )
+
+    render(<TerminalDrawer isOpen={true} onClose={vi.fn()} />)
+
+    expect(mockSetWorkdir).toHaveBeenCalledWith('/project/workdir')
+    expect(mockSetWorkdir).toHaveBeenCalledTimes(1)
+  })
+
+  // -----------------------------------------------------------------------
+  // Criterion 2: Neither workspace nor project workdir — no setWorkdir call
+  // -----------------------------------------------------------------------
+  it('should not call setWorkdir when both workspace and project workdir are missing', () => {
+    render(<TerminalDrawer isOpen={true} onClose={vi.fn()} />)
+
+    expect(mockSetWorkdir).not.toHaveBeenCalled()
+  })
+
+  // -----------------------------------------------------------------------
+  // Criterion 3: The "New terminal" button uses the workspace path as cwd
+  // The button passes undefined as workdir, so createSession falls back to
+  // the store's workdir (which was set by the effect to workspace).
+  // -----------------------------------------------------------------------
+  it('should call createSession with undefined workdir when new terminal button is clicked', () => {
+    useSessionStoreMock.mockImplementation((selector: (s: Record<string, unknown>) => unknown) =>
+      selector({
+        currentSession: { id: 's1', projectId: 'p1', workspace: '/workspace/path' },
+      }),
+    )
+
+    useProjectStoreMock.mockImplementation((selector: (s: Record<string, unknown>) => unknown) =>
+      selector({
+        currentProject: { id: 'p1', workdir: '/project/workdir' },
+      }),
+    )
+
+    render(<TerminalDrawer isOpen={true} onClose={vi.fn()} />)
+
+    // The effect should have set workdir to the workspace path
+    expect(mockSetWorkdir).toHaveBeenCalledWith('/workspace/path')
+
+    // Find the "New terminal" button by title and click it
+    const buttons = document.querySelectorAll('button')
+    const newTerminalBtn = Array.from(buttons).find((b) => b.getAttribute('title') === 'New terminal')
+    expect(newTerminalBtn).not.toBeNull()
+
+    newTerminalBtn!.click()
+
+    expect(mockCreateSession).toHaveBeenCalledWith(undefined, 'p1')
+    expect(mockCreateSession).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
### Summary

Lorsque l'utilisateur ouvre le terminal depuis la barre superieure, le repertoire de travail etait toujours celui du projet racine, meme lorsqu'un workspace etait actif. Cette PR fait en sorte que le terminal s'ouvre par defaut dans le repertoire du workspace actif, avec un fallback sur le projet racine si aucun workspace n'est actif.

### Technical Details

- **Probleme :** TerminalDrawer.tsx lisait uniquement currentProject.workdir pour definir le repertoire de travail du terminal, ignorant currentSession.workspace (chemin absolu du workspace actif)
- **Solution :** Trois changements dans TerminalDrawer.tsx :
  1. Import de useSessionStore et lecture de currentSession
  2. Le useEffect de synchronisation du workdir utilise currentSession?.workspace ?? currentProject?.workdir
  3. Les appels createSession(undefined, ...) utilisent currentSession?.projectId ?? currentProject?.id pour aligner le projet avec le workspace
- **Mecanisme :** Le serveur (terminalManager.resolveWorkdir) accepte n'importe quel chemin absolu comme cwd => pas de changement serveur necessaire
- **Tests :** Nouveau fichier TerminalDrawer.workspace.test.tsx avec 4 tests couvrant : workspace path, fallback workdir, ni workspace ni projet, bouton New terminal

### AI-Enhanced Development

- **AI Models:** DeepSeek V4 Flash

### Cache Impact

- **No**