### PR TITLE
fix: conditionally expand message bubble width during Edit & Resend

### DIFF
--- a/web/src/components/plan/ChatMessage.tsx
+++ b/web/src/components/plan/ChatMessage.tsx
@@ -139,7 +139,7 @@ function UserMessage({ message, messageId, sessionId }: UserMessageProps) {
       )}
 
       <div
-        className={`max-w-[75%] rounded p-2 ${
+        className={`max-w-[75%] ${editing ? 'w-full' : ''} rounded p-2 ${
           isSystemGenerated
             ? isCommand
               ? 'bg-teal-500/10 border border-teal-500/30'


### PR DESCRIPTION
### Summary

When clicking Edit & Resend on a user message, the textarea now properly fills the available width of the message bubble.

### AI-Enhanced Development

AI Models: Qwen 3.5 122B

### Cache Impact

No