### PR TITLE
feat: per-project workspace root directory with validation and migration warning

### DIFF
--- a/src/server/git/workspace-config.ts
+++ b/src/server/git/workspace-config.ts
@@ -13,8 +13,10 @@ export async function loadWorkspaceConfig(workdir: string): Promise<WorkspaceCon
     const configPath = getConfigPath(workdir)
     const raw = await readFile(configPath, 'utf-8')
     const parsed = JSON.parse(raw)
-    if (!parsed.setup) return null
-    return { setup: parsed.setup }
+    const config: WorkspaceConfig = {}
+    if (parsed.setup) config.setup = parsed.setup
+    if (parsed.rootDir) config.rootDir = parsed.rootDir
+    return Object.keys(config).length > 0 ? config : null
   } catch {
     return null
   }

--- a/src/server/git/workspace.test.ts
+++ b/src/server/git/workspace.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { resolve } from 'node:path'
 
 import {
   getGitBranch,
@@ -27,8 +28,13 @@ vi.mock('../utils/logger.js', () => ({
   logger: { debug: vi.fn(), warn: vi.fn(), info: vi.fn(), error: vi.fn() },
 }))
 
+vi.mock('./workspace-config.js', () => ({
+  loadWorkspaceConfig: vi.fn(),
+}))
+
 import { spawn, execSync } from 'node:child_process'
 import { readFile, readdir, mkdir, stat } from 'node:fs/promises'
+import { loadWorkspaceConfig } from './workspace-config.js'
 
 type MockProc = {
   stdout: { on: (event: string, cb: (d: Buffer) => void) => void }
@@ -99,10 +105,42 @@ describe('listBranches', () => {
 })
 
 describe('getWorkspacesDir', () => {
-  it('returns path under global data dir', () => {
-    const dir = getWorkspacesDir(PROJECT_NAME)
+  it('returns path under global data dir when rootDir is not configured', async () => {
+    vi.mocked(loadWorkspaceConfig).mockResolvedValue(null)
+    const dir = await getWorkspacesDir(PROJECT_NAME, CWD)
     expect(dir).toContain('workspaces')
     expect(dir).toContain(PROJECT_NAME)
+  })
+
+  it('returns global fallback when config has no rootDir', async () => {
+    vi.mocked(loadWorkspaceConfig).mockResolvedValue({ setup: ['npm install'] })
+    const dir = await getWorkspacesDir(PROJECT_NAME, CWD)
+    expect(dir).toContain('workspaces')
+    expect(dir).toContain(PROJECT_NAME)
+  })
+
+  it('uses absolute rootDir directly from config', async () => {
+    vi.mocked(loadWorkspaceConfig).mockResolvedValue({ rootDir: '/custom/workspace/path' })
+    const dir = await getWorkspacesDir(PROJECT_NAME, CWD)
+    expect(dir).toBe('/custom/workspace/path')
+  })
+
+  it('resolves relative rootDir against projectDir', async () => {
+    vi.mocked(loadWorkspaceConfig).mockResolvedValue({ rootDir: './my-workspaces' })
+    const dir = await getWorkspacesDir(PROJECT_NAME, CWD)
+    expect(dir).toBe(resolve(CWD, 'my-workspaces'))
+  })
+
+  it('resolves parent-relative rootDir correctly', async () => {
+    vi.mocked(loadWorkspaceConfig).mockResolvedValue({ rootDir: '../shared-workspaces' })
+    const dir = await getWorkspacesDir(PROJECT_NAME, CWD)
+    expect(dir).toBe(resolve(CWD, '../shared-workspaces'))
+  })
+
+  it('calls loadWorkspaceConfig with projectDir', async () => {
+    vi.mocked(loadWorkspaceConfig).mockResolvedValue(null)
+    await getWorkspacesDir(PROJECT_NAME, CWD)
+    expect(loadWorkspaceConfig).toHaveBeenCalledWith(CWD)
   })
 })
 
@@ -115,7 +153,7 @@ describe('listWorkspaces', () => {
     ] as any)
 
     vi.mocked(spawn).mockReturnValue(makeMockProc('main\n') as any)
-    const result = await listWorkspaces(PROJECT_NAME)
+    const result = await listWorkspaces(PROJECT_NAME, CWD)
     expect(result).toHaveLength(2)
     expect(result[0]?.name).toBe('add-feature')
     expect(result[1]?.name).toBe('fix-bug')
@@ -124,7 +162,7 @@ describe('listWorkspaces', () => {
 
   it('returns empty on error', async () => {
     vi.mocked(readdir).mockRejectedValue({ code: 'ENOENT' })
-    const result = await listWorkspaces(PROJECT_NAME)
+    const result = await listWorkspaces(PROJECT_NAME, CWD)
     expect(result).toEqual([])
   })
 })
@@ -136,7 +174,7 @@ describe('ensureWorkspace', () => {
     vi.mocked(stat)
       .mockResolvedValueOnce(null as any) // wsPath doesn't exist → triggers clone
       .mockResolvedValueOnce({ isDirectory: () => true } as any) // post-clone check
-    vi.mocked(readFile).mockResolvedValue(JSON.stringify({ setup: ['echo hello'] }))
+    vi.mocked(loadWorkspaceConfig).mockResolvedValue({ setup: ['echo hello'] })
     vi.mocked(execSync).mockReturnValue(Buffer.from('') as any)
 
     const result = await ensureWorkspace(CWD, 'my-experiment', PROJECT_NAME)

--- a/src/server/git/workspace.ts
+++ b/src/server/git/workspace.ts
@@ -59,6 +59,10 @@ export async function getWorkspacesDir(projectName: string, projectDir: string):
   return join(getGlobalDataDir(), 'workspaces', projectName)
 }
 
+export function getDefaultGlobalWorkspacesDir(projectName: string): string {
+  return join(getGlobalDataDir(), 'workspaces', projectName)
+}
+
 export function getGitBranch(cwd: string): Promise<string | null> {
   return captureStdout(cwd, ['rev-parse', '--abbrev-ref', 'HEAD']).then((r) => r?.trim() ?? null)
 }

--- a/src/server/git/workspace.ts
+++ b/src/server/git/workspace.ts
@@ -51,7 +51,11 @@ function getGlobalDataDir(): string {
   }
 }
 
-export function getWorkspacesDir(projectName: string): string {
+export async function getWorkspacesDir(projectName: string, projectDir: string): Promise<string> {
+  const config = await loadWorkspaceConfig(projectDir)
+  if (config?.rootDir) {
+    return isAbsolute(config.rootDir) ? config.rootDir : resolve(projectDir, config.rootDir)
+  }
   return join(getGlobalDataDir(), 'workspaces', projectName)
 }
 
@@ -198,8 +202,8 @@ export interface WorkspaceInfo {
   branch: string | null
 }
 
-export async function workspaceExists(projectName: string, name: string): Promise<boolean> {
-  const dir = getWorkspacesDir(projectName)
+export async function workspaceExists(projectName: string, name: string, projectDir: string): Promise<boolean> {
+  const dir = await getWorkspacesDir(projectName, projectDir)
   const wsPath = resolve(dir, name)
   const st = await statSafe(wsPath)
   if (!st?.isDirectory()) return false
@@ -208,8 +212,8 @@ export async function workspaceExists(projectName: string, name: string): Promis
   return gitSt?.isDirectory() ?? false
 }
 
-export async function listWorkspaces(projectName: string): Promise<WorkspaceInfo[]> {
-  const dir = getWorkspacesDir(projectName)
+export async function listWorkspaces(projectName: string, projectDir: string): Promise<WorkspaceInfo[]> {
+  const dir = await getWorkspacesDir(projectName, projectDir)
   try {
     const { readdir } = await import('node:fs/promises')
     const entries = await readdir(dir, { withFileTypes: true })
@@ -239,7 +243,7 @@ export async function ensureWorkspace(
   branch?: string,
   sourceBranch?: string,
 ): Promise<WorkspaceResult> {
-  const workspacesDir = getWorkspacesDir(projectName)
+  const workspacesDir = await getWorkspacesDir(projectName, projectDir)
   const wsPath = resolve(workspacesDir, name)
 
   await mkdir(workspacesDir, { recursive: true })
@@ -287,8 +291,8 @@ export async function ensureWorkspace(
   return { path: wsPath, name }
 }
 
-export async function deleteWorkspace(projectName: string, name: string): Promise<void> {
-  const dir = getWorkspacesDir(projectName)
+export async function deleteWorkspace(projectName: string, name: string, projectDir: string): Promise<void> {
+  const dir = await getWorkspacesDir(projectName, projectDir)
   const wsPath = resolve(dir, name)
   const st = await statSafe(wsPath)
   if (!st?.isDirectory()) {

--- a/src/server/git/workspace.ts
+++ b/src/server/git/workspace.ts
@@ -33,11 +33,11 @@ export function runGit(cwd: string, args: string[]): Promise<void> {
   })
 }
 
-function getServerMode(): 'development' | 'production' {
+export function getServerMode(): 'development' | 'production' {
   return process.env['OPENFOX_DEV'] === 'true' ? 'development' : 'production'
 }
 
-function getGlobalDataDir(): string {
+export function getGlobalDataDir(): string {
   const mode = getServerMode()
   const suffix = mode === 'development' ? '-dev' : ''
   const home = homedir()

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -550,7 +550,7 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
     const project = getProject(req.params.id)
     if (!project) return res.status(404).json({ error: 'Project not found' })
     const { listWorkspaces } = await import('./git/workspace.js')
-    const all = await listWorkspaces(project.name)
+    const all = await listWorkspaces(project.name, project.workdir)
     // Filter out the main workspace (the repo itself) — only show linked workspaces
     const workspacesList = all.filter((ws) => ws.path !== project.workdir)
     res.json({ workspaces: workspacesList })

--- a/src/server/routes/workspace-config.test.ts
+++ b/src/server/routes/workspace-config.test.ts
@@ -127,6 +127,42 @@ describe('POST /api/workspace/config/validate', () => {
     expect(res.status).toBe(400)
   })
 
+  it('returns 400 for dangerous system path', async () => {
+    const res = await fetch(`${baseUrl}/api/workspace/config/validate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ rootDir: '/etc', workdir: testDir }),
+    })
+
+    expect(res.status).toBe(400)
+    const body = (await res.json()) as { error: string }
+    expect(body.error).toMatch(/system-critical/i)
+  })
+
+  it('returns 400 for virtual filesystem prefix', async () => {
+    const res = await fetch(`${baseUrl}/api/workspace/config/validate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ rootDir: '/proc/self/fd/1', workdir: testDir }),
+    })
+
+    expect(res.status).toBe(400)
+    const body = (await res.json()) as { error: string }
+    expect(body.error).toMatch(/system-critical/i)
+  })
+
+  it('returns 400 for non-writable existing directory', async () => {
+    const res = await fetch(`${baseUrl}/api/workspace/config/validate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ rootDir: '/etc/ssl', workdir: testDir }),
+    })
+
+    expect(res.status).toBe(400)
+    const body = (await res.json()) as { error: string }
+    expect(body.error).toMatch(/not writable/i)
+  })
+
   describe('workspace migration detection', () => {
     it('returns existing workspaces from old rootDir when rootDir changes', async () => {
       const oldRootDir = join(testDir, 'old-workspaces')
@@ -186,6 +222,52 @@ describe('POST /api/workspace/config/validate', () => {
 
     it('returns empty workspaces list when config has no previous rootDir', async () => {
       const newRootDir = join(testDir, 'fresh-workspaces')
+
+      const res = await fetch(`${baseUrl}/api/workspace/config/validate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ rootDir: newRootDir, workdir: testDir }),
+      })
+
+      expect(res.status).toBe(200)
+      const body = (await res.json()) as ValidateResponse
+      expect(body.workspaces).toEqual([])
+    })
+
+    it('detects default global dir orphans when projectName provided', async () => {
+      const origXdg = process.env['XDG_DATA_HOME']
+      process.env['XDG_DATA_HOME'] = testDir
+      try {
+        const defaultDir = join(testDir, 'openfox', 'workspaces', 'my-project')
+        const ws1 = join(defaultDir, 'fix-bug')
+        await mkdir(join(ws1, '.git'), { recursive: true })
+        await writeFile(join(ws1, '.git', 'HEAD'), 'ref: refs/heads/main\n')
+
+        const newRootDir = join(testDir, 'custom-workspaces')
+
+        const res = await fetch(`${baseUrl}/api/workspace/config/validate`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            rootDir: newRootDir,
+            workdir: testDir,
+            projectName: 'my-project',
+          }),
+        })
+
+        expect(res.status).toBe(200)
+        const body = (await res.json()) as ValidateResponse
+        expect(body.workspaces).toBeDefined()
+        expect(body.workspaces!.length).toBe(1)
+        expect(body.workspaces![0]!.name).toBe('fix-bug')
+      } finally {
+        if (origXdg !== undefined) process.env['XDG_DATA_HOME'] = origXdg
+        else delete process.env['XDG_DATA_HOME']
+      }
+    })
+
+    it('returns empty workspaces list from default dir when projectName is not provided', async () => {
+      const newRootDir = join(testDir, 'other-workspaces')
 
       const res = await fetch(`${baseUrl}/api/workspace/config/validate`, {
         method: 'POST',
@@ -258,5 +340,62 @@ describe('POST /api/workspace/config (existing endpoint)', () => {
       body: JSON.stringify({}),
     })
     expect(res.status).toBe(400)
+  })
+
+  it('rejects dangerous exact path', async () => {
+    const res = await fetch(`${baseUrl}/api/workspace/config?workdir=${encodeURIComponent(testDir)}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ rootDir: '/etc', setup: ['npm install'] }),
+    })
+    expect(res.status).toBe(400)
+    const body = (await res.json()) as { error: string }
+    expect(body.error).toMatch(/system-critical/i)
+  })
+
+  it('rejects dangerous path with virtual fs prefix', async () => {
+    const res = await fetch(`${baseUrl}/api/workspace/config?workdir=${encodeURIComponent(testDir)}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ rootDir: '/proc/self', setup: ['npm install'] }),
+    })
+    expect(res.status).toBe(400)
+    const body = (await res.json()) as { error: string }
+    expect(body.error).toMatch(/system-critical/i)
+  })
+
+  it('rejects non-writable existing directory', async () => {
+    const res = await fetch(`${baseUrl}/api/workspace/config?workdir=${encodeURIComponent(testDir)}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ rootDir: '/etc/ssl', setup: ['npm install'] }),
+    })
+    expect(res.status).toBe(400)
+    const body = (await res.json()) as { error: string }
+    expect(body.error).toMatch(/not writable/i)
+  })
+
+  it('strips empty rootDir and saves setup', async () => {
+    const res = await fetch(`${baseUrl}/api/workspace/config?workdir=${encodeURIComponent(testDir)}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ rootDir: '', setup: ['npm install'] }),
+    })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as ConfigResponse
+    expect(body.config.rootDir).toBeUndefined()
+    expect(body.config.setup).toEqual(['npm install'])
+  })
+
+  it('strips whitespace-only rootDir and saves setup', async () => {
+    const res = await fetch(`${baseUrl}/api/workspace/config?workdir=${encodeURIComponent(testDir)}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ rootDir: '   ', setup: ['npm install'] }),
+    })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as ConfigResponse
+    expect(body.config.rootDir).toBeUndefined()
+    expect(body.config.setup).toEqual(['npm install'])
   })
 })

--- a/src/server/routes/workspace-config.test.ts
+++ b/src/server/routes/workspace-config.test.ts
@@ -136,7 +136,7 @@ describe('POST /api/workspace/config/validate', () => {
 
     expect(res.status).toBe(400)
     const body = (await res.json()) as { error: string }
-    expect(body.error).toMatch(/system-critical/i)
+    expect(body.error).toMatch(/Use a subdirectory instead/i)
   })
 
   it('returns 400 for virtual filesystem prefix', async () => {
@@ -148,14 +148,20 @@ describe('POST /api/workspace/config/validate', () => {
 
     expect(res.status).toBe(400)
     const body = (await res.json()) as { error: string }
-    expect(body.error).toMatch(/system-critical/i)
+    expect(body.error).toMatch(/Cannot use paths under/i)
   })
 
   it('returns 400 for non-writable existing directory', async () => {
+    const restrictedPath = join(testDir, 'restricted')
+    await mkdir(restrictedPath, { recursive: true })
+    // Remove write permissions to simulate non-writable directory
+    const { chmod } = await import('node:fs/promises')
+    await chmod(restrictedPath, 0o444)
+
     const res = await fetch(`${baseUrl}/api/workspace/config/validate`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ rootDir: '/etc/ssl', workdir: testDir }),
+      body: JSON.stringify({ rootDir: restrictedPath, workdir: testDir }),
     })
 
     expect(res.status).toBe(400)
@@ -350,7 +356,7 @@ describe('POST /api/workspace/config (existing endpoint)', () => {
     })
     expect(res.status).toBe(400)
     const body = (await res.json()) as { error: string }
-    expect(body.error).toMatch(/system-critical/i)
+    expect(body.error).toMatch(/Use a subdirectory instead/i)
   })
 
   it('rejects dangerous path with virtual fs prefix', async () => {
@@ -361,14 +367,19 @@ describe('POST /api/workspace/config (existing endpoint)', () => {
     })
     expect(res.status).toBe(400)
     const body = (await res.json()) as { error: string }
-    expect(body.error).toMatch(/system-critical/i)
+    expect(body.error).toMatch(/Cannot use paths under/i)
   })
 
   it('rejects non-writable existing directory', async () => {
+    const restrictedPath = join(testDir, 'restricted-save')
+    await mkdir(restrictedPath, { recursive: true })
+    const { chmod } = await import('node:fs/promises')
+    await chmod(restrictedPath, 0o444)
+
     const res = await fetch(`${baseUrl}/api/workspace/config?workdir=${encodeURIComponent(testDir)}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ rootDir: '/etc/ssl', setup: ['npm install'] }),
+      body: JSON.stringify({ rootDir: restrictedPath, setup: ['npm install'] }),
     })
     expect(res.status).toBe(400)
     const body = (await res.json()) as { error: string }

