### PR TITLE
fix: send version without 'v' prefix to prevent double-prefix in UI

### DIFF
--- a/src/server/routes/auto-update.test.ts
+++ b/src/server/routes/auto-update.test.ts
@@ -40,8 +40,8 @@ describe('Auto Update Routes', () => {
       if (cmd === 'git' && Array.isArray(args) && args[0] === 'fetch') {
         return makeMockChild({ stdout: '' })
       }
-      // git describe via bash -c returns just the tag name
-      if (cmd === 'bash' && Array.isArray(args) && args[0] === '-c' && args[1]?.includes('git describe')) {
+      // git describe returns just the tag name
+      if (cmd === 'git' && Array.isArray(args) && args[0] === 'describe') {
         return makeMockChild({ stdout: '1.2.3\n' })
       }
       return makeMockChild({ stdout: 'Updated: 1.2.3\n' })

--- a/src/server/routes/auto-update.ts
+++ b/src/server/routes/auto-update.ts
@@ -186,15 +186,16 @@ export function createAutoUpdateRoutes(options: AutoUpdateRoutesOptions = {}): R
       const latestVersion = latest.replace(/^v/, '')
       const isUpdateAvailable = currentVersion !== latestVersion
 
-      // Cache the result
+      // Cache the result (use latestVersion without 'v' prefix for consistency)
       const now = Date.now()
-      versionCache.data = { current, latest, isUpdateAvailable, isService }
+      versionCache.data = { current, latest: latestVersion, isUpdateAvailable, isService }
       versionCache.timestamp = now
 
-      res.json({ current, latest, isUpdateAvailable, isService })
+      res.json({ current, latest: latestVersion, isUpdateAvailable, isService })
     } catch (err) {
       logger.error('[auto-update] Error in version check', { error: err instanceof Error ? err.message : String(err) })
-      res.json({ current, latest: current, isUpdateAvailable: false, isService })
+      const currentVersion = isDev ? current.replace(/-dev$/, '') : current
+      res.json({ current, latest: currentVersion, isUpdateAvailable: false, isService })
     }
   })
 


### PR DESCRIPTION
### Summary

Fixes: 
<img width="392" height="102" alt="image" src="https://github.com/user-attachments/assets/0d1f79fc-eed6-4536-a1dd-ee055be59899" />

- Server now returns latestVersion (without 'v') instead of latest (with 'v')
- Frontend adds 'v' prefix when displaying, preventing 'vv2.0.77' bug
- Updated test mock to match git describe command signature

### AI-Enhanced Development

- **AI Models:**

Qwen 3.5 122B

### Cache Impact

**No**
