### PR TITLE
fix(web): support subpath deployments behind reverse proxies

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -2,12 +2,12 @@
 <html lang="en" class="dark">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/png" href="/assets/openfox.png" />
+    <link rel="icon" type="image/png" href="./assets/openfox.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, height=device-height" />
     <title>OpenFox</title>
   </head>
   <body class="bg-bg-primary text-text-primary font-mono">
     <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <script type="module" src="./src/main.tsx"></script>
   </body>
 </html>

--- a/web/src/components/AutoUpdateModal.tsx
+++ b/web/src/components/AutoUpdateModal.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import { Modal } from './shared/Modal'
 import { authFetch } from '../lib/api'
+import { appUrl } from '../lib/basePath'
 
 type ModalState = 'ready' | 'updating' | 'restarting' | 'complete' | 'failed'
 
@@ -21,7 +22,7 @@ export function AutoUpdateModal({ isOpen, onClose, versionInfo }: AutoUpdateModa
   // Auto-fetch only once when modal opens and no versionInfo provided
   useEffect(() => {
     if (!isOpen || versionInfo) return
-    fetch('/api/auto-update/check')
+    fetch(appUrl('/api/auto-update/check'))
       .then((res) => res.json())
       .then((data) => {
         setModalVersionInfo({ current: data.current, latest: data.latest })

--- a/web/src/components/onboarding/steps/ProjectsFolderStep.tsx
+++ b/web/src/components/onboarding/steps/ProjectsFolderStep.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import { authFetch } from '../../../lib/api'
 import { DirectoryBrowser } from '../../shared/DirectoryBrowser'
+import { appUrl } from '../../../lib/basePath'
 
 interface ProjectsFolderStepProps {
   onNext: (data: { workdir: string }) => void
@@ -17,7 +18,7 @@ export function ProjectsFolderStep({ onNext }: ProjectsFolderStepProps) {
         if (data.workdir) {
           setWorkdir(data.workdir)
         } else {
-          fetch('/api/directories?path=' + encodeURIComponent('/home'))
+          fetch(appUrl('/api/directories?path=') + encodeURIComponent('/home'))
             .then((r) => r.json())
             .then((dirData) => {
               if (dirData.current) {
@@ -28,7 +29,7 @@ export function ProjectsFolderStep({ onNext }: ProjectsFolderStepProps) {
         }
       })
       .catch(() => {
-        fetch('/api/directories?path=' + encodeURIComponent('/home'))
+        fetch(appUrl('/api/directories?path=') + encodeURIComponent('/home'))
           .then((r) => r.json())
           .then((data) => {
             if (data.current) {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,3 +1,5 @@
+import { appUrl } from './basePath'
+
 export function getSessionToken(): string | null {
   return localStorage.getItem('openfox_token')
 }
@@ -9,7 +11,7 @@ export async function authFetch(url: string, options: RequestInit = {}): Promise
     ...(token ? { 'x-session-token': token } : {}),
   }
 
-  return fetch(url, { ...options, headers })
+  return fetch(appUrl(url), { ...options, headers })
 }
 
 export async function truncateSession(sessionId: string, messageIndex: number): Promise<boolean> {

--- a/web/src/lib/basePath.test.ts
+++ b/web/src/lib/basePath.test.ts
@@ -1,0 +1,86 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+beforeEach(() => {
+  document.head.innerHTML = ''
+  document.body.innerHTML = ''
+  vi.resetModules()
+})
+
+describe('detectBasePath', () => {
+  it('returns empty string when document is undefined', async () => {
+    const origDocument = globalThis.document
+    delete (globalThis as any).document
+    const { detectBasePath } = await import('./basePath')
+    expect(detectBasePath()).toBe('')
+    globalThis.document = origDocument
+  })
+
+  it('returns empty string when no matching script tag found', async () => {
+    document.body.innerHTML = '<script src="/other.js"></script>'
+    const { detectBasePath } = await import('./basePath')
+    expect(detectBasePath()).toBe('')
+  })
+
+  it('returns empty string for root deployment with /assets/ script', async () => {
+    document.body.innerHTML = '<script type="module" src="/assets/index-abc123.js"></script>'
+    const { detectBasePath } = await import('./basePath')
+    expect(detectBasePath()).toBe('')
+  })
+
+  it('extracts subpath from /assets/ script path', async () => {
+    document.body.innerHTML = '<script type="module" src="/openfox/assets/index-abc123.js"></script>'
+    const { detectBasePath } = await import('./basePath')
+    expect(detectBasePath()).toBe('/openfox')
+  })
+
+  it('extracts deep subpath from /assets/ script path', async () => {
+    document.body.innerHTML = '<script type="module" src="/deep/path/openfox/assets/index-abc123.js"></script>'
+    const { detectBasePath } = await import('./basePath')
+    expect(detectBasePath()).toBe('/deep/path/openfox')
+  })
+
+  it('returns empty string for root deployment with /src/main.tsx script (dev mode)', async () => {
+    document.body.innerHTML = '<script type="module" src="/src/main.tsx"></script>'
+    const { detectBasePath } = await import('./basePath')
+    expect(detectBasePath()).toBe('')
+  })
+
+  it('extracts subpath from /src/main.tsx script path (dev mode)', async () => {
+    document.body.innerHTML = '<script type="module" src="/openfox/src/main.tsx"></script>'
+    const { detectBasePath } = await import('./basePath')
+    expect(detectBasePath()).toBe('/openfox')
+  })
+
+  it('skips non-matching scripts like Vite HMR client', async () => {
+    document.body.innerHTML = `
+      <script type="module" src="/@vite/client"></script>
+      <script type="module" src="/myapp/assets/index.js"></script>
+    `
+    const { detectBasePath } = await import('./basePath')
+    expect(detectBasePath()).toBe('/myapp')
+  })
+})
+
+describe('appUrl', () => {
+  it('returns non-absolute paths unchanged', async () => {
+    document.body.innerHTML = '<script type="module" src="/openfox/assets/index.js"></script>'
+    const { appUrl } = await import('./basePath')
+    expect(appUrl('relative/path')).toBe('relative/path')
+    expect(appUrl('http://example.com/api')).toBe('http://example.com/api')
+  })
+
+  it('prefixes path with appBasePath when deployed under subpath', async () => {
+    document.body.innerHTML = '<script type="module" src="/openfox/assets/index.js"></script>'
+    const { appUrl } = await import('./basePath')
+    expect(appUrl('/api/test')).toBe('/openfox/api/test')
+    expect(appUrl('/ws')).toBe('/openfox/ws')
+  })
+
+  it('returns path unchanged when deployed at root', async () => {
+    document.body.innerHTML = '<script type="module" src="/assets/index.js"></script>'
+    const { appUrl } = await import('./basePath')
+    expect(appUrl('/api/test')).toBe('/api/test')
+    expect(appUrl('/ws')).toBe('/ws')
+  })
+})

--- a/web/src/lib/basePath.ts
+++ b/web/src/lib/basePath.ts
@@ -1,0 +1,22 @@
+function detectBasePath(): string {
+  if (typeof document === 'undefined') return ''
+
+  const script = Array.from(document.scripts).find((item) => {
+    const path = new URL(item.src, window.location.href).pathname
+    return path.includes('/assets/') || path.endsWith('/src/main.tsx')
+  })
+
+  if (!script) return ''
+
+  const path = new URL(script.src, window.location.href).pathname
+  const marker = path.includes('/assets/') ? '/assets/' : '/src/'
+  const markerIndex = path.indexOf(marker)
+  return markerIndex > 0 ? path.slice(0, markerIndex) : ''
+}
+
+export const appBasePath = detectBasePath()
+
+export function appUrl(path: string): string {
+  if (!path.startsWith('/')) return path
+  return `${appBasePath}${path}` || '/'
+}

--- a/web/src/lib/basePath.ts
+++ b/web/src/lib/basePath.ts
@@ -1,4 +1,4 @@
-function detectBasePath(): string {
+export function detectBasePath(): string {
   if (typeof document === 'undefined') return ''
 
   const script = Array.from(document.scripts).find((item) => {

--- a/web/src/lib/sound.ts
+++ b/web/src/lib/sound.ts
@@ -5,6 +5,7 @@ import {
   type SoundEvent,
   type AgentType,
 } from '../stores/notifications'
+import { appUrl } from './basePath'
 
 // Audio cache: keyed by URL so custom sounds are also cached
 const audioCache = new Map<string, HTMLAudioElement>()
@@ -12,7 +13,7 @@ const audioCache = new Map<string, HTMLAudioElement>()
 function getAudio(url: string): HTMLAudioElement {
   let audio = audioCache.get(url)
   if (!audio) {
-    audio = new Audio(url)
+    audio = new Audio(appUrl(url))
     audio.volume = 0.5
     audioCache.set(url, audio)
   }
@@ -54,7 +55,7 @@ function sendBrowserNotification(event: SoundEvent) {
 
   new Notification(NOTIFICATION_TITLES[event], {
     body: NOTIFICATION_BODIES[event],
-    icon: '/fox.svg',
+    icon: appUrl('/fox.svg'),
     tag: `openfox-${event}`, // Prevents duplicate notifications
   })
 }

--- a/web/src/lib/ws.ts
+++ b/web/src/lib/ws.ts
@@ -1,6 +1,7 @@
 import type { ClientMessage, ServerMessage, ClientMessageType } from '@shared/protocol.js'
 import { isServerMessage } from '@shared/protocol.js'
 import { generateUUID } from './uuid.js'
+import { appUrl } from './basePath.js'
 
 export type ConnectionStatus = 'connected' | 'disconnected' | 'reconnecting'
 type MessageHandler = (message: ServerMessage) => void
@@ -229,5 +230,5 @@ if (!port) {
         ? '443'
         : '80'
 }
-const wsUrl = `${protocol}//${window.location.hostname}:${port}/ws`
+const wsUrl = `${protocol}//${window.location.hostname}:${port}${appUrl('/ws')}`
 export const wsClient = new WebSocketClient(wsUrl)

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,11 +1,15 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
+import { Router } from 'wouter'
 import App from './App'
+import { appBasePath } from './lib/basePath'
 import './styles/globals.css'
 import '@xterm/xterm/css/xterm.css'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
+    <Router base={appBasePath}>
+      <App />
+    </Router>
   </React.StrictMode>,
 )

--- a/web/src/stores/session/store.ts
+++ b/web/src/stores/session/store.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand'
 import { authFetch } from '../../lib/api'
+import { appUrl } from '../../lib/basePath'
 import type { SessionSummary, Message } from '@shared/types.js'
 import type { QueuedMessage, PendingQuestionPayload } from '@shared/protocol.js'
 import { wsClient } from '../../lib/ws'
@@ -221,7 +222,7 @@ export const useSessionStore = create<SessionState>((set, get) => {
 
     submitPassword: async (password: string) => {
       try {
-        const res = await fetch('/api/auth/login', {
+        const res = await fetch(appUrl('/api/auth/login'), {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ password }),

--- a/web/src/stores/update.ts
+++ b/web/src/stores/update.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand'
+import { appUrl } from '../lib/basePath'
 
 type UpdateStatus = 'idle' | 'checking' | 'upToDate' | 'available' | 'error'
 
@@ -18,7 +19,7 @@ export const useUpdateStore = create<UpdateState>((set, get) => ({
     if (!force && get().status === 'checking') return
     set({ status: 'checking' })
     try {
-      const res = await fetch(`/api/auto-update/check${force ? '?force=true' : ''}`)
+      const res = await fetch(appUrl(`/api/auto-update/check${force ? '?force=true' : ''}`))
       if (!res.ok) throw new Error(`HTTP ${res.status}`)
       const data = (await res.json()) as { isUpdateAvailable: boolean; current: string; latest: string }
       set({

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -6,6 +6,7 @@ import { createViteWatchOptions } from './vite-watch.js'
 import { existsSync } from 'fs'
 
 const baseConfig = defineConfig({
+  base: './',
   plugins: [
     react(),
     VitePWA({

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -56,6 +56,10 @@ const baseConfig = defineConfig({
     watch: createViteWatchOptions(),
     // In dev mode, users access Vite directly (for HMR to work)
     // Vite proxies API/WS to the backend server
+    // Note: proxy rules match literal /api and /ws paths. When testing
+    // subpath deployments in dev mode (e.g. behind a reverse proxy),
+    // these rules won't match /<subpath>/api/... — use a production
+    // build behind the reverse proxy instead, or add custom rewrites.
     proxy: {
       '/api': {
         target: 'http://localhost:10469',


### PR DESCRIPTION
### Summary

This PR adds support for serving OpenFox from a subpath instead of requiring the application to live at `/`.

This matters for server deployments using ngrok, Tailscale, Nginx, Caddy, Traefik, or another reverse proxy shared with other services.

Example deployment:

```text
https://example.com/openfox/
```

OpenFox previously used root-relative URLs such as:

```text
/api
/ws
/onboarding
/assets
/sounds
```

When the application was exposed under `/openfox`, the browser still requested root-level paths instead of keeping requests under the OpenFox base path.

This PR makes the frontend base-path aware across:

- Vite asset paths
- Wouter routing
- internal navigation
- authenticated API requests
- direct `fetch` calls
- WebSocket URLs
- notification sounds and icons
- PWA files
- onboarding routes

The application base path is detected from the loaded frontend bundle. Root deployments continue to work, while subpath deployments now resolve consistently.

Validation performed:

```bash
npm run typecheck:web
npm run build:web
git diff --check
```

A local reverse proxy was also used to verify:

```text
/openfox/                 200
/openfox/onboarding       200
/openfox/api/auth         200
/openfox/assets/...       200

/onboarding               404
/api/auth                 404
```

### AI-Enhanced Development

Tell what models helped shape this PR:

- **AI Models:** GPT-5.6

### Cache Impact

Does this PR affect anything cached — system prompts, tool definitions, skills, or other context?

- **No**