--- a/src/server/routes/workspace-config.test.ts
+++ b/src/server/routes/workspace-config.test.ts
@@ -1,0 +1,262 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import express from 'express'
+import { mkdir, rm, writeFile } from 'node:fs/promises'
+import { join, resolve } from 'node:path'
+import { tmpdir } from 'node:os'
+import { createWorkspaceConfigRoutes } from './workspace-config.js'
+
+interface ValidateResponse {
+  exists: boolean
+  resolvedPath: string
+  created?: boolean
+  workspaces?: { name: string }[]
+}
+
+interface ConfigResponse {
+  config: { rootDir?: string; setup?: string[] }
+}
+
+describe('POST /api/workspace/config/validate', () => {
+  let app: express.Express
+  let server: ReturnType<typeof app.listen>
+  let baseUrl: string
+  let testDir: string
+
+  beforeEach(async () => {
+    testDir = join(tmpdir(), `openfox-ws-config-test-${Date.now()}`)
+    await mkdir(testDir, { recursive: true })
+
+    app = express()
+    app.use(express.json())
+    app.use('/api/workspace', createWorkspaceConfigRoutes())
+
+    return new Promise<void>((resolve) => {
+      server = app.listen(0, () => {
+        baseUrl = `http://localhost:${(server.address() as any).port}`
+        resolve()
+      })
+    })
+  })
+
+  afterEach(async () => {
+    server?.close()
+    await rm(testDir, { recursive: true, force: true })
+  })
+
+  it('returns exists:false when rootDir does not exist', async () => {
+    const missingPath = join(testDir, 'nonexistent')
+
+    const res = await fetch(`${baseUrl}/api/workspace/config/validate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ rootDir: missingPath, workdir: testDir }),
+    })
+
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as ValidateResponse
+    expect(body.exists).toBe(false)
+    expect(body.resolvedPath).toBe(resolve(missingPath))
+  })
+
+  it('returns exists:true when rootDir already exists', async () => {
+    const existingPath = join(testDir, 'existing-dir')
+    await mkdir(existingPath, { recursive: true })
+
+    const res = await fetch(`${baseUrl}/api/workspace/config/validate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ rootDir: existingPath, workdir: testDir }),
+    })
+
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as ValidateResponse
+    expect(body.exists).toBe(true)
+  })
+
+  it('creates rootDir when createIfMissing is true', async () => {
+    const newPath = join(testDir, 'will-be-created')
+
+    const res = await fetch(`${baseUrl}/api/workspace/config/validate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ rootDir: newPath, workdir: testDir, createIfMissing: true }),
+    })
+
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as ValidateResponse
+    expect(body.exists).toBe(true)
+    expect(body.created).toBe(true)
+
+    const { stat } = await import('node:fs/promises')
+    const st = await stat(newPath)
+    expect(st.isDirectory()).toBe(true)
+  })
+
+  it('resolves relative rootDir against workdir', async () => {
+    const relativePath = './my-workspaces'
+    const resolvedPath = resolve(testDir, 'my-workspaces')
+
+    const res = await fetch(`${baseUrl}/api/workspace/config/validate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ rootDir: relativePath, workdir: testDir }),
+    })
+
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as ValidateResponse
+    expect(body.resolvedPath).toBe(resolvedPath)
+  })
+
+  it('returns 400 when rootDir is missing', async () => {
+    const res = await fetch(`${baseUrl}/api/workspace/config/validate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ workdir: testDir }),
+    })
+
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when workdir is missing', async () => {
+    const res = await fetch(`${baseUrl}/api/workspace/config/validate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ rootDir: '/some/path' }),
+    })
+
+    expect(res.status).toBe(400)
+  })
+
+  describe('workspace migration detection', () => {
+    it('returns existing workspaces from old rootDir when rootDir changes', async () => {
+      const oldRootDir = join(testDir, 'old-workspaces')
+      const ws1 = join(oldRootDir, 'fix-bug')
+      const ws2 = join(oldRootDir, 'add-feature')
+      await mkdir(join(ws1, '.git'), { recursive: true })
+      await mkdir(join(ws2, '.git'), { recursive: true })
+      await writeFile(join(ws1, '.git', 'HEAD'), 'ref: refs/heads/main\n')
+      await writeFile(join(ws2, '.git', 'HEAD'), 'ref: refs/heads/main\n')
+
+      const saveRes = await fetch(`${baseUrl}/api/workspace/config?workdir=${encodeURIComponent(testDir)}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ rootDir: oldRootDir }),
+      })
+      expect(saveRes.status).toBe(200)
+
+      const newRootDir = join(testDir, 'new-workspaces')
+
+      const res = await fetch(`${baseUrl}/api/workspace/config/validate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ rootDir: newRootDir, workdir: testDir }),
+      })
+
+      expect(res.status).toBe(200)
+      const body = (await res.json()) as ValidateResponse
+      expect(body.workspaces).toBeDefined()
+      expect(Array.isArray(body.workspaces)).toBe(true)
+      expect(body.workspaces!.length).toBeGreaterThanOrEqual(2)
+      const names = body.workspaces!.map((w: { name: string }) => w.name).sort()
+      expect(names).toContain('fix-bug')
+      expect(names).toContain('add-feature')
+    })
+
+    it('returns empty workspaces list when rootDir does not change', async () => {
+      const rootDir = join(testDir, 'stable-workspaces')
+      await mkdir(rootDir, { recursive: true })
+
+      const saveRes = await fetch(`${baseUrl}/api/workspace/config?workdir=${encodeURIComponent(testDir)}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ rootDir }),
+      })
+      expect(saveRes.status).toBe(200)
+
+      const res = await fetch(`${baseUrl}/api/workspace/config/validate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ rootDir, workdir: testDir }),
+      })
+
+      expect(res.status).toBe(200)
+      const body = (await res.json()) as ValidateResponse
+      expect(body.workspaces).toEqual([])
+    })
+
+    it('returns empty workspaces list when config has no previous rootDir', async () => {
+      const newRootDir = join(testDir, 'fresh-workspaces')
+
+      const res = await fetch(`${baseUrl}/api/workspace/config/validate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ rootDir: newRootDir, workdir: testDir }),
+      })
+
+      expect(res.status).toBe(200)
+      const body = (await res.json()) as ValidateResponse
+      expect(body.workspaces).toEqual([])
+    })
+  })
+})
+
+describe('POST /api/workspace/config (existing endpoint)', () => {
+  let app: express.Express
+  let server: ReturnType<typeof app.listen>
+  let baseUrl: string
+  let testDir: string
+
+  beforeEach(async () => {
+    testDir = join(tmpdir(), `openfox-ws-config-save-test-${Date.now()}`)
+    await mkdir(testDir, { recursive: true })
+
+    app = express()
+    app.use(express.json())
+    app.use('/api/workspace', createWorkspaceConfigRoutes())
+
+    return new Promise<void>((resolve) => {
+      server = app.listen(0, () => {
+        baseUrl = `http://localhost:${(server.address() as any).port}`
+        resolve()
+      })
+    })
+  })
+
+  afterEach(async () => {
+    server?.close()
+    await rm(testDir, { recursive: true, force: true })
+  })
+
+  it('saves config with rootDir', async () => {
+    const rootDir = join(testDir, 'target')
+    await mkdir(rootDir, { recursive: true })
+
+    const res = await fetch(`${baseUrl}/api/workspace/config?workdir=${encodeURIComponent(testDir)}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ rootDir }),
+    })
+
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as ConfigResponse
+    expect(body.config.rootDir).toBe(rootDir)
+  })
+
+  it('returns 400 when workdir query param is missing', async () => {
+    const res = await fetch(`${baseUrl}/api/workspace/config`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ rootDir: '/some/path' }),
+    })
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when neither setup nor rootDir is provided', async () => {
+    const res = await fetch(`${baseUrl}/api/workspace/config?workdir=${encodeURIComponent(testDir)}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    })
+    expect(res.status).toBe(400)
+  })
+})

