### PR TITLE
fix(package.json): add allowScripts for better-sqlite3

### DIFF
--- a/package.json
+++ b/package.json
@@ -180,5 +180,8 @@
     "minimatch": "10.2.5",
     "micromatch": "4.0.8",
     "@rollup/plugin-terser": "1.0.0"
+  },
+  "allowScripts": {
+    "better-sqlite3": true
   }
 }


### PR DESCRIPTION
### Summary

npm v12+ blocks dependency install scripts by default as a security hardening measure following recent supply chain attacks. Without allowScripts, users would have to manually approve better-sqlite3 (e.g. --allow-scripts=better-sqlite3) on systems like Debian 13.

This change adds the allowScripts field so better-sqlite3's native compilation runs automatically during `npm install -g openfox`.

### AI-Enhanced Development

Problem known, AI used only for supervised implementation

- **AI Models:** Qwopus3.6-27b

### Cache Impact

Does this PR affect anything cached — system prompts, tool definitions, skills, or other context?

- **No**