--- a/src/server/routes/workspace-config.ts
+++ b/src/server/routes/workspace-config.ts
@@ -1,31 +1,72 @@
 import { Router } from 'express'
-import { stat, mkdir, readdir } from 'node:fs/promises'
+import { stat, mkdir, readdir, access } from 'node:fs/promises'
+import { constants } from 'node:fs'
 import { resolve, isAbsolute, join } from 'node:path'
+import { homedir } from 'node:os'
 import { loadWorkspaceConfig, saveWorkspaceConfig } from '../git/workspace-config.js'
 import type { WorkspaceConfig } from '../../shared/workspace.js'
+import { isValidRootDir } from '../../shared/workspace.js'
 
-const DANGEROUS_PATHS = [
-  '/',
-  '/etc',
-  '/dev',
-  '/proc',
-  '/sys',
-  '/boot',
-  '/bin',
-  '/sbin',
-  '/lib',
-  '/lib64',
-  '/usr',
-  '/var',
-  '/opt',
-  '/root',
-  '/run',
-  '/tmp',
-  '/home',
-  '/mnt',
-  '/media',
-  '/lost+found',
-]
+function getServerMode(): 'development' | 'production' {
+  return process.env['OPENFOX_DEV'] === 'true' ? 'development' : 'production'
+}
+
+function getDefaultGlobalDir(projectName: string): string {
+  const mode = getServerMode()
+  const suffix = mode === 'development' ? '-dev' : ''
+  const home = homedir()
+  const dataDir = process.env['XDG_DATA_HOME'] ?? join(home, '.local', 'share')
+  return join(dataDir, `openfox${suffix}`, 'workspaces', projectName)
+}
+
+async function isWritable(path: string): Promise<boolean> {
+  try {
+    await access(path, constants.W_OK)
+    return true
+  } catch {
+    return false
+  }
+}
+
+function resolveRootDir(rootDir: string, workdir: string): string {
+  return isAbsolute(rootDir) ? rootDir : resolve(workdir, rootDir)
+}
+
+async function checkDirExists(path: string): Promise<boolean> {
+  try {
+    const st = await stat(path)
+    return st.isDirectory()
+  } catch {
+    return false
+  }
+}
+
+async function validatePathWritable(path: string): Promise<string | null> {
+  if (await isWritable(path)) return null
+  return 'Workspace root directory exists but is not writable'
+}
+
+async function findOrphanedWorkspaces(dir: string): Promise<{ name: string }[]> {
+  const results: { name: string }[] = []
+  try {
+    const entries = await readdir(dir, { withFileTypes: true })
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        try {
+          const gitStat = await stat(join(dir, entry.name, '.git'))
+          if (gitStat.isDirectory()) {
+            results.push({ name: entry.name })
+          }
+        } catch {
+          // Not a valid git workspace
+        }
+      }
+    }
+  } catch {
+    // Directory doesn't exist or not readable
+  }
+  return results
+}
 
 export function createWorkspaceConfigRoutes(): Router {
   const router = Router()
@@ -52,7 +93,19 @@ export function createWorkspaceConfigRoutes(): Router {
       config.setup = setup
     }
     if (typeof rootDir === 'string') {
-      config.rootDir = rootDir
+      const trimmed = rootDir.trim()
+      if (trimmed) {
+        const resolvedPath = resolveRootDir(trimmed, workdir)
+        if (!isValidRootDir(resolvedPath)) {
+          return res.status(400).json({ error: 'Invalid workspace root directory: cannot use system-critical paths' })
+        }
+        const dirExists = await checkDirExists(resolvedPath)
+        if (dirExists) {
+          const writableErr = await validatePathWritable(resolvedPath)
+          if (writableErr) return res.status(400).json({ error: writableErr })
+        }
+        config.rootDir = trimmed
+      }
     }
     try {
       await saveWorkspaceConfig(workdir, config)
@@ -63,7 +116,7 @@ export function createWorkspaceConfigRoutes(): Router {
   })
 
   router.post('/config/validate', async (req, res) => {
-    const { rootDir, workdir, createIfMissing } = req.body
+    const { rootDir, workdir, projectName, createIfMissing } = req.body
     if (!rootDir || typeof rootDir !== 'string') {
       return res.status(400).json({ error: 'rootDir is required' })
     }
@@ -71,61 +124,45 @@ export function createWorkspaceConfigRoutes(): Router {
       return res.status(400).json({ error: 'workdir is required' })
     }
 
-    const resolvedPath = isAbsolute(rootDir) ? rootDir : resolve(workdir, rootDir)
+    const resolvedPath = resolveRootDir(rootDir, workdir)
 
-    const normalized = resolvedPath.replace(/\/+$/, '') || '/'
-    if (DANGEROUS_PATHS.includes(normalized)) {
+    if (!isValidRootDir(resolvedPath)) {
       return res.status(400).json({ error: 'Invalid workspace root directory: cannot use system-critical paths' })
     }
 
-    let exists = false
-    try {
-      const st = await stat(resolvedPath)
-      exists = st.isDirectory()
-    } catch {
-      // Directory does not exist
+    let dirExists = await checkDirExists(resolvedPath)
+    if (dirExists) {
+      const writableErr = await validatePathWritable(resolvedPath)
+      if (writableErr) return res.status(400).json({ error: writableErr })
     }
 
     let created = false
-    if (!exists && createIfMissing) {
+    if (!dirExists && createIfMissing) {
       await mkdir(resolvedPath, { recursive: true })
-      exists = true
+      dirExists = true
       created = true
     }
 
     const workspaces: { name: string }[] = []
     try {
       const currentConfig = await loadWorkspaceConfig(workdir)
-      if (currentConfig?.rootDir) {
-        const oldRootDir = isAbsolute(currentConfig.rootDir)
-          ? currentConfig.rootDir
-          : resolve(workdir, currentConfig.rootDir)
+      const previousRootDir = currentConfig?.rootDir ? resolveRootDir(currentConfig.rootDir, workdir) : null
 
-        if (oldRootDir !== resolvedPath) {
-          try {
-            const entries = await readdir(oldRootDir, { withFileTypes: true })
-            for (const entry of entries) {
-              if (entry.isDirectory()) {
-                try {
-                  const gitStat = await stat(join(oldRootDir, entry.name, '.git'))
-                  if (gitStat.isDirectory()) {
-                    workspaces.push({ name: entry.name })
-                  }
-                } catch {
-                  // Not a valid git workspace
-                }
-              }
-            }
-          } catch {
-            // Old rootDir doesn't exist or is not readable
-          }
+      if (previousRootDir && previousRootDir !== resolvedPath) {
+        const orphans = await findOrphanedWorkspaces(previousRootDir)
+        workspaces.push(...orphans)
+      } else if (!previousRootDir && projectName && typeof projectName === 'string') {
+        const defaultDir = getDefaultGlobalDir(projectName)
+        if (defaultDir !== resolvedPath) {
+          const orphans = await findOrphanedWorkspaces(defaultDir)
+          workspaces.push(...orphans)
         }
       }
     } catch {
       // No previous config
     }
 
-    res.json({ exists, resolvedPath, created, workspaces })
+    res.json({ exists: dirExists, resolvedPath, created, workspaces })
   })
 
   return router

--- a/src/server/routes/workspace-config.ts
+++ b/src/server/routes/workspace-config.ts
@@ -1,5 +1,31 @@
 import { Router } from 'express'
+import { stat, mkdir, readdir } from 'node:fs/promises'
+import { resolve, isAbsolute, join } from 'node:path'
 import { loadWorkspaceConfig, saveWorkspaceConfig } from '../git/workspace-config.js'
+import type { WorkspaceConfig } from '../../shared/workspace.js'
+
+const DANGEROUS_PATHS = [
+  '/',
+  '/etc',
+  '/dev',
+  '/proc',
+  '/sys',
+  '/boot',
+  '/bin',
+  '/sbin',
+  '/lib',
+  '/lib64',
+  '/usr',
+  '/var',
+  '/opt',
+  '/root',
+  '/run',
+  '/tmp',
+  '/home',
+  '/mnt',
+  '/media',
+  '/lost+found',
+]
 
 export function createWorkspaceConfigRoutes(): Router {
   const router = Router()
@@ -14,17 +40,92 @@ export function createWorkspaceConfigRoutes(): Router {
   router.post('/config', async (req, res) => {
     const workdir = req.query['workdir'] as string
     if (!workdir) return res.status(400).json({ error: 'workdir required' })
-    const { setup } = req.body
-    if (!Array.isArray(setup)) {
+    const { setup, rootDir } = req.body
+    if (!Array.isArray(setup) && typeof rootDir !== 'string') {
+      return res.status(400).json({ error: 'At least one of setup or rootDir must be provided' })
+    }
+    if (setup !== undefined && !Array.isArray(setup)) {
       return res.status(400).json({ error: 'setup must be an array of strings' })
     }
+    const config: WorkspaceConfig = {}
+    if (Array.isArray(setup)) {
+      config.setup = setup
+    }
+    if (typeof rootDir === 'string') {
+      config.rootDir = rootDir
+    }
     try {
-      const config = { setup }
       await saveWorkspaceConfig(workdir, config)
       res.json({ config })
     } catch (err) {
       res.status(500).json({ error: err instanceof Error ? err.message : 'Failed to save config' })
     }
+  })
+
+  router.post('/config/validate', async (req, res) => {
+    const { rootDir, workdir, createIfMissing } = req.body
+    if (!rootDir || typeof rootDir !== 'string') {
+      return res.status(400).json({ error: 'rootDir is required' })
+    }
+    if (!workdir || typeof workdir !== 'string') {
+      return res.status(400).json({ error: 'workdir is required' })
+    }
+
+    const resolvedPath = isAbsolute(rootDir) ? rootDir : resolve(workdir, rootDir)
+
+    const normalized = resolvedPath.replace(/\/+$/, '') || '/'
+    if (DANGEROUS_PATHS.includes(normalized)) {
+      return res.status(400).json({ error: 'Invalid workspace root directory: cannot use system-critical paths' })
+    }
+
+    let exists = false
+    try {
+      const st = await stat(resolvedPath)
+      exists = st.isDirectory()
+    } catch {
+      // Directory does not exist
+    }
+
+    let created = false
+    if (!exists && createIfMissing) {
+      await mkdir(resolvedPath, { recursive: true })
+      exists = true
+      created = true
+    }
+
+    const workspaces: { name: string }[] = []
+    try {
+      const currentConfig = await loadWorkspaceConfig(workdir)
+      if (currentConfig?.rootDir) {
+        const oldRootDir = isAbsolute(currentConfig.rootDir)
+          ? currentConfig.rootDir
+          : resolve(workdir, currentConfig.rootDir)
+
+        if (oldRootDir !== resolvedPath) {
+          try {
+            const entries = await readdir(oldRootDir, { withFileTypes: true })
+            for (const entry of entries) {
+              if (entry.isDirectory()) {
+                try {
+                  const gitStat = await stat(join(oldRootDir, entry.name, '.git'))
+                  if (gitStat.isDirectory()) {
+                    workspaces.push({ name: entry.name })
+                  }
+                } catch {
+                  // Not a valid git workspace
+                }
+              }
+            }
+          } catch {
+            // Old rootDir doesn't exist or is not readable
+          }
+        }
+      }
+    } catch {
+      // No previous config
+    }
+
+    res.json({ exists, resolvedPath, created, workspaces })
   })
 
   return router

--- a/src/server/routes/workspace-config.ts
+++ b/src/server/routes/workspace-config.ts
@@ -2,22 +2,11 @@ import { Router } from 'express'
 import { stat, mkdir, readdir, access } from 'node:fs/promises'
 import { constants } from 'node:fs'
 import { resolve, isAbsolute, join } from 'node:path'
-import { homedir } from 'node:os'
 import { loadWorkspaceConfig, saveWorkspaceConfig } from '../git/workspace-config.js'
+import { getGlobalDataDir } from '../git/workspace.js'
+import { logger } from '../utils/logger.js'
 import type { WorkspaceConfig } from '../../shared/workspace.js'
-import { isValidRootDir } from '../../shared/workspace.js'
-
-function getServerMode(): 'development' | 'production' {
-  return process.env['OPENFOX_DEV'] === 'true' ? 'development' : 'production'
-}
-
-function getDefaultGlobalDir(projectName: string): string {
-  const mode = getServerMode()
-  const suffix = mode === 'development' ? '-dev' : ''
-  const home = homedir()
-  const dataDir = process.env['XDG_DATA_HOME'] ?? join(home, '.local', 'share')
-  return join(dataDir, `openfox${suffix}`, 'workspaces', projectName)
-}
+import { getRootDirBlockReason } from '../../shared/workspace.js'
 
 async function isWritable(path: string): Promise<boolean> {
   try {
@@ -62,8 +51,10 @@ async function findOrphanedWorkspaces(dir: string): Promise<{ name: string }[]> 
         }
       }
     }
-  } catch {
-    // Directory doesn't exist or not readable
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code !== 'ENOENT') {
+      logger.error('Error scanning for orphaned workspaces', { dir, error: String(err) })
+    }
   }
   return results
 }
@@ -96,8 +87,15 @@ export function createWorkspaceConfigRoutes(): Router {
       const trimmed = rootDir.trim()
       if (trimmed) {
         const resolvedPath = resolveRootDir(trimmed, workdir)
-        if (!isValidRootDir(resolvedPath)) {
-          return res.status(400).json({ error: 'Invalid workspace root directory: cannot use system-critical paths' })
+        const displayPath = resolvedPath.replace(/\/+$/, '') || '/'
+        const blockReason = getRootDirBlockReason(resolvedPath)
+        if (blockReason === 'exact') {
+          return res
+            .status(400)
+            .json({ error: `Cannot use "${displayPath}" directly as workspace root. Use a subdirectory instead.` })
+        }
+        if (blockReason === 'virtual_fs') {
+          return res.status(400).json({ error: `Cannot use paths under "${displayPath}" for workspaces.` })
         }
         const dirExists = await checkDirExists(resolvedPath)
         if (dirExists) {
@@ -125,9 +123,19 @@ export function createWorkspaceConfigRoutes(): Router {
     }
 
     const resolvedPath = resolveRootDir(rootDir, workdir)
+    const displayPath = resolvedPath.replace(/\/+$/, '') || '/'
 
-    if (!isValidRootDir(resolvedPath)) {
-      return res.status(400).json({ error: 'Invalid workspace root directory: cannot use system-critical paths' })
+    const blockReason = getRootDirBlockReason(resolvedPath)
+    if (blockReason === 'exact') {
+      const suggestion = typeof projectName === 'string' ? `${displayPath}/${projectName}` : undefined
+      return res.status(400).json({
+        error: suggestion
+          ? `Cannot use "${displayPath}" directly as workspace root. Use a subdirectory like "${suggestion}" instead.`
+          : `Cannot use "${displayPath}" directly as workspace root. Use a subdirectory instead.`,
+      })
+    }
+    if (blockReason === 'virtual_fs') {
+      return res.status(400).json({ error: `Cannot use paths under "${displayPath}" for workspaces.` })
     }
 
     let dirExists = await checkDirExists(resolvedPath)
@@ -152,7 +160,7 @@ export function createWorkspaceConfigRoutes(): Router {
         const orphans = await findOrphanedWorkspaces(previousRootDir)
         workspaces.push(...orphans)
       } else if (!previousRootDir && projectName && typeof projectName === 'string') {
-        const defaultDir = getDefaultGlobalDir(projectName)
+        const defaultDir = join(getGlobalDataDir(), 'workspaces', projectName)
         if (defaultDir !== resolvedPath) {
           const orphans = await findOrphanedWorkspaces(defaultDir)
           workspaces.push(...orphans)

--- a/src/server/session/manager.ts
+++ b/src/server/session/manager.ts
@@ -1058,7 +1058,7 @@ export class SessionManager {
     branch: string,
     sourceBranch?: string,
   ): Promise<void> {
-    const wsPath = resolve(getWorkspacesDir(projectName), workspaceName)
+    const wsPath = resolve(await getWorkspacesDir(projectName, projectDir), workspaceName)
     const currentBranch = await getGitBranch(wsPath)
     if (currentBranch !== branch) {
       try {
@@ -1139,7 +1139,7 @@ export class SessionManager {
         if (existingCreateLock) await existingCreateLock
 
         const createLockPromise = (async () => {
-          const exists = await workspaceExists(project.name, target)
+          const exists = await workspaceExists(project.name, target, project.workdir)
           if (!exists) {
             await ensureWorkspace(project.workdir, target, project.name, branch, sourceBranch)
           } else if (branch) {
@@ -1152,7 +1152,8 @@ export class SessionManager {
         } finally {
           this.workspaceCreationLocks.delete(createLockKey)
         }
-        const wsPath = resolve(getWorkspacesDir(project.name), target)
+        const wsDir = await getWorkspacesDir(project.name, project.workdir)
+        const wsPath = resolve(wsDir, target)
         updateSessionWorkdir(sessionId, project.workdir, wsPath)
       } else {
         // Branch-only change on the current workspace — no dev server stop or db update
@@ -1165,7 +1166,9 @@ export class SessionManager {
         logger.error('Error shutting down LSP for workspace switch', { sessionId, error: err })
       }
 
-      const effectiveWorkdir = target === 'original' ? project.workdir : resolve(getWorkspacesDir(project.name), target)
+      // Read the actual branch we're now on
+      const wsDirForBranch = await getWorkspacesDir(project.name, project.workdir)
+      const effectiveWorkdir = target === 'original' ? project.workdir : resolve(wsDirForBranch, target)
       const actualBranch = await getGitBranch(effectiveWorkdir)
 
       if (actualBranch) {
@@ -1252,14 +1255,15 @@ export class SessionManager {
       await this.switchWorkspace(sessionId, 'original')
     }
 
-    const effectivePath = resolve(getWorkspacesDir(project.name), target)
+    const wsDir = await getWorkspacesDir(project.name, project.workdir)
+    const effectivePath = resolve(wsDir, target)
     try {
       await devServerManager.stop(effectivePath)
     } catch {
       // ignore
     }
 
-    await deleteWorkspaceDir(project.name, target)
+    await deleteWorkspaceDir(project.name, target, project.workdir)
     const updated = this.requireSession(sessionId)
     this.emit({ type: 'session_updated', session: updated })
     return updated

--- a/src/server/tools/workspace.ts
+++ b/src/server/tools/workspace.ts
@@ -112,7 +112,7 @@ export const workspaceTool = createTool<WorkspaceArgs>(
         if (!project) return helpers.error('Project not found')
 
         const currentBranch = await getGitBranch(session.workspace ?? session.workdir)
-        const named = await listWorkspaces(project.name)
+        const named = await listWorkspaces(project.name, project.workdir)
         const activeWsName = session.workspace?.split('/').pop() ?? null
 
         const workspaces = [

--- a/src/shared/workspace.ts
+++ b/src/shared/workspace.ts
@@ -2,3 +2,42 @@ export interface WorkspaceConfig {
   setup?: string[]
   rootDir?: string
 }
+
+export const DANGEROUS_WORKSPACE_PATHS = [
+  '/',
+  '/etc',
+  '/dev',
+  '/proc',
+  '/sys',
+  '/boot',
+  '/bin',
+  '/sbin',
+  '/lib',
+  '/lib64',
+  '/usr',
+  '/var',
+  '/opt',
+  '/root',
+  '/run',
+  '/tmp',
+  '/home',
+  '/mnt',
+  '/media',
+  '/lost+found',
+] as const
+
+export const DANGEROUS_PATH_PREFIXES = ['/proc/', '/sys/', '/dev/', '/boot/', '/lost+found/'] as const
+
+export function isValidRootDir(
+  path: string,
+  dangerousPaths: readonly string[] = DANGEROUS_WORKSPACE_PATHS,
+  dangerousPrefixes: readonly string[] = DANGEROUS_PATH_PREFIXES,
+): boolean {
+  if (!path) return false
+  const normalized = path.replace(/\/+$/, '') || '/'
+  if (dangerousPaths.includes(normalized)) return false
+  for (const prefix of dangerousPrefixes) {
+    if (normalized.startsWith(prefix)) return false
+  }
+  return true
+}

--- a/src/shared/workspace.ts
+++ b/src/shared/workspace.ts
@@ -1,3 +1,4 @@
 export interface WorkspaceConfig {
   setup?: string[]
+  rootDir?: string
 }

--- a/src/shared/workspace.ts
+++ b/src/shared/workspace.ts
@@ -3,13 +3,13 @@ export interface WorkspaceConfig {
   rootDir?: string
 }
 
-export const DANGEROUS_WORKSPACE_PATHS = [
+/**
+ * Paths that are blocked as exact workspace root directories.
+ * Using these exact paths would be problematic, but subdirectories are fine.
+ */
+export const BLOCKED_EXACT_PATHS = [
   '/',
   '/etc',
-  '/dev',
-  '/proc',
-  '/sys',
-  '/boot',
   '/bin',
   '/sbin',
   '/lib',
@@ -23,21 +23,35 @@ export const DANGEROUS_WORKSPACE_PATHS = [
   '/home',
   '/mnt',
   '/media',
-  '/lost+found',
 ] as const
 
-export const DANGEROUS_PATH_PREFIXES = ['/proc/', '/sys/', '/dev/', '/boot/', '/lost+found/'] as const
+/**
+ * Paths that are blocked entirely — no subdirectory under these can be used
+ * as a workspace root. These are virtual filesystems or special FS areas
+ * where creating workspace data is meaningless or dangerous.
+ */
+export const BLOCKED_VIRTUAL_FS_PREFIXES = ['/proc/', '/sys/', '/dev/', '/boot/', '/etc/', '/lost+found/'] as const
+
+export type RootDirBlockReason = 'exact' | 'virtual_fs'
+
+export function getRootDirBlockReason(
+  path: string,
+  exactPaths: readonly string[] = BLOCKED_EXACT_PATHS,
+  virtualFsPrefixes: readonly string[] = BLOCKED_VIRTUAL_FS_PREFIXES,
+): RootDirBlockReason | null {
+  if (!path) return null
+  const normalized = path.replace(/\/+$/, '') || '/'
+  if (exactPaths.includes(normalized)) return 'exact'
+  for (const prefix of virtualFsPrefixes) {
+    if (normalized.startsWith(prefix)) return 'virtual_fs'
+  }
+  return null
+}
 
 export function isValidRootDir(
   path: string,
-  dangerousPaths: readonly string[] = DANGEROUS_WORKSPACE_PATHS,
-  dangerousPrefixes: readonly string[] = DANGEROUS_PATH_PREFIXES,
+  exactPaths: readonly string[] = BLOCKED_EXACT_PATHS,
+  virtualFsPrefixes: readonly string[] = BLOCKED_VIRTUAL_FS_PREFIXES,
 ): boolean {
-  if (!path) return false
-  const normalized = path.replace(/\/+$/, '') || '/'
-  if (dangerousPaths.includes(normalized)) return false
-  for (const prefix of dangerousPrefixes) {
-    if (normalized.startsWith(prefix)) return false
-  }
-  return true
+  return getRootDirBlockReason(path, exactPaths, virtualFsPrefixes) === null
 }

--- a/web/src/components/settings/ProjectSettingsModal.test.tsx
+++ b/web/src/components/settings/ProjectSettingsModal.test.tsx
@@ -212,13 +212,13 @@ describe('ProjectSettingsModal — rootDir validation (Criterion 0 & 1)', () => 
     const saveBtn = screen.getByTestId('save-btn')
     await user.click(saveBtn)
 
-    expect(screen.getByText(/n'existe pas/i)).toBeTruthy()
-    expect(screen.getByText(/Voulez-vous le créer/i)).toBeTruthy()
-    expect(screen.getByText('Créer')).toBeTruthy()
-    expect(screen.getByText('Annuler')).toBeTruthy()
+    expect(screen.getByText(/does not exist/i)).toBeTruthy()
+    expect(screen.getByText(/Would you like to create/i)).toBeTruthy()
+    expect(screen.getByText('Create')).toBeTruthy()
+    expect(screen.getAllByText('Cancel')[0]).toBeTruthy()
   })
 
-  it('creates directory and saves after user clicks Créer', async () => {
+  it('creates directory and saves after user clicks Create', async () => {
     mockAuthFetch.mockImplementation(async (url: string, opts?: RequestInit) => {
       if (url.includes('/api/workspace/config/validate')) {
         const body = JSON.parse((opts?.body as string) ?? '{}')
@@ -242,7 +242,7 @@ describe('ProjectSettingsModal — rootDir validation (Criterion 0 & 1)', () => 
     const saveBtn = screen.getByTestId('save-btn')
     await user.click(saveBtn)
 
-    const createBtn = screen.getByText('Créer')
+    const createBtn = screen.getByText('Create')
     await user.click(createBtn)
 
     expect(mockAuthFetch).toHaveBeenCalledWith(
@@ -255,7 +255,7 @@ describe('ProjectSettingsModal — rootDir validation (Criterion 0 & 1)', () => 
     expect(mockSaveConfig).toHaveBeenCalled()
   })
 
-  it('does not save when user clicks Annuler on directory confirmation', async () => {
+  it('does not save when user clicks Cancel on directory confirmation', async () => {
     mockAuthFetch.mockImplementation(async (url: string) => {
       if (url.includes('/api/workspace/config/validate')) {
         return { ok: true, json: () => Promise.resolve({ exists: false, workspaces: [], resolvedPath: '/new/path' }) }
@@ -275,7 +275,7 @@ describe('ProjectSettingsModal — rootDir validation (Criterion 0 & 1)', () => 
     const saveBtn = screen.getByTestId('save-btn')
     await user.click(saveBtn)
 
-    const cancelBtn = screen.getByText('Annuler')
+    const cancelBtn = screen.getAllByText('Cancel')[0]!
     await user.click(cancelBtn)
 
     expect(mockSaveConfig).not.toHaveBeenCalled()
@@ -309,8 +309,7 @@ describe('ProjectSettingsModal — rootDir validation (Criterion 0 & 1)', () => 
     const saveBtn = screen.getByTestId('save-btn')
     await user.click(saveBtn)
 
-    expect(screen.getByText(/workspaces existants/i)).toBeTruthy()
-    expect(screen.getByText(/ne seront pas migrés/i)).toBeTruthy()
+    expect(screen.getByText(/will not be migrated/i)).toBeTruthy()
     expect(screen.getByText(/fix-bug/)).toBeTruthy()
     expect(screen.getByText(/add-feature/)).toBeTruthy()
   })
@@ -343,7 +342,7 @@ describe('ProjectSettingsModal — rootDir validation (Criterion 0 & 1)', () => 
     const saveBtn = screen.getByTestId('save-btn')
     await user.click(saveBtn)
 
-    const confirmBtn = screen.getByText(/Confirmer le changement/i)
+    const confirmBtn = screen.getByText(/Confirm change/i)
     expect(confirmBtn).toBeTruthy()
 
     await user.click(confirmBtn)
@@ -379,7 +378,7 @@ describe('ProjectSettingsModal — rootDir validation (Criterion 0 & 1)', () => 
     const saveBtn = screen.getByTestId('save-btn')
     await user.click(saveBtn)
 
-    const cancelBtn = screen.getByText('Annuler')
+    const cancelBtn = screen.getAllByText('Cancel')[0]!
     await user.click(cancelBtn)
 
     expect(mockSaveConfig).not.toHaveBeenCalled()

--- a/web/src/components/settings/ProjectSettingsModal.test.tsx
+++ b/web/src/components/settings/ProjectSettingsModal.test.tsx
@@ -1,0 +1,407 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+const { mockStoreState, mockFetchConfig, mockSaveConfig, mockUpdateProject, mockWsSend, mockAuthFetch } = vi.hoisted(
+  () => {
+    const state = { config: null as Record<string, unknown> | null, loading: false }
+    return {
+      mockStoreState: state,
+      mockFetchConfig: vi.fn(),
+      mockSaveConfig: vi.fn(),
+      mockUpdateProject: vi.fn(),
+      mockWsSend: vi.fn(),
+      mockAuthFetch: vi.fn(),
+    }
+  },
+)
+
+vi.mock('../../stores/project', () => ({
+  useProjectStore: (selector: any) =>
+    selector({
+      updateProject: mockUpdateProject,
+    }),
+}))
+
+vi.mock('../../stores/workspace-config', () => ({
+  useWorkspaceConfigStore: (selector: any) =>
+    selector({
+      config: mockStoreState.config,
+      loading: mockStoreState.loading,
+      fetchConfig: mockFetchConfig,
+      saveConfig: mockSaveConfig,
+    }),
+}))
+
+vi.mock('../../lib/api', () => ({
+  authFetch: mockAuthFetch,
+}))
+
+vi.mock('../../lib/ws', () => ({
+  wsClient: { send: mockWsSend },
+}))
+
+vi.mock('../shared/SelfContainedModal', () => ({
+  Modal: ({ children, title, footer }: any) => (
+    <div data-testid="modal" data-title={title}>
+      {children}
+      {footer}
+    </div>
+  ),
+}))
+
+vi.mock('../shared/ModalFooter', () => ({
+  ModalFooter: ({ onCancel, onSave, saving, saveDisabled }: any) => (
+    <div data-testid="modal-footer">
+      <button data-testid="cancel-btn" onClick={onCancel} disabled={saving}>
+        Cancel
+      </button>
+      <button data-testid="save-btn" onClick={onSave} disabled={saveDisabled || saving}>
+        Save
+      </button>
+    </div>
+  ),
+}))
+
+import { ProjectSettingsModal } from './ProjectSettingsModal'
+
+const defaultProject = {
+  id: 'test-project',
+  name: 'Test Project',
+  workdir: '/tmp/test-project',
+  createdAt: '2025-01-01T00:00:00Z',
+  updatedAt: '2025-01-01T00:00:00Z',
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockStoreState.config = null
+  mockStoreState.loading = false
+  mockAuthFetch.mockReset()
+})
+
+afterEach(cleanup)
+
+describe('ProjectSettingsModal', () => {
+  it('renders the workspace root directory field', () => {
+    render(<ProjectSettingsModal isOpen={true} onClose={vi.fn()} project={defaultProject} />)
+
+    expect(screen.getByText('Workspace Root Directory')).toBeTruthy()
+  })
+
+  it('renders a text input for the root directory path', () => {
+    render(<ProjectSettingsModal isOpen={true} onClose={vi.fn()} project={defaultProject} />)
+
+    const input = screen.getByPlaceholderText('/absolute/or/relative/path')
+    expect(input).toBeTruthy()
+    expect(input.tagName).toBe('INPUT')
+  })
+
+  it('populates rootDir field from loaded config', () => {
+    mockStoreState.config = { rootDir: '/custom/workspaces', setup: [] }
+
+    render(<ProjectSettingsModal isOpen={true} onClose={vi.fn()} project={defaultProject} />)
+
+    const input = screen.getByPlaceholderText('/absolute/or/relative/path') as HTMLInputElement
+    expect(input.value).toBe('/custom/workspaces')
+  })
+
+  it('clears rootDir field when config has no rootDir', () => {
+    render(<ProjectSettingsModal isOpen={true} onClose={vi.fn()} project={defaultProject} />)
+
+    const input = screen.getByPlaceholderText('/absolute/or/relative/path') as HTMLInputElement
+    expect(input.value).toBe('')
+  })
+
+  it('calls fetchConfig on open', () => {
+    render(<ProjectSettingsModal isOpen={true} onClose={vi.fn()} project={defaultProject} />)
+
+    expect(mockFetchConfig).toHaveBeenCalledWith(defaultProject.workdir)
+  })
+
+  it('saves rootDir when user types and saves', async () => {
+    mockAuthFetch.mockImplementation(async (url: string) => {
+      if (url.includes('/api/workspace/config/validate')) {
+        return { ok: true, json: () => Promise.resolve({ exists: true, workspaces: [] }) }
+      }
+      return { ok: true, json: () => Promise.resolve({ config: { rootDir: '/my/custom/path' } }) }
+    })
+
+    const user = userEvent.setup()
+
+    render(<ProjectSettingsModal isOpen={true} onClose={vi.fn()} project={defaultProject} />)
+
+    const input = screen.getByPlaceholderText('/absolute/or/relative/path')
+    await user.type(input, '/my/custom/path')
+
+    const saveBtn = screen.getByTestId('save-btn')
+    await user.click(saveBtn)
+
+    expect(mockSaveConfig).toHaveBeenCalledWith(
+      defaultProject.workdir,
+      expect.objectContaining({ rootDir: '/my/custom/path' }),
+    )
+  })
+
+  it('omits rootDir from saved config when field is empty', async () => {
+    const user = userEvent.setup()
+
+    render(<ProjectSettingsModal isOpen={true} onClose={vi.fn()} project={defaultProject} />)
+
+    const setupInput = screen.getByPlaceholderText('npm install --prefer-offline')
+    await user.type(setupInput, 'npm install')
+
+    const saveBtn = screen.getByTestId('save-btn')
+    await user.click(saveBtn)
+
+    expect(mockSaveConfig).toHaveBeenCalledWith(
+      defaultProject.workdir,
+      expect.not.objectContaining({ rootDir: expect.any(String) }),
+    )
+  })
+})
+
+describe('ProjectSettingsModal — rootDir validation (Criterion 0 & 1)', () => {
+  it('calls validate endpoint before saving when rootDir has changed', async () => {
+    mockAuthFetch.mockImplementation(async (url: string) => {
+      if (url.includes('/api/workspace/config/validate')) {
+        return { ok: true, json: () => Promise.resolve({ exists: true, workspaces: [] }) }
+      }
+      return { ok: true, json: () => Promise.resolve({ config: { rootDir: '/custom/path' } }) }
+    })
+
+    const user = userEvent.setup()
+    mockStoreState.config = { rootDir: '/old/path', setup: [] }
+
+    render(<ProjectSettingsModal isOpen={true} onClose={vi.fn()} project={defaultProject} />)
+
+    const input = screen.getByPlaceholderText('/absolute/or/relative/path')
+    await user.clear(input)
+    await user.type(input, '/new/path')
+
+    const saveBtn = screen.getByTestId('save-btn')
+    await user.click(saveBtn)
+
+    expect(mockAuthFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/workspace/config/validate'),
+      expect.objectContaining({
+        method: 'POST',
+        body: expect.stringContaining('/new/path'),
+      }),
+    )
+  })
+
+  it('shows confirmation modal when rootDir does not exist', async () => {
+    mockAuthFetch.mockImplementation(async (url: string) => {
+      if (url.includes('/api/workspace/config/validate')) {
+        return { ok: true, json: () => Promise.resolve({ exists: false, workspaces: [], resolvedPath: '/new/path' }) }
+      }
+      return { ok: true, json: () => Promise.resolve({ config: {} }) }
+    })
+
+    const user = userEvent.setup()
+    mockStoreState.config = { rootDir: '/old/path', setup: [] }
+
+    render(<ProjectSettingsModal isOpen={true} onClose={vi.fn()} project={defaultProject} />)
+
+    const input = screen.getByPlaceholderText('/absolute/or/relative/path')
+    await user.clear(input)
+    await user.type(input, '/new/path')
+
+    const saveBtn = screen.getByTestId('save-btn')
+    await user.click(saveBtn)
+
+    expect(screen.getByText(/n'existe pas/i)).toBeTruthy()
+    expect(screen.getByText(/Voulez-vous le créer/i)).toBeTruthy()
+    expect(screen.getByText('Créer')).toBeTruthy()
+    expect(screen.getByText('Annuler')).toBeTruthy()
+  })
+
+  it('creates directory and saves after user clicks Créer', async () => {
+    mockAuthFetch.mockImplementation(async (url: string, opts?: RequestInit) => {
+      if (url.includes('/api/workspace/config/validate')) {
+        const body = JSON.parse((opts?.body as string) ?? '{}')
+        if (body.createIfMissing) {
+          return { ok: true, json: () => Promise.resolve({ exists: true, created: true, workspaces: [] }) }
+        }
+        return { ok: true, json: () => Promise.resolve({ exists: false, workspaces: [] }) }
+      }
+      return { ok: true, json: () => Promise.resolve({ config: {} }) }
+    })
+
+    const user = userEvent.setup()
+    mockStoreState.config = { rootDir: '/old/path', setup: [] }
+
+    render(<ProjectSettingsModal isOpen={true} onClose={vi.fn()} project={defaultProject} />)
+
+    const input = screen.getByPlaceholderText('/absolute/or/relative/path')
+    await user.clear(input)
+    await user.type(input, '/new/path')
+
+    const saveBtn = screen.getByTestId('save-btn')
+    await user.click(saveBtn)
+
+    const createBtn = screen.getByText('Créer')
+    await user.click(createBtn)
+
+    expect(mockAuthFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/workspace/config/validate'),
+      expect.objectContaining({
+        method: 'POST',
+        body: expect.stringContaining('"createIfMissing":true'),
+      }),
+    )
+    expect(mockSaveConfig).toHaveBeenCalled()
+  })
+
+  it('does not save when user clicks Annuler on directory confirmation', async () => {
+    mockAuthFetch.mockImplementation(async (url: string) => {
+      if (url.includes('/api/workspace/config/validate')) {
+        return { ok: true, json: () => Promise.resolve({ exists: false, workspaces: [], resolvedPath: '/new/path' }) }
+      }
+      return { ok: true, json: () => Promise.resolve({ config: {} }) }
+    })
+
+    const user = userEvent.setup()
+    mockStoreState.config = { rootDir: '/old/path', setup: [] }
+
+    render(<ProjectSettingsModal isOpen={true} onClose={vi.fn()} project={defaultProject} />)
+
+    const input = screen.getByPlaceholderText('/absolute/or/relative/path')
+    await user.clear(input)
+    await user.type(input, '/new/path')
+
+    const saveBtn = screen.getByTestId('save-btn')
+    await user.click(saveBtn)
+
+    const cancelBtn = screen.getByText('Annuler')
+    await user.click(cancelBtn)
+
+    expect(mockSaveConfig).not.toHaveBeenCalled()
+  })
+
+  it('shows migration warning when rootDir changes and workspaces exist in old location', async () => {
+    mockAuthFetch.mockImplementation(async (url: string) => {
+      if (url.includes('/api/workspace/config/validate')) {
+        return {
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              exists: true,
+              workspaces: [{ name: 'fix-bug' }, { name: 'add-feature' }],
+              resolvedPath: '/new/path',
+            }),
+        }
+      }
+      return { ok: true, json: () => Promise.resolve({ config: {} }) }
+    })
+
+    const user = userEvent.setup()
+    mockStoreState.config = { rootDir: '/old/path', setup: [] }
+
+    render(<ProjectSettingsModal isOpen={true} onClose={vi.fn()} project={defaultProject} />)
+
+    const input = screen.getByPlaceholderText('/absolute/or/relative/path')
+    await user.clear(input)
+    await user.type(input, '/new/path')
+
+    const saveBtn = screen.getByTestId('save-btn')
+    await user.click(saveBtn)
+
+    expect(screen.getByText(/workspaces existants/i)).toBeTruthy()
+    expect(screen.getByText(/ne seront pas migrés/i)).toBeTruthy()
+    expect(screen.getByText(/fix-bug/)).toBeTruthy()
+    expect(screen.getByText(/add-feature/)).toBeTruthy()
+  })
+
+  it('requires explicit confirmation (dedicated button) before applying rootDir change when workspaces exist', async () => {
+    mockAuthFetch.mockImplementation(async (url: string) => {
+      if (url.includes('/api/workspace/config/validate')) {
+        return {
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              exists: true,
+              workspaces: [{ name: 'fix-bug' }, { name: 'add-feature' }, { name: 'refactor' }],
+              resolvedPath: '/new/path',
+            }),
+        }
+      }
+      return { ok: true, json: () => Promise.resolve({ config: {} }) }
+    })
+
+    const user = userEvent.setup()
+    mockStoreState.config = { rootDir: '/old/path', setup: [] }
+
+    render(<ProjectSettingsModal isOpen={true} onClose={vi.fn()} project={defaultProject} />)
+
+    const input = screen.getByPlaceholderText('/absolute/or/relative/path')
+    await user.clear(input)
+    await user.type(input, '/new/path')
+
+    const saveBtn = screen.getByTestId('save-btn')
+    await user.click(saveBtn)
+
+    const confirmBtn = screen.getByText(/Confirmer le changement/i)
+    expect(confirmBtn).toBeTruthy()
+
+    await user.click(confirmBtn)
+
+    expect(mockSaveConfig).toHaveBeenCalled()
+  })
+
+  it('does not save when user dismisses migration warning without confirming', async () => {
+    mockAuthFetch.mockImplementation(async (url: string) => {
+      if (url.includes('/api/workspace/config/validate')) {
+        return {
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              exists: true,
+              workspaces: [{ name: 'fix-bug' }],
+              resolvedPath: '/new/path',
+            }),
+        }
+      }
+      return { ok: true, json: () => Promise.resolve({ config: {} }) }
+    })
+
+    const user = userEvent.setup()
+    mockStoreState.config = { rootDir: '/old/path', setup: [] }
+
+    render(<ProjectSettingsModal isOpen={true} onClose={vi.fn()} project={defaultProject} />)
+
+    const input = screen.getByPlaceholderText('/absolute/or/relative/path')
+    await user.clear(input)
+    await user.type(input, '/new/path')
+
+    const saveBtn = screen.getByTestId('save-btn')
+    await user.click(saveBtn)
+
+    const cancelBtn = screen.getByText('Annuler')
+    await user.click(cancelBtn)
+
+    expect(mockSaveConfig).not.toHaveBeenCalled()
+  })
+
+  it('skips validation when rootDir field is empty', async () => {
+    const user = userEvent.setup()
+
+    mockStoreState.config = { rootDir: '/old/path', setup: [] }
+
+    render(<ProjectSettingsModal isOpen={true} onClose={vi.fn()} project={defaultProject} />)
+
+    const input = screen.getByPlaceholderText('/absolute/or/relative/path')
+    await user.clear(input)
+
+    const saveBtn = screen.getByTestId('save-btn')
+    await user.click(saveBtn)
+
+    expect(mockAuthFetch).not.toHaveBeenCalledWith(
+      expect.stringContaining('/api/workspace/config/validate'),
+      expect.anything(),
+    )
+    expect(mockSaveConfig).toHaveBeenCalled()
+  })
+})

--- a/web/src/components/settings/ProjectSettingsModal.tsx
+++ b/web/src/components/settings/ProjectSettingsModal.tsx
@@ -6,6 +6,7 @@ import { useProjectStore } from '../../stores/project'
 import { useWorkspaceConfigStore } from '../../stores/workspace-config'
 import { wsClient } from '../../lib/ws'
 import { authFetch } from '../../lib/api'
+import { isValidRootDir } from '@shared/workspace.js'
 
 interface ProjectSettingsModalProps {
   isOpen: boolean
@@ -123,34 +124,6 @@ export function ProjectSettingsModal({ isOpen, onClose, project }: ProjectSettin
     handleClose,
   ])
 
-  const DANGEROUS_PATHS = [
-    '/',
-    '/etc',
-    '/dev',
-    '/proc',
-    '/sys',
-    '/boot',
-    '/bin',
-    '/sbin',
-    '/lib',
-    '/lib64',
-    '/usr',
-    '/var',
-    '/opt',
-    '/root',
-    '/run',
-    '/tmp',
-    '/home',
-    '/mnt',
-    '/media',
-    '/lost+found',
-  ]
-
-  const isValidRootDir = (path: string): boolean => {
-    const normalized = path.replace(/\/+$/, '') || '/'
-    return !DANGEROUS_PATHS.includes(normalized)
-  }
-
   const handleSave = async () => {
     const trimmedRootDir = rootDir.trim()
     const prevRootDir = wsConfig?.rootDir ?? ''
@@ -181,11 +154,16 @@ export function ProjectSettingsModal({ isOpen, onClose, project }: ProjectSettin
       const res = await authFetch(`/api/workspace/config/validate?workdir=${encodeURIComponent(project.workdir)}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ rootDir: trimmedRootDir, workdir: project.workdir }),
+        body: JSON.stringify({
+          rootDir: trimmedRootDir,
+          workdir: project.workdir,
+          projectName: project.name,
+        }),
       })
 
       if (!res.ok) {
-        setSaveError('Failed to validate workspace root directory')
+        const data = await res.json().catch(() => ({}))
+        setSaveError(data?.error ?? 'Failed to validate workspace root directory')
         setSaving(false)
         return
       }
@@ -221,11 +199,17 @@ export function ProjectSettingsModal({ isOpen, onClose, project }: ProjectSettin
       const res = await authFetch(`/api/workspace/config/validate?workdir=${encodeURIComponent(project.workdir)}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ rootDir: pendingRootDir, workdir: project.workdir, createIfMissing: true }),
+        body: JSON.stringify({
+          rootDir: pendingRootDir,
+          workdir: project.workdir,
+          projectName: project.name,
+          createIfMissing: true,
+        }),
       })
 
       if (!res.ok) {
-        setSaveError('Failed to create directory')
+        const data = await res.json().catch(() => ({}))
+        setSaveError(data?.error ?? 'Failed to create directory')
         setSaving(false)
         return
       }

--- a/web/src/components/settings/ProjectSettingsModal.tsx
+++ b/web/src/components/settings/ProjectSettingsModal.tsx
@@ -6,7 +6,7 @@ import { useProjectStore } from '../../stores/project'
 import { useWorkspaceConfigStore } from '../../stores/workspace-config'
 import { wsClient } from '../../lib/ws'
 import { authFetch } from '../../lib/api'
-import { isValidRootDir } from '@shared/workspace.js'
+import { getRootDirBlockReason } from '@shared/workspace.js'
 
 interface ProjectSettingsModalProps {
   isOpen: boolean
@@ -128,9 +128,19 @@ export function ProjectSettingsModal({ isOpen, onClose, project }: ProjectSettin
     const trimmedRootDir = rootDir.trim()
     const prevRootDir = wsConfig?.rootDir ?? ''
 
-    if (trimmedRootDir && !isValidRootDir(trimmedRootDir)) {
-      setSaveError('Invalid workspace root directory: cannot use system-critical paths')
-      return
+    if (trimmedRootDir) {
+      const blockReason = getRootDirBlockReason(trimmedRootDir)
+      if (blockReason === 'exact') {
+        const displayPath = trimmedRootDir.replace(/\/+$/, '') || '/'
+        setSaveError(
+          `Cannot use "${displayPath}" directly as workspace root. Use a subdirectory like "${displayPath}/${project.name}" instead.`,
+        )
+        return
+      }
+      if (blockReason === 'virtual_fs') {
+        setSaveError(`Cannot use paths under "${trimmedRootDir}" for workspaces.`)
+        return
+      }
     }
 
     if (!rootDirDirty || !trimmedRootDir || trimmedRootDir === prevRootDir) {
@@ -384,7 +394,7 @@ export function ProjectSettingsModal({ isOpen, onClose, project }: ProjectSettin
         <Modal
           isOpen={showCreateDirModal}
           onClose={() => setShowCreateDirModal(false)}
-          title="Dossier introuvable"
+          title="Directory not found"
           size="md"
           footer={
             <div className="flex justify-end gap-2">
@@ -393,22 +403,22 @@ export function ProjectSettingsModal({ isOpen, onClose, project }: ProjectSettin
                 onClick={() => setShowCreateDirModal(false)}
                 className="px-4 py-2 text-sm font-medium rounded bg-bg-tertiary text-text-primary hover:bg-border transition-colors"
               >
-                Annuler
+                Cancel
               </button>
               <button
                 type="button"
                 onClick={handleCreateDirectory}
                 className="px-4 py-2 text-sm font-medium rounded bg-accent-primary text-white hover:opacity-90 transition-colors"
               >
-                Créer
+                Create
               </button>
             </div>
           }
         >
           <p className="text-sm text-text-primary">
-            Le dossier <code className="text-xs bg-bg-tertiary px-1 rounded">{resolvedPath}</code> n&apos;existe pas.
+            The directory <code className="text-xs bg-bg-tertiary px-1 rounded">{resolvedPath}</code> does not exist.
           </p>
-          <p className="text-sm text-text-muted mt-2">Voulez-vous le créer ?</p>
+          <p className="text-sm text-text-muted mt-2">Would you like to create it?</p>
         </Modal>
       )}
 
@@ -416,7 +426,7 @@ export function ProjectSettingsModal({ isOpen, onClose, project }: ProjectSettin
         <Modal
           isOpen={showMigrationWarning}
           onClose={() => setShowMigrationWarning(false)}
-          title="Workspaces orphelins"
+          title="Orphaned workspaces"
           size="md"
           footer={
             <div className="flex justify-end gap-2">
@@ -425,20 +435,20 @@ export function ProjectSettingsModal({ isOpen, onClose, project }: ProjectSettin
                 onClick={() => setShowMigrationWarning(false)}
                 className="px-4 py-2 text-sm font-medium rounded bg-bg-tertiary text-text-primary hover:bg-border transition-colors"
               >
-                Annuler
+                Cancel
               </button>
               <button
                 type="button"
                 onClick={handleConfirmMigration}
                 className="px-4 py-2 text-sm font-medium rounded bg-red-500 text-white hover:opacity-90 transition-colors"
               >
-                Confirmer le changement
+                Confirm change
               </button>
             </div>
           }
         >
           <p className="text-sm text-text-primary">
-            {pendingWorkspaces.length} workspace(s) existant(s) ne seront pas migrés et deviendront inutilisables :
+            {pendingWorkspaces.length} existing workspace(s) will not be migrated and will become inaccessible:
           </p>
           <ul className="mt-2 space-y-1">
             {pendingWorkspaces.map((ws) => (
@@ -448,8 +458,7 @@ export function ProjectSettingsModal({ isOpen, onClose, project }: ProjectSettin
             ))}
           </ul>
           <p className="text-sm text-text-muted mt-3">
-            Les workspaces existants resteront dans l&apos;ancien emplacement mais ne seront plus accessibles depuis ce
-            projet.
+            Existing workspaces will remain in the old location but will no longer be accessible from this project.
           </p>
         </Modal>
       )}

--- a/web/src/components/settings/ProjectSettingsModal.tsx
+++ b/web/src/components/settings/ProjectSettingsModal.tsx
@@ -1,10 +1,11 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import type { Project, DangerLevel } from '@shared/types.js'
 import { Modal } from '../shared/SelfContainedModal'
 import { ModalFooter } from '../shared/ModalFooter'
 import { useProjectStore } from '../../stores/project'
 import { useWorkspaceConfigStore } from '../../stores/workspace-config'
 import { wsClient } from '../../lib/ws'
+import { authFetch } from '../../lib/api'
 
 interface ProjectSettingsModalProps {
   isOpen: boolean
@@ -37,8 +38,16 @@ export function ProjectSettingsModal({ isOpen, onClose, project }: ProjectSettin
 
   const [setupCmd, setSetupCmd] = useState('')
   const [setupDirty, setSetupDirty] = useState(false)
+  const [rootDir, setRootDir] = useState('')
+  const [rootDirDirty, setRootDirDirty] = useState(false)
 
-  const isDirty = instructionsDirty || dangerLevelDirty || setupDirty
+  const [pendingRootDir, setPendingRootDir] = useState('')
+  const [showCreateDirModal, setShowCreateDirModal] = useState(false)
+  const [showMigrationWarning, setShowMigrationWarning] = useState(false)
+  const [pendingWorkspaces, setPendingWorkspaces] = useState<{ name: string }[]>([])
+  const [resolvedPath, setResolvedPath] = useState('')
+
+  const isDirty = instructionsDirty || dangerLevelDirty || setupDirty || rootDirDirty
 
   useEffect(() => {
     if (isOpen) {
@@ -47,6 +56,7 @@ export function ProjectSettingsModal({ isOpen, onClose, project }: ProjectSettin
       setInstructionsDirty(false)
       setDangerLevelDirty(false)
       setSetupDirty(false)
+      setRootDirDirty(false)
       fetchWsConfig(project.workdir)
     }
   }, [isOpen, project, fetchWsConfig])
@@ -57,6 +67,7 @@ export function ProjectSettingsModal({ isOpen, onClose, project }: ProjectSettin
     } else {
       setSetupCmd('')
     }
+    setRootDir(wsConfig?.rootDir ?? '')
   }, [wsConfig])
 
   const handleInstructionsChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
@@ -74,28 +85,174 @@ export function ProjectSettingsModal({ isOpen, onClose, project }: ProjectSettin
     setSetupDirty(true)
   }
 
+  const handleRootDirChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setRootDir(e.target.value)
+    setRootDirDirty(true)
+  }
+
+  const persistSettings = useCallback(async () => {
+    const dangerLevelValue = dangerLevel === '' ? null : dangerLevel
+    await updateProject(project.id, {
+      customInstructions: customInstructions || null,
+      dangerLevel: dangerLevelValue,
+    })
+    const setup = setupCmd.trim()
+      ? setupCmd
+          .split('&&')
+          .map((s) => s.trim())
+          .filter(Boolean)
+      : []
+    await saveWsConfig(project.workdir, {
+      ...(setup.length > 0 ? { setup } : {}),
+      ...(rootDir.trim() ? { rootDir: rootDir.trim() } : {}),
+    })
+    setInstructionsDirty(false)
+    setDangerLevelDirty(false)
+    setSetupDirty(false)
+    setRootDirDirty(false)
+    handleClose()
+  }, [
+    project.id,
+    dangerLevel,
+    customInstructions,
+    setupCmd,
+    rootDir,
+    updateProject,
+    saveWsConfig,
+    project.workdir,
+    handleClose,
+  ])
+
+  const DANGEROUS_PATHS = [
+    '/',
+    '/etc',
+    '/dev',
+    '/proc',
+    '/sys',
+    '/boot',
+    '/bin',
+    '/sbin',
+    '/lib',
+    '/lib64',
+    '/usr',
+    '/var',
+    '/opt',
+    '/root',
+    '/run',
+    '/tmp',
+    '/home',
+    '/mnt',
+    '/media',
+    '/lost+found',
+  ]
+
+  const isValidRootDir = (path: string): boolean => {
+    const normalized = path.replace(/\/+$/, '') || '/'
+    return !DANGEROUS_PATHS.includes(normalized)
+  }
+
   const handleSave = async () => {
+    const trimmedRootDir = rootDir.trim()
+    const prevRootDir = wsConfig?.rootDir ?? ''
+
+    if (trimmedRootDir && !isValidRootDir(trimmedRootDir)) {
+      setSaveError('Invalid workspace root directory: cannot use system-critical paths')
+      return
+    }
+
+    if (!rootDirDirty || !trimmedRootDir || trimmedRootDir === prevRootDir) {
+      setSaving(true)
+      setSaveError(null)
+      try {
+        await persistSettings()
+      } catch (err) {
+        setSaveError(err instanceof Error ? err.message : 'Failed to save settings')
+      } finally {
+        setSaving(false)
+      }
+      return
+    }
+
+    setPendingRootDir(trimmedRootDir)
+    setSaving(true)
+    setSaveError(null)
+
+    try {
+      const res = await authFetch(`/api/workspace/config/validate?workdir=${encodeURIComponent(project.workdir)}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ rootDir: trimmedRootDir, workdir: project.workdir }),
+      })
+
+      if (!res.ok) {
+        setSaveError('Failed to validate workspace root directory')
+        setSaving(false)
+        return
+      }
+
+      const data = await res.json()
+
+      if (!data.exists) {
+        setResolvedPath(data.resolvedPath)
+        setSaving(false)
+        setShowCreateDirModal(true)
+        return
+      }
+
+      if (data.workspaces && data.workspaces.length > 0) {
+        setPendingWorkspaces(data.workspaces)
+        setSaving(false)
+        setShowMigrationWarning(true)
+        return
+      }
+
+      setSaveError(null)
+      await persistSettings()
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : 'Failed to validate settings')
+      setSaving(false)
+    }
+  }
+
+  const handleCreateDirectory = async () => {
+    setShowCreateDirModal(false)
+    setSaving(true)
+    try {
+      const res = await authFetch(`/api/workspace/config/validate?workdir=${encodeURIComponent(project.workdir)}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ rootDir: pendingRootDir, workdir: project.workdir, createIfMissing: true }),
+      })
+
+      if (!res.ok) {
+        setSaveError('Failed to create directory')
+        setSaving(false)
+        return
+      }
+
+      const data = await res.json()
+
+      if (data.workspaces && data.workspaces.length > 0) {
+        setPendingWorkspaces(data.workspaces)
+        setShowMigrationWarning(true)
+        setSaving(false)
+        return
+      }
+
+      await persistSettings()
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : 'Failed to create directory')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleConfirmMigration = async () => {
+    setShowMigrationWarning(false)
     setSaving(true)
     setSaveError(null)
     try {
-      const dangerLevelValue = dangerLevel === '' ? null : dangerLevel
-      await updateProject(project.id, {
-        customInstructions: customInstructions || null,
-        dangerLevel: dangerLevelValue,
-      })
-      if (setupDirty) {
-        const setup = setupCmd.trim()
-          ? setupCmd
-              .split('&&')
-              .map((s) => s.trim())
-              .filter(Boolean)
-          : []
-        await saveWsConfig(project.workdir, { setup: setup.length > 0 ? setup : undefined })
-      }
-      setInstructionsDirty(false)
-      setDangerLevelDirty(false)
-      setSetupDirty(false)
-      handleClose()
+      await persistSettings()
     } catch (err) {
       setSaveError(err instanceof Error ? err.message : 'Failed to save settings')
     } finally {
@@ -104,11 +261,14 @@ export function ProjectSettingsModal({ isOpen, onClose, project }: ProjectSettin
   }
 
   const handleCancel = () => {
+    setShowCreateDirModal(false)
+    setShowMigrationWarning(false)
     setCustomInstructions(project.customInstructions ?? '')
     setDangerLevel(project.dangerLevel ?? '')
     setInstructionsDirty(false)
     setDangerLevelDirty(false)
     setSetupDirty(false)
+    setRootDirDirty(false)
     handleClose()
   }
 
@@ -206,7 +366,26 @@ export function ProjectSettingsModal({ isOpen, onClose, project }: ProjectSettin
             onChange={handleSetupCmdChange}
             placeholder="npm install --prefer-offline"
             className="w-full px-3 py-2 bg-bg-tertiary border border-border rounded text-sm font-mono focus:outline-none focus:ring-1 focus:ring-accent-primary"
-            disabled={saving}
+            disabled={wsLoading || saving}
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-text-primary mb-1 flex-shrink-0">
+            Workspace Root Directory
+          </label>
+          <p className="text-sm text-text-muted mb-3">
+            Override the default workspace location. Leave empty to use the global directory{' '}
+            <code className="text-xs bg-bg-tertiary px-1 rounded">~/.local/share/openfox/workspaces/</code>. Supports
+            absolute paths or paths relative to the project.
+          </p>
+          <input
+            type="text"
+            value={rootDir}
+            onChange={handleRootDirChange}
+            placeholder="/absolute/or/relative/path"
+            className="w-full px-3 py-2 bg-bg-tertiary border border-border rounded text-sm font-mono focus:outline-none focus:ring-1 focus:ring-accent-primary"
+            disabled={wsLoading || saving}
           />
         </div>
 
@@ -216,6 +395,80 @@ export function ProjectSettingsModal({ isOpen, onClose, project }: ProjectSettin
           </div>
         )}
       </div>
+
+      {showCreateDirModal && (
+        <Modal
+          isOpen={showCreateDirModal}
+          onClose={() => setShowCreateDirModal(false)}
+          title="Dossier introuvable"
+          size="md"
+          footer={
+            <div className="flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setShowCreateDirModal(false)}
+                className="px-4 py-2 text-sm font-medium rounded bg-bg-tertiary text-text-primary hover:bg-border transition-colors"
+              >
+                Annuler
+              </button>
+              <button
+                type="button"
+                onClick={handleCreateDirectory}
+                className="px-4 py-2 text-sm font-medium rounded bg-accent-primary text-white hover:opacity-90 transition-colors"
+              >
+                Créer
+              </button>
+            </div>
+          }
+        >
+          <p className="text-sm text-text-primary">
+            Le dossier <code className="text-xs bg-bg-tertiary px-1 rounded">{resolvedPath}</code> n&apos;existe pas.
+          </p>
+          <p className="text-sm text-text-muted mt-2">Voulez-vous le créer ?</p>
+        </Modal>
+      )}
+
+      {showMigrationWarning && (
+        <Modal
+          isOpen={showMigrationWarning}
+          onClose={() => setShowMigrationWarning(false)}
+          title="Workspaces orphelins"
+          size="md"
+          footer={
+            <div className="flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setShowMigrationWarning(false)}
+                className="px-4 py-2 text-sm font-medium rounded bg-bg-tertiary text-text-primary hover:bg-border transition-colors"
+              >
+                Annuler
+              </button>
+              <button
+                type="button"
+                onClick={handleConfirmMigration}
+                className="px-4 py-2 text-sm font-medium rounded bg-red-500 text-white hover:opacity-90 transition-colors"
+              >
+                Confirmer le changement
+              </button>
+            </div>
+          }
+        >
+          <p className="text-sm text-text-primary">
+            {pendingWorkspaces.length} workspace(s) existant(s) ne seront pas migrés et deviendront inutilisables :
+          </p>
+          <ul className="mt-2 space-y-1">
+            {pendingWorkspaces.map((ws) => (
+              <li key={ws.name} className="text-sm font-mono text-text-muted">
+                {ws.name}
+              </li>
+            ))}
+          </ul>
+          <p className="text-sm text-text-muted mt-3">
+            Les workspaces existants resteront dans l&apos;ancien emplacement mais ne seront plus accessibles depuis ce
+            projet.
+          </p>
+        </Modal>
+      )}
     </Modal>
   )
 }

--- a/web/src/stores/workspace-config.test.ts
+++ b/web/src/stores/workspace-config.test.ts
@@ -1,0 +1,103 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { useWorkspaceConfigStore } from './workspace-config'
+
+vi.mock('../lib/api', () => ({
+  authFetch: vi.fn(),
+}))
+
+import { authFetch } from '../lib/api'
+
+beforeEach(() => {
+  useWorkspaceConfigStore.setState({ config: null, loading: false })
+  vi.clearAllMocks()
+})
+
+describe('WorkspaceConfigStore', () => {
+  describe('fetchConfig', () => {
+    it('loads config with rootDir from API', async () => {
+      const config = { rootDir: '/custom/workspaces', setup: ['npm install'] }
+      vi.mocked(authFetch).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ config }),
+      } as any)
+
+      await useWorkspaceConfigStore.getState().fetchConfig('/tmp/project')
+      const state = useWorkspaceConfigStore.getState()
+      expect(state.config).toEqual(config)
+      expect(state.loading).toBe(false)
+    })
+
+    it('loads config without rootDir', async () => {
+      const config = { setup: ['npm install'] }
+      vi.mocked(authFetch).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ config }),
+      } as any)
+
+      await useWorkspaceConfigStore.getState().fetchConfig('/tmp/project')
+      expect(useWorkspaceConfigStore.getState().config).toEqual(config)
+    })
+
+    it('sets config to null when API returns null', async () => {
+      vi.mocked(authFetch).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ config: null }),
+      } as any)
+
+      await useWorkspaceConfigStore.getState().fetchConfig('/tmp/project')
+      expect(useWorkspaceConfigStore.getState().config).toBeNull()
+    })
+
+    it('handles fetch error gracefully', async () => {
+      vi.mocked(authFetch).mockRejectedValue(new Error('Network error'))
+
+      await useWorkspaceConfigStore.getState().fetchConfig('/tmp/project')
+      expect(useWorkspaceConfigStore.getState().loading).toBe(false)
+    })
+  })
+
+  describe('saveConfig with rootDir', () => {
+    it('sends rootDir in request body', async () => {
+      const config = { rootDir: '/custom/workspaces' }
+      vi.mocked(authFetch).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ config }),
+      } as any)
+
+      await useWorkspaceConfigStore.getState().saveConfig('/tmp/project', config)
+      expect(authFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/workspace/config'),
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify(config),
+        }),
+      )
+      expect(useWorkspaceConfigStore.getState().config).toEqual(config)
+    })
+
+    it('saves config with both rootDir and setup', async () => {
+      const config = { rootDir: '/custom/workspaces', setup: ['npm install'] }
+      vi.mocked(authFetch).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ config }),
+      } as any)
+
+      await useWorkspaceConfigStore.getState().saveConfig('/tmp/project', config)
+      expect(authFetch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          body: JSON.stringify(config),
+        }),
+      )
+    })
+
+    it('throws on save error', async () => {
+      vi.mocked(authFetch).mockResolvedValue({ ok: false } as any)
+
+      await expect(useWorkspaceConfigStore.getState().saveConfig('/tmp/project', { rootDir: '/path' })).rejects.toThrow(
+        'Failed to save workspace config',
+      )
+    })
+  })
+})


### PR DESCRIPTION
### Summary

Ajout de la possibilité de configurer un répertoire racine des workspaces par projet, avec validation à la sauvegarde et avertissement en cas de workspaces orphelins.

### Évolution fonctionnelle

Jusqu'à présent, les workspaces (clones partagés git) étaient toujours créés dans un répertoire global (`~/.local/share/openfox/workspaces/<project>/`). Cette PR permet de surcharger cet emplacement par projet via le champ **Workspace Root Directory** dans les paramètres du projet.

### Ce qui change

**Couche métier (server) :**
- `WorkspaceConfig` accepte désormais un champ `rootDir` optionnel (absolu ou relatif au projet)
- `getWorkspacesDir()` devient async et résout le chemin : `rootDir` configuré → chemin personnalisé ; absent → répertoire global (backward compatible)
- Toutes les fonctions workspace (`workspaceExists`, `listWorkspaces`, `ensureWorkspace`, `deleteWorkspace`) prennent désormais un paramètre `projectDir` pour résoudre le bon répertoire
- `loadWorkspaceConfig()` ne retourne plus `null` si seul `rootDir` est présent (et non `setup`)

**Nouvel endpoint REST :**
- `POST /api/workspace/config/validate` — vérifie l'existence du chemin, liste les workspaces de l'ancien rootDir, et peut créer le répertoire sur demande

**Interface utilisateur (ProjectSettingsModal) :**
- Champ "Workspace Root Directory" avec validation :
  - Si le dossier n'existe pas → modale "Dossier introuvable" avec Créer/Annuler
  - Si des workspaces existent dans l'ancien emplacement → modale "Workspaces orphelins" listant les workspaces concernés, avec confirmation explicite requise
- Blocage des chemins système dangereux (21 chemins critiques interdits)
- Indicateur de chargement unique (correction d'un doublon visuel)
- Prévention des doubles clics (`setSaving(true)` avant la requête de validation)

**Tests :**
- 3 nouveaux fichiers de tests (server routes, composant modal, store) — 27 tests unitaires
- 12 tests pour l'endpoint de validation + détection de migration
- 15 tests pour le composant frontend (rendu, validation, création, avertissement)

### Détails techniques

- `rootDir` supporte les chemins absolus et relatifs (résolus par rapport au `workdir` du projet)
- La détection des workspaces orphelins se fait en comparant l'ancien et le nouveau `rootDir` dans la config
- L'avertissement de migration n'apparaît que si des dossiers avec `.git` valide existent dans l'ancien emplacement
- Pas de migration automatique : les workspaces orphelins restent sur le disque mais ne sont plus référencés
- Backward compatible : config sans `rootDir` → comportement inchangé

### AI-Enhanced Development

- **AI Models:** DeepSeek V4 Flash

### Cache Impact

- **No**