### PR TITLE
feat: show provider name next to model and add autocomplete search in ProviderSelector

### DIFF
--- a/web/src/components/settings/ProviderSelector.test.tsx
+++ b/web/src/components/settings/ProviderSelector.test.tsx
@@ -82,6 +82,7 @@ vi.mock('../shared/icons', () => ({
   EditSmallIcon: ({ className }: any) => `<svg class="${className}">e</svg>`,
   StarIcon: ({ className }: any) => `<svg class="${className}">☆</svg>`,
   StarFilledIcon: ({ className }: any) => `<svg class="${className}">★</svg>`,
+  SearchIcon: ({ className }: any) => `<svg class="${className}" data-testid="search-icon">🔍</svg>`,
 }))
 
 vi.mock('../shared/ProviderModal', () => ({
@@ -253,5 +254,339 @@ describe('ProviderSelector', () => {
     expect(button!.textContent).toContain('Anthropic')
     expect(button!.textContent).toContain('claude opus 4')
     expect(button!.textContent).toContain('•')
+  })
+})
+
+describe('ProviderSelector search mode (AC 0-5)', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    document.body.innerHTML = ''
+    await setConfigState({
+      providers: [],
+      activeProviderId: null,
+      defaultModelSelection: null,
+      activating: false,
+      activateProvider: vi.fn(),
+      refreshModel: vi.fn(),
+      refreshProviderModels: vi.fn(),
+      setDefaultModel: vi.fn(),
+      fetchConfig: vi.fn(),
+    })
+    await setSessionState({
+      currentSession: null,
+      setSessionProvider: vi.fn(),
+    })
+  })
+
+  it('[AUTOMATED] AC-0 click transforms button to search input with placeholder and SearchIcon', async () => {
+    await setConfigState({
+      providers: [
+        {
+          id: 'provider-1',
+          name: 'OpenAI',
+          url: 'https://api.openai.com/v1',
+          backend: 'openai',
+          isLocal: false,
+          models: [{ id: 'gpt-4', name: 'GPT-4', contextWindow: 128000, selected: true }],
+          isActive: true,
+        },
+      ],
+      activeProviderId: 'provider-1',
+      defaultModelSelection: 'provider-1/gpt-4',
+    })
+    const { ProviderSelector } = await import('./ProviderSelector')
+    const container = render(<ProviderSelector />)
+
+    const button = container.querySelector('button')
+    expect(button).toBeTruthy()
+
+    await act(async () => { button!.click() })
+
+    const input = container.querySelector('input')
+    expect(input).toBeTruthy()
+    const placeholder = input!.getAttribute('placeholder')
+    expect(placeholder).toBeTruthy()
+    expect(placeholder!.length).toBeGreaterThan(0)
+
+    const searchIcon = container.querySelector('[data-testid="search-icon"]')
+    expect(searchIcon ?? container.textContent?.includes('🔍')).toBeTruthy()
+  })
+
+  it('[AUTOMATED] AC-1 typing filters models case-insensitively by name and id', async () => {
+    await setConfigState({
+      providers: [
+        {
+          id: 'provider-1',
+          name: 'OpenAI',
+          url: 'https://api.openai.com/v1',
+          backend: 'openai',
+          isLocal: false,
+          models: [
+            { id: 'gpt-4', name: 'GPT-4', contextWindow: 128000, selected: true },
+            { id: 'gpt-4-turbo', name: 'GPT-4 Turbo', contextWindow: 128000, selected: true },
+            { id: 'claude-3', name: 'Claude 3', contextWindow: 200000, selected: true },
+          ],
+          isActive: true,
+        },
+      ],
+      activeProviderId: 'provider-1',
+      defaultModelSelection: 'provider-1/gpt-4',
+    })
+    const { ProviderSelector } = await import('./ProviderSelector')
+    const container = render(<ProviderSelector />)
+
+    await act(async () => { container.querySelector('button')!.click() })
+
+    const input = container.querySelector('input')!
+
+    // Filter by name ("gpt" matches GPT-4 and GPT-4 Turbo, not Claude 3)
+    await act(async () => {
+      input.value = 'gpt'
+      input.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+    expect(container.textContent).toMatch(/GPT.?4/)
+    expect(container.textContent).not.toMatch(/Claude/)
+
+    // Filter by id ("claude" matches claude-3 id, case-insensitive)
+    await act(async () => {
+      input.value = 'claude'
+      input.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+    expect(container.textContent).toMatch(/Claude/)
+    expect(container.textContent).not.toMatch(/GPT.?4/)
+  })
+
+  it('[AUTOMATED] AC-2 results are grouped by provider with provider name as header', async () => {
+    await setConfigState({
+      providers: [
+        {
+          id: 'provider-1',
+          name: 'OpenAI',
+          url: 'https://api.openai.com/v1',
+          backend: 'openai',
+          isLocal: false,
+          models: [
+            { id: 'gpt-4', name: 'GPT-4', contextWindow: 128000, selected: true },
+            { id: 'gpt-4-turbo', name: 'GPT-4 Turbo', contextWindow: 128000, selected: true },
+          ],
+          isActive: true,
+        },
+        {
+          id: 'provider-2',
+          name: 'Anthropic',
+          url: 'https://api.anthropic.com',
+          backend: 'anthropic',
+          isLocal: false,
+          models: [
+            { id: 'claude-3-opus', name: 'Claude 3 Opus', contextWindow: 200000, selected: true },
+          ],
+          isActive: true,
+        },
+      ],
+      activeProviderId: 'provider-1',
+      defaultModelSelection: 'provider-1/gpt-4',
+    })
+    const { ProviderSelector } = await import('./ProviderSelector')
+    const container = render(<ProviderSelector />)
+
+    await act(async () => { container.querySelector('button')!.click() })
+
+    const input = container.querySelector('input')!
+
+    // Query that matches models across both providers (e.g. "u" matches
+    // "GPT-4 Turbo" and "Claude 3 Opus")
+    await act(async () => {
+      input.value = 'u'
+      input.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+
+    const text = container.textContent!
+    const openaiIdx = text.indexOf('OpenAI')
+    const anthropicIdx = text.indexOf('Anthropic')
+    expect(openaiIdx).toBeGreaterThanOrEqual(0)
+    expect(anthropicIdx).toBeGreaterThanOrEqual(0)
+  })
+
+  it('[AUTOMATED] AC-3 selecting a model with session active calls setSessionProvider', async () => {
+    const mockSetSessionProvider = vi.fn()
+    await setConfigState({
+      providers: [
+        {
+          id: 'provider-1',
+          name: 'OpenAI',
+          url: 'https://api.openai.com/v1',
+          backend: 'openai',
+          isLocal: false,
+          models: [{ id: 'gpt-4', name: 'GPT-4', contextWindow: 128000, selected: true }],
+          isActive: true,
+        },
+      ],
+      activeProviderId: 'provider-1',
+      defaultModelSelection: 'provider-1/gpt-4',
+    })
+    await setSessionState({
+      currentSession: { id: 'session-1', providerId: 'provider-1', providerModel: 'gpt-4' },
+      setSessionProvider: mockSetSessionProvider,
+    })
+    const { ProviderSelector } = await import('./ProviderSelector')
+    const container = render(<ProviderSelector />)
+
+    await act(async () => { container.querySelector('button')!.click() })
+
+    const modelBtn = Array.from(container.querySelectorAll('button')).find(
+      (b) => b.textContent?.includes('GPT-4')
+    )
+    expect(modelBtn).toBeTruthy()
+
+    await act(async () => { modelBtn!.click() })
+
+    expect(mockSetSessionProvider).toHaveBeenCalledWith('provider-1', 'gpt-4')
+  })
+
+  it('[AUTOMATED] AC-3 selecting a model without session calls activateProvider', async () => {
+    const mockActivateProvider = vi.fn().mockResolvedValue(true)
+    await setConfigState({
+      providers: [
+        {
+          id: 'provider-1',
+          name: 'OpenAI',
+          url: 'https://api.openai.com/v1',
+          backend: 'openai',
+          isLocal: false,
+          models: [{ id: 'gpt-4', name: 'GPT-4', contextWindow: 128000, selected: true }],
+          isActive: true,
+        },
+      ],
+      activeProviderId: 'provider-1',
+      defaultModelSelection: null,
+      activateProvider: mockActivateProvider,
+    })
+    const { ProviderSelector } = await import('./ProviderSelector')
+    const container = render(<ProviderSelector />)
+
+    await act(async () => { container.querySelector('button')!.click() })
+
+    const modelBtn = Array.from(container.querySelectorAll('button')).find(
+      (b) => b.textContent?.includes('GPT-4')
+    )
+    expect(modelBtn).toBeTruthy()
+
+    await act(async () => { modelBtn!.click() })
+
+    expect(mockActivateProvider).toHaveBeenCalled()
+  })
+
+  it('[AUTOMATED] AC-4 Escape key closes search without changing model', async () => {
+    const mockActivateProvider = vi.fn()
+    await setConfigState({
+      providers: [
+        {
+          id: 'provider-1',
+          name: 'OpenAI',
+          url: 'https://api.openai.com/v1',
+          backend: 'openai',
+          isLocal: false,
+          models: [{ id: 'gpt-4', name: 'GPT-4', contextWindow: 128000, selected: true }],
+          isActive: true,
+        },
+      ],
+      activeProviderId: 'provider-1',
+      defaultModelSelection: 'provider-1/gpt-4',
+      activateProvider: mockActivateProvider,
+    })
+    const { ProviderSelector } = await import('./ProviderSelector')
+    const container = render(<ProviderSelector />)
+
+    await act(async () => { container.querySelector('button')!.click() })
+
+    const input = container.querySelector('input')
+    expect(input).toBeTruthy()
+
+    await act(async () => {
+      input!.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+    })
+
+    expect(container.querySelector('input')).toBeFalsy()
+    expect(mockActivateProvider).not.toHaveBeenCalled()
+  })
+
+  it('[AUTOMATED] AC-4 focus loss closes search without changing model', async () => {
+    const mockActivateProvider = vi.fn()
+    await setConfigState({
+      providers: [
+        {
+          id: 'provider-1',
+          name: 'OpenAI',
+          url: 'https://api.openai.com/v1',
+          backend: 'openai',
+          isLocal: false,
+          models: [{ id: 'gpt-4', name: 'GPT-4', contextWindow: 128000, selected: true }],
+          isActive: true,
+        },
+      ],
+      activeProviderId: 'provider-1',
+      defaultModelSelection: 'provider-1/gpt-4',
+      activateProvider: mockActivateProvider,
+    })
+    const { ProviderSelector } = await import('./ProviderSelector')
+    const container = render(<ProviderSelector />)
+
+    await act(async () => { container.querySelector('button')!.click() })
+
+    const input = container.querySelector('input')
+    expect(input).toBeTruthy()
+
+    // Simulate focus loss: click on a different element outside the dropdown
+    const outside = document.createElement('div')
+    document.body.appendChild(outside)
+    await act(async () => {
+      outside.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }))
+    })
+
+    expect(container.querySelector('input')).toBeFalsy()
+    expect(mockActivateProvider).not.toHaveBeenCalled()
+  })
+
+  it('[AUTOMATED] AC-5 Enter with single result selects the model directly', async () => {
+    const mockSetSessionProvider = vi.fn()
+    await setConfigState({
+      providers: [
+        {
+          id: 'provider-1',
+          name: 'OpenAI',
+          url: 'https://api.openai.com/v1',
+          backend: 'openai',
+          isLocal: false,
+          models: [
+            { id: 'gpt-4', name: 'GPT-4', contextWindow: 128000, selected: true },
+            { id: 'gpt-4-turbo', name: 'GPT-4 Turbo', contextWindow: 128000, selected: true },
+          ],
+          isActive: true,
+        },
+      ],
+      activeProviderId: 'provider-1',
+      defaultModelSelection: 'provider-1/gpt-4',
+    })
+    await setSessionState({
+      currentSession: { id: 'session-1', providerId: 'provider-1', providerModel: 'gpt-4' },
+      setSessionProvider: mockSetSessionProvider,
+    })
+    const { ProviderSelector } = await import('./ProviderSelector')
+    const container = render(<ProviderSelector />)
+
+    await act(async () => { container.querySelector('button')!.click() })
+
+    const input = container.querySelector('input')!
+
+    await act(async () => {
+      input.value = 'turbo'
+      input.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+
+    await act(async () => {
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    })
+
+    expect(mockSetSessionProvider).toHaveBeenCalledWith('provider-1', 'gpt-4-turbo')
   })
 })

--- a/web/src/components/settings/ProviderSelector.test.tsx
+++ b/web/src/components/settings/ProviderSelector.test.tsx
@@ -1,0 +1,257 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { createRoot } from 'react-dom/client'
+import { act } from 'react'
+
+interface MockStore {
+  (selector?: (state: any) => any): any
+  setState: (partial: Record<string, any>) => void
+}
+
+function mockStore(initial: Record<string, any>): MockStore {
+  let state = { ...initial }
+  const fn = vi.fn((selector?: (s: typeof state) => any) => {
+    return selector ? selector(state) : state
+  }) as unknown as MockStore
+  fn.setState = (partial: Record<string, any>) => {
+    state = { ...state, ...partial }
+  }
+  return fn
+}
+
+const mockNavigate = vi.fn()
+
+vi.mock('wouter', () => ({
+  useLocation: () => ['/', mockNavigate],
+  Link: ({ children, href }: any) => `<a href="${href}">${children}</a>`,
+}))
+
+vi.mock('../../lib/ws', () => ({
+  wsClient: {
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    send: vi.fn(),
+    subscribe: vi.fn(),
+    onStatusChange: vi.fn(),
+  },
+}))
+
+vi.mock('../../stores/session', () => ({
+  useSessionStore: mockStore({
+    currentSession: null,
+    setSessionProvider: vi.fn(),
+  }),
+}))
+
+vi.mock('../../stores/config', () => ({
+  useConfigStore: mockStore({
+    providers: [],
+    activeProviderId: null,
+    defaultModelSelection: null,
+    activating: false,
+    activateProvider: vi.fn(),
+    refreshModel: vi.fn(),
+    refreshProviderModels: vi.fn(),
+    setDefaultModel: vi.fn(),
+    fetchConfig: vi.fn(),
+  }),
+  getBackendDisplayName: (backend: string) => {
+    const map: Record<string, string> = {
+      vllm: 'vLLM',
+      sglang: 'SGLang',
+      ollama: 'Ollama',
+      llamacpp: 'llama.cpp',
+      lmstudio: 'LM Studio',
+      openai: 'OpenAI',
+      anthropic: 'Anthropic',
+      'opencode-go': 'OpenCode Go',
+      unknown: 'Other',
+    }
+    return map[backend] ?? backend
+  },
+}))
+
+vi.mock('../../lib/api', () => ({
+  authFetch: vi.fn(),
+}))
+
+vi.mock('../shared/icons', () => ({
+  ChevronDownIcon: ({ className, rotate }: any) => `<svg class="${className}" data-rotate="${rotate}">v</svg>`,
+  ReloadIcon: ({ className }: any) => `<svg class="${className}">r</svg>`,
+  CheckIcon: ({ className }: any) => `<svg class="${className}">✓</svg>`,
+  EditSmallIcon: ({ className }: any) => `<svg class="${className}">e</svg>`,
+  StarIcon: ({ className }: any) => `<svg class="${className}">☆</svg>`,
+  StarFilledIcon: ({ className }: any) => `<svg class="${className}">★</svg>`,
+}))
+
+vi.mock('../shared/ProviderModal', () => ({
+  ProviderModal: () => '<div>ProviderModal</div>',
+  providerFormPayload: (data: any) => data,
+}))
+
+function render(ui: React.ReactElement): HTMLElement {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  act(() => {
+    root.render(ui)
+  })
+  return container
+}
+
+async function setConfigState(partial: Record<string, any>) {
+  const { useConfigStore } = await import('../../stores/config')
+  ;(useConfigStore as unknown as MockStore).setState(partial)
+}
+
+async function setSessionState(partial: Record<string, any>) {
+  const { useSessionStore } = await import('../../stores/session')
+  ;(useSessionStore as unknown as MockStore).setState(partial)
+}
+
+describe('ProviderSelector', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    document.body.innerHTML = ''
+    await setConfigState({
+      providers: [],
+      activeProviderId: null,
+      defaultModelSelection: null,
+      activating: false,
+      activateProvider: vi.fn(),
+      refreshModel: vi.fn(),
+      refreshProviderModels: vi.fn(),
+      setDefaultModel: vi.fn(),
+      fetchConfig: vi.fn(),
+    })
+    await setSessionState({
+      currentSession: null,
+      setSessionProvider: vi.fn(),
+    })
+  })
+
+  it('[AUTOMATED] Criterion 3/0 - renders model name without provider prefix when providers list is empty', async () => {
+    await setConfigState({
+      providers: [],
+      activeProviderId: null,
+      defaultModelSelection: null,
+    })
+    const { ProviderSelector } = await import('./ProviderSelector')
+    const container = render(<ProviderSelector />)
+    const button = container.querySelector('button')
+    expect(button).toBeTruthy()
+    expect(button!.textContent).toContain('No model')
+    expect(button!.textContent).not.toContain('•')
+  })
+
+  it('[AUTOMATED] Criterion 0 - shows provider name • modelName when a provider is active with a default model', async () => {
+    await setConfigState({
+      providers: [
+        {
+          id: 'provider-1',
+          name: 'OpenAI',
+          url: 'https://api.openai.com/v1',
+          backend: 'openai',
+          isLocal: false,
+          models: [{ id: 'gpt-4', name: 'GPT-4', contextWindow: 128000, selected: true }],
+          isActive: true,
+        },
+      ],
+      activeProviderId: 'provider-1',
+      defaultModelSelection: 'provider-1/gpt-4',
+    })
+    const { ProviderSelector } = await import('./ProviderSelector')
+    const container = render(<ProviderSelector />)
+    const button = container.querySelector('button')
+    expect(button!.textContent).toContain('OpenAI')
+    expect(button!.textContent).toContain('gpt 4')
+    expect(button!.textContent).toContain('•')
+  })
+
+  it('[AUTOMATED] Criterion 1 - falls back to model-only display when activeProvider is not found (no prefix)', async () => {
+    await setConfigState({
+      providers: [
+        {
+          id: 'provider-1',
+          name: 'OpenAI',
+          url: 'https://api.openai.com/v1',
+          backend: 'openai',
+          isLocal: false,
+          models: [{ id: 'gpt-4', name: 'GPT-4', contextWindow: 128000, selected: true }],
+          isActive: true,
+        },
+      ],
+      activeProviderId: 'nonexistent-id',
+      defaultModelSelection: 'nonexistent-id/gpt-4',
+    })
+    const { ProviderSelector } = await import('./ProviderSelector')
+    const container = render(<ProviderSelector />)
+    const button = container.querySelector('button')
+    expect(button!.textContent).not.toContain('•')
+    expect(button!.textContent).toContain('gpt 4')
+  })
+
+  it('[AUTOMATED] Criterion 2 - local/api badge is still rendered when providers exist', async () => {
+    await setConfigState({
+      providers: [
+        {
+          id: 'provider-1',
+          name: 'Ollama',
+          url: 'http://localhost:11434',
+          backend: 'ollama',
+          isLocal: true,
+          models: [{ id: 'llama3', name: 'Llama 3', contextWindow: 8192, selected: true }],
+          isActive: true,
+        },
+      ],
+      activeProviderId: 'provider-1',
+      defaultModelSelection: 'provider-1/llama3',
+    })
+    const { ProviderSelector } = await import('./ProviderSelector')
+    const container = render(<ProviderSelector />)
+    expect(container.textContent).toMatch(/local|api/)
+  })
+
+  it('[AUTOMATED] Criterion 2 - local/api badge is still rendered when providers list is empty', async () => {
+    await setConfigState({
+      providers: [],
+      activeProviderId: null,
+      defaultModelSelection: null,
+    })
+    const { ProviderSelector } = await import('./ProviderSelector')
+    const container = render(<ProviderSelector />)
+    expect(container.textContent).toMatch(/local|api/)
+  })
+
+  it('[AUTOMATED] Criterion 0 - shows provider name • modelName with session-scoped model', async () => {
+    await setConfigState({
+      providers: [
+        {
+          id: 'provider-1',
+          name: 'Anthropic',
+          url: 'https://api.anthropic.com',
+          backend: 'anthropic',
+          isLocal: false,
+          models: [{ id: 'claude-opus-4', name: 'Claude Opus 4', contextWindow: 200000, selected: true }],
+          isActive: true,
+        },
+      ],
+      activeProviderId: 'provider-1',
+      defaultModelSelection: 'provider-1/claude-opus-4',
+    })
+    await setSessionState({
+      currentSession: {
+        id: 'session-1',
+        providerId: 'provider-1',
+        providerModel: 'claude-opus-4',
+      },
+      setSessionProvider: vi.fn(),
+    })
+    const { ProviderSelector } = await import('./ProviderSelector')
+    const container = render(<ProviderSelector />)
+    const button = container.querySelector('button')
+    expect(button!.textContent).toContain('Anthropic')
+    expect(button!.textContent).toContain('claude opus 4')
+    expect(button!.textContent).toContain('•')
+  })
+})

--- a/web/src/components/settings/ProviderSelector.tsx
+++ b/web/src/components/settings/ProviderSelector.tsx
@@ -4,7 +4,7 @@ import { useConfigStore, getBackendDisplayName, type Provider } from '../../stor
 import { useSessionStore } from '../../stores/session'
 import { ProviderModal, providerFormPayload, type ProviderFormData } from '../shared/ProviderModal'
 import { authFetch } from '../../lib/api'
-import { ChevronDownIcon, ReloadIcon, CheckIcon, EditSmallIcon, StarIcon, StarFilledIcon } from '../shared/icons'
+import { ChevronDownIcon, ReloadIcon, CheckIcon, EditSmallIcon, StarIcon, StarFilledIcon, SearchIcon } from '../shared/icons'
 
 function formatContextWindow(context: number): string {
   if (context >= 1000000) return `${(context / 1000000).toFixed(1)}M`
@@ -20,6 +20,7 @@ export function ProviderSelector() {
   const [expandedProviderIds, setExpandedProviderIds] = useState<string[]>([])
   interface ModelWithConfig {
     id: string
+    name?: string
     contextWindow: number
     source: 'backend' | 'user' | 'default'
   }
@@ -69,6 +70,9 @@ export function ProviderSelector() {
   const differsFromDefault = isSessionScoped && defaultModel !== null && sessionModel !== defaultModel
 
   const [settingDefault, setSettingDefault] = useState(false)
+  const [searchQuery, setSearchQuery] = useState('')
+  const [searchMode, setSearchMode] = useState(false)
+  const inputRef = useRef<HTMLInputElement>(null)
 
   // Close dropdown when clicking outside
   useEffect(() => {
@@ -90,6 +94,20 @@ export function ProviderSelector() {
       }
     }
   }, [])
+
+  useEffect(() => {
+    if (!isOpen) {
+      setSearchQuery('')
+      setSearchMode(false)
+    }
+  }, [isOpen])
+
+  // Focus the search input when dropdown opens (search mode button becomes input)
+  useEffect(() => {
+    if (isOpen) {
+      inputRef.current?.focus()
+    }
+  }, [isOpen])
 
   // Auto-expand all providers when menu opens and load their models (once per session)
   useEffect(() => {
@@ -137,13 +155,11 @@ export function ProviderSelector() {
   const activeProvider = providers.find((p) => p.id === effectiveProviderId)
   const isLlmOffline = activeProvider?.status === 'disconnected'
 
-  // Check if a given provider/model pair is the session-active model
   const isSessionActive = (providerId: string, modelId: string): boolean => {
     if (!currentSession) return false
     return currentSession.providerId === providerId && currentSession.providerModel === modelId
   }
 
-  // Check if a given provider/model pair is the global default
   const isDefault = (providerId: string, modelId: string): boolean => {
     if (!defaultModelSelection) return false
     return defaultModelSelection === `${providerId}/${modelId}`
@@ -154,7 +170,7 @@ export function ProviderSelector() {
     try {
       await refreshProviderModels(providerId)
     } catch {
-      // Silently fail - will retry next time dropdown is opened
+      // Silently fail
     } finally {
       setLoadingModels(null)
     }
@@ -176,7 +192,6 @@ export function ProviderSelector() {
     }
 
     if (currentSession) {
-      // Session-scoped: persist provider choice to session (no model specified)
       setSessionProvider(provider.id, undefined)
       setIsOpen(false)
       setExpandedProviderIds([])
@@ -296,21 +311,17 @@ export function ProviderSelector() {
     setShowProviderModal(false)
   }
 
-  // Handle clicking a model name: set it for the session (if session exists) or globally
   const handleModelClick = async (providerId: string, newModel: string) => {
     if (currentSession) {
-      // Optimistic update: immediately reflect the new model in the header
       useSessionStore.setState((state) => ({
         currentSession: state.currentSession ? { ...state.currentSession, providerId, providerModel: newModel } : null,
       }))
-      // Session-scoped: persist model choice to session only
       setSessionProvider(providerId, newModel)
       setExpandedProviderIds([])
       setIsOpen(false)
       return
     }
 
-    // No session: set globally as default via activateProvider (which persists defaultModelSelection)
     const success = await activateProvider(providerId)
     if (success) {
       setExpandedProviderIds([])
@@ -318,7 +329,6 @@ export function ProviderSelector() {
     }
   }
 
-  // Handle clicking the star icon: set as global default
   const handleSetDefault = async (e: React.MouseEvent, providerId: string, modelId: string) => {
     e.stopPropagation()
     setSettingDefault(true)
@@ -331,10 +341,100 @@ export function ProviderSelector() {
     }
   }
 
-  // If no providers configured, show simple model display
   function getVisibleModels(provider: Provider) {
     const hasSelected = provider.models.some((m) => m.selected)
     return hasSelected ? provider.models.filter((m) => m.selected) : provider.models
+  }
+
+  function ModelEntry({ providerId, modelConfig }: { providerId: string; modelConfig: ModelWithConfig }) {
+    const isActive = isSessionActive(providerId, modelConfig.id)
+    const isDef = isDefault(providerId, modelConfig.id)
+    return (
+      <div
+        className={`flex items-center px-4 py-1.5 text-sm hover:bg-bg-tertiary transition-colors group ${
+          loadingModels === 'activating' ? 'opacity-50 cursor-wait' : ''
+        } ${isActive ? 'text-accent-primary' : 'text-text-secondary'}`}
+      >
+        <button
+          type="button"
+          onClick={() => handleModelClick(providerId, modelConfig.id)}
+          disabled={loadingModels === 'activating'}
+          className="flex-1 truncate text-left"
+        >
+          {modelConfig.name ??
+            modelConfig.id.split('/').pop()?.replace(/-/g, ' ') ??
+            modelConfig.id}
+        </button>
+        <div className="flex items-center gap-1.5 flex-shrink-0 ml-2">
+          <span className="text-xs text-text-muted">{formatContextWindow(modelConfig.contextWindow)}</span>
+          {currentSession && (
+            <button
+              type="button"
+              onClick={(e) => handleSetDefault(e, providerId, modelConfig.id)}
+              disabled={settingDefault}
+              className="p-0.5 hover:bg-bg-tertiary rounded transition-colors disabled:opacity-40"
+              title={isDef ? 'Default model' : 'Set as default model'}
+            >
+              {isDef ? (
+                <StarFilledIcon className="w-3.5 h-3.5 text-accent-warning" />
+              ) : (
+                <StarIcon className="w-3.5 h-3.5 text-text-muted hover:text-accent-warning" />
+              )}
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation()
+              handleEditModel(providerId, modelConfig)
+            }}
+            className="opacity-0 group-hover:opacity-100 p-0.5 hover:bg-bg-tertiary rounded transition-opacity"
+            title="Edit model context"
+          >
+            <EditSmallIcon className="w-3 h-3 text-text-muted" />
+          </button>
+          {isActive && (
+            <span className="text-accent-success flex-shrink-0" title="Session model">
+              <CheckIcon className="w-3.5 h-3.5" />
+            </span>
+          )}
+        </div>
+      </div>
+    )
+  }
+
+  const filteredGroups = searchQuery.trim()
+    ? providers
+        .map((p) => ({
+          provider: p,
+          models: getVisibleModels(p).filter((m) => {
+            const q = searchQuery.toLowerCase()
+            const name = (m.name ?? '').toLowerCase()
+            const id = m.id.toLowerCase()
+            return name.includes(q) || id.includes(q)
+          }),
+        }))
+        .filter((g) => g.models.length > 0)
+    : []
+
+  const handleSearchKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Escape') {
+      setIsOpen(false)
+      return
+    }
+    if (e.key === 'Enter') {
+      const query = (e.target as HTMLInputElement).value.trim()
+      if (!query) return
+      const q = query.toLowerCase()
+      const matches = providers.flatMap((p) =>
+        getVisibleModels(p)
+          .filter((m) => (m.name ?? '').toLowerCase().includes(q) || m.id.toLowerCase().includes(q))
+          .map((m) => ({ providerId: p.id, modelId: m.id })),
+      )
+      if (matches.length === 1) {
+        handleModelClick(matches[0]!.providerId, matches[0]!.modelId)
+      }
+    }
   }
 
   if (providers.length === 0) {
@@ -376,218 +476,190 @@ export function ProviderSelector() {
 
   return (
     <div className="relative" ref={dropdownRef}>
-      <button
-        type="button"
-        onClick={() => setIsOpen(!isOpen)}
-        className="flex items-center gap-1 px-1.5 py-0.5 rounded hover:bg-bg-tertiary transition-colors group"
-        title="Click to switch provider or model"
-      >
-        {isLlmOffline ? (
-          <span className="text-sm text-accent-error animate-pulse">offline</span>
-        ) : (
-          <>
-            <span className={`text-sm ${differsFromDefault ? 'text-accent-primary italic' : 'text-accent-primary'}`}>
-              {activeProvider ? (
-                <>
-                  {activeProvider.name} • {shortModelName}
-                </>
-              ) : (
-                shortModelName
-              )}
-            </span>
-            {differsFromDefault && (
-              <span className="text-xs text-text-muted ml-0.5" title="Session-scoped model (different from default)">
-                •
+      {isOpen && providers.length > 0 ? (
+        <div className="flex items-center gap-1 px-1.5 py-0.5 rounded bg-bg-tertiary">
+          <SearchIcon className="w-3.5 h-3.5 text-text-muted flex-shrink-0" />
+          <input
+            ref={inputRef}
+            type="text"
+            value={searchQuery}
+            onInput={(e) => {
+              setSearchQuery(e.currentTarget.value)
+              setSearchMode(e.currentTarget.value.trim().length > 0)
+            }}
+            onKeyDown={handleSearchKeyDown}
+            placeholder="Search models..."
+            className="bg-transparent border-none outline-none text-sm text-text-primary w-28 placeholder:text-text-muted"
+          />
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={() => setIsOpen(!isOpen)}
+          className="flex items-center gap-1 px-1.5 py-0.5 rounded hover:bg-bg-tertiary transition-colors group"
+          title="Click to switch provider or model"
+        >
+          {isLlmOffline ? (
+            <span className="text-sm text-accent-error animate-pulse">offline</span>
+          ) : (
+            <>
+              <span className={`text-sm ${differsFromDefault ? 'text-accent-primary italic' : 'text-accent-primary'}`}>
+                {activeProvider ? (
+                  <>
+                    {activeProvider.name} • {shortModelName}
+                  </>
+                ) : (
+                  shortModelName
+                )}
               </span>
-            )}
-            <span
-              className={`text-xs px-1.5 py-0.5 rounded-full ${
-                activeProvider?.isLocal
-                  ? 'text-accent-success bg-accent-success/10'
-                  : 'text-accent-warning bg-accent-warning/10'
-              }`}
-            >
-              {activeProvider?.isLocal ? 'local' : 'api'}
-            </span>
-          </>
-        )}
-        <ChevronDownIcon className={`w-3 h-3 text-text-muted transition-transform`} rotate={isOpen ? 180 : 0} />
-      </button>
+              {differsFromDefault && (
+                <span className="text-xs text-text-muted ml-0.5" title="Session-scoped model (different from default)">
+                  •
+                </span>
+              )}
+              <span
+                className={`text-xs px-1.5 py-0.5 rounded-full ${
+                  activeProvider?.isLocal
+                    ? 'text-accent-success bg-accent-success/10'
+                    : 'text-accent-warning bg-accent-warning/10'
+                }`}
+              >
+                {activeProvider?.isLocal ? 'local' : 'api'}
+              </span>
+            </>
+          )}
+          <ChevronDownIcon className={`w-3 h-3 text-text-muted transition-transform`} rotate={isOpen ? 180 : 0} />
+        </button>
+      )}
 
-      {/* Unified Provider + Model Dropdown */}
       {isOpen && (
         <div className="absolute bottom-full right-0 mb-1 min-w-72 max-w-[100vw] bg-bg-secondary border border-border rounded-lg shadow-lg z-50 overflow-hidden max-h-[80vh] overflow-y-auto">
-          <div className="py-1">
-            {providers.map((provider) => (
-              <div key={provider.id}>
-                <div
-                  className={`px-3 py-2 flex items-center justify-between ${
-                    provider.id === effectiveProviderId ? 'bg-bg-tertiary' : 'hover:bg-bg-tertiary'
-                  } ${activating ? 'opacity-50 cursor-wait' : 'cursor-pointer'}`}
-                >
+          {searchMode && (
+            <div key="search-pane" className="py-1">
+              {filteredGroups.length > 0 ? (
+                filteredGroups.map((group) => (
+                  <div key={`search-group-${group.provider.id}`}>
+                    <div className="px-3 py-1.5 text-xs font-medium text-text-muted uppercase tracking-wider">
+                      {group.provider.name}
+                    </div>
+                    {group.models.map((modelConfig) => (
+                      <ModelEntry key={modelConfig.id} providerId={group.provider.id} modelConfig={modelConfig} />
+                    ))}
+                  </div>
+                ))
+              ) : (
+                <div className="px-4 py-3 text-sm text-text-muted text-center">No models match your search</div>
+              )}
+            </div>
+          )}
+          {!searchMode && (
+            <div className="py-1">
+              {providers.map((provider) => (
+                <div key={provider.id}>
                   <div
-                    onClick={() => !activating && handleProviderClick(provider)}
-                    className="flex flex-col min-w-0 flex-1 cursor-pointer"
+                    className={`px-3 py-2 flex items-center justify-between ${
+                      provider.id === effectiveProviderId ? 'bg-bg-tertiary' : 'hover:bg-bg-tertiary'
+                    } ${activating ? 'opacity-50 cursor-wait' : 'cursor-pointer'}`}
                   >
-                    <span
-                      className={`text-sm font-medium truncate ${
-                        provider.id === effectiveProviderId ? 'text-accent-primary' : 'text-text-primary'
-                      }`}
+                    <div
+                      onClick={() => !activating && handleProviderClick(provider)}
+                      className="flex flex-col min-w-0 flex-1 cursor-pointer"
                     >
-                      {provider.name}
-                    </span>
-                    <span className="text-xs text-text-muted truncate">
-                      {provider.backend !== 'unknown' && getBackendDisplayName(provider.backend)}
-                    </span>
-                  </div>
-                  <div className="flex items-center gap-2 flex-shrink-0">
-                    {Boolean(provider.authAdapter) &&
-                      (authStates[provider.id] === 'connected' || provider.credentialRef ? (
-                        <button
-                          type="button"
-                          onClick={(event) => handleDisconnectAccount(event, provider.id)}
-                          disabled={authBusy === provider.id}
-                          className="text-[10px] px-1.5 py-0.5 rounded border border-accent-success/40 text-accent-success hover:bg-accent-success/10 disabled:opacity-50"
-                          title="Disconnect provider account"
-                        >
-                          Connected
-                        </button>
-                      ) : (
-                        <button
-                          type="button"
-                          onClick={(event) => handleConnectAccount(event, provider.id)}
-                          disabled={authBusy === provider.id}
-                          className="text-[10px] px-1.5 py-0.5 rounded border border-accent-primary/40 text-accent-primary hover:bg-accent-primary/10 disabled:opacity-50"
-                          title="Connect provider account"
-                        >
-                          {authBusy === provider.id
-                            ? 'Starting…'
-                            : authStates[provider.id] === 'error' || authStates[provider.id] === 'expired'
-                              ? 'Retry'
-                              : 'Connect'}
-                        </button>
-                      ))}
-                    {provider.id === effectiveProviderId ? (
-                      <span className="text-accent-success" title="Active provider">
-                        <CheckIcon className="w-4 h-4" />
+                      <span
+                        className={`text-sm font-medium truncate ${
+                          provider.id === effectiveProviderId ? 'text-accent-primary' : 'text-text-primary'
+                        }`}
+                      >
+                        {provider.name}
                       </span>
-                    ) : (
-                      <span className="w-4" />
-                    )}
-                    <button
-                      type="button"
-                      onClick={(e) => {
-                        e.stopPropagation()
-                        handleRefreshClick(e, provider.id)
-                      }}
-                      className="p-0.5 hover:bg-bg-tertiary rounded transition-colors"
-                      title="Refresh models"
-                    >
-                      <ReloadIcon
-                        className={`w-4 h-4 ${loadingModels === provider.id ? 'animate-spin' : ''} ${
-                          provider.id === activeProviderId ? 'text-accent-primary' : 'text-text-muted'
-                        }`}
-                      />
-                    </button>
-                    <button
-                      type="button"
-                      onClick={(e) => {
-                        e.stopPropagation()
-                        handleChevronClick(provider)
-                      }}
-                      className="p-0.5 hover:bg-bg-tertiary rounded transition-colors"
-                      title="Show models"
-                    >
-                      <ChevronDownIcon
-                        className={`w-4 h-4 transition-transform ${expandedProviderIds.includes(provider.id) ? 'rotate-180' : ''} ${
-                          provider.id === activeProviderId ? 'text-accent-primary' : 'text-text-muted'
-                        }`}
-                      />
-                    </button>
-                  </div>
-                </div>
-
-                {/* Model submenu - shown for expanded provider */}
-                {expandedProviderIds.includes(provider.id) && (
-                  <div className="bg-bg-primary border-t border-border max-h-40 overflow-y-auto">
-                    {loadingModels === provider.id ? (
-                      <div className="px-4 py-2 text-xs text-text-muted">Loading models...</div>
-                    ) : provider.models?.length ? (
-                      getVisibleModels(provider).map((modelConfig) => {
-                        const isActive = isSessionActive(provider.id, modelConfig.id)
-                        const isDef = isDefault(provider.id, modelConfig.id)
-                        return (
-                          <div
-                            key={modelConfig.id}
-                            className={`flex items-center px-4 py-1.5 text-sm hover:bg-bg-tertiary transition-colors group ${
-                              loadingModels === 'activating' ? 'opacity-50 cursor-wait' : ''
-                            } ${isActive ? 'text-accent-primary' : 'text-text-secondary'}`}
+                      <span className="text-xs text-text-muted truncate">
+                        {provider.backend !== 'unknown' && getBackendDisplayName(provider.backend)}
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-2 flex-shrink-0">
+                      {Boolean(provider.authAdapter) &&
+                        (authStates[provider.id] === 'connected' || provider.credentialRef ? (
+                          <button
+                            type="button"
+                            onClick={(event) => handleDisconnectAccount(event, provider.id)}
+                            disabled={authBusy === provider.id}
+                            className="text-[10px] px-1.5 py-0.5 rounded border border-accent-success/40 text-accent-success hover:bg-accent-success/10 disabled:opacity-50"
+                            title="Disconnect provider account"
                           >
-                            {/* Click on model name → session-scoped (or global if no session) */}
-                            <button
-                              type="button"
-                              onClick={() => handleModelClick(provider.id, modelConfig.id)}
-                              disabled={loadingModels === 'activating'}
-                              className="flex-1 truncate text-left"
-                            >
-                              {modelConfig.name ??
-                                modelConfig.id.split('/').pop()?.replace(/-/g, ' ') ??
-                                modelConfig.id}
-                            </button>
-
-                            <div className="flex items-center gap-1.5 flex-shrink-0 ml-2">
-                              <span className="text-xs text-text-muted">
-                                {formatContextWindow(modelConfig.contextWindow)}
-                              </span>
-
-                              {/* Star: filled = default, outline = click to set as default. Hidden when no session since model-name click already sets global default. */}
-                              {currentSession && (
-                                <button
-                                  type="button"
-                                  onClick={(e) => handleSetDefault(e, provider.id, modelConfig.id)}
-                                  disabled={settingDefault}
-                                  className="p-0.5 hover:bg-bg-tertiary rounded transition-colors disabled:opacity-40"
-                                  title={isDef ? 'Default model' : 'Set as default model'}
-                                >
-                                  {isDef ? (
-                                    <StarFilledIcon className="w-3.5 h-3.5 text-accent-warning" />
-                                  ) : (
-                                    <StarIcon className="w-3.5 h-3.5 text-text-muted hover:text-accent-warning" />
-                                  )}
-                                </button>
-                              )}
-
-                              {/* Edit button */}
-                              <button
-                                type="button"
-                                onClick={(e) => {
-                                  e.stopPropagation()
-                                  handleEditModel(provider.id, modelConfig)
-                                }}
-                                className="opacity-0 group-hover:opacity-100 p-0.5 hover:bg-bg-tertiary rounded transition-opacity"
-                                title="Edit model context"
-                              >
-                                <EditSmallIcon className="w-3 h-3 text-text-muted" />
-                              </button>
-
-                              {/* Checkmark: session-active model */}
-                              {isActive && (
-                                <span className="text-accent-success flex-shrink-0" title="Session model">
-                                  <CheckIcon className="w-3.5 h-3.5" />
-                                </span>
-                              )}
-                            </div>
-                          </div>
-                        )
-                      })
-                    ) : (
-                      <div className="px-4 py-2 text-xs text-text-muted">No models available</div>
-                    )}
+                            Connected
+                          </button>
+                        ) : (
+                          <button
+                            type="button"
+                            onClick={(event) => handleConnectAccount(event, provider.id)}
+                            disabled={authBusy === provider.id}
+                            className="text-[10px] px-1.5 py-0.5 rounded border border-accent-primary/40 text-accent-primary hover:bg-accent-primary/10 disabled:opacity-50"
+                            title="Connect provider account"
+                          >
+                            {authBusy === provider.id
+                              ? 'Starting…'
+                              : authStates[provider.id] === 'error' || authStates[provider.id] === 'expired'
+                                ? 'Retry'
+                                : 'Connect'}
+                          </button>
+                        ))}
+                      {provider.id === effectiveProviderId ? (
+                        <span className="text-accent-success" title="Active provider">
+                          <CheckIcon className="w-4 h-4" />
+                        </span>
+                      ) : (
+                        <span className="w-4" />
+                      )}
+                      <button
+                        type="button"
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          handleRefreshClick(e, provider.id)
+                        }}
+                        className="p-0.5 hover:bg-bg-tertiary rounded transition-colors"
+                        title="Refresh models"
+                      >
+                        <ReloadIcon
+                          className={`w-4 h-4 ${loadingModels === provider.id ? 'animate-spin' : ''} ${
+                            provider.id === activeProviderId ? 'text-accent-primary' : 'text-text-muted'
+                          }`}
+                        />
+                      </button>
+                      <button
+                        type="button"
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          handleChevronClick(provider)
+                        }}
+                        className="p-0.5 hover:bg-bg-tertiary rounded transition-colors"
+                        title="Show models"
+                      >
+                        <ChevronDownIcon
+                          className={`w-4 h-4 transition-transform ${expandedProviderIds.includes(provider.id) ? 'rotate-180' : ''} ${
+                            provider.id === activeProviderId ? 'text-accent-primary' : 'text-text-muted'
+                          }`}
+                        />
+                      </button>
+                    </div>
                   </div>
-                )}
-              </div>
-            ))}
-          </div>
+
+                  {expandedProviderIds.includes(provider.id) && (
+                    <div className="bg-bg-primary border-t border-border max-h-40 overflow-y-auto">
+                      {loadingModels === provider.id ? (
+                        <div className="px-4 py-2 text-xs text-text-muted">Loading models...</div>
+                      ) : provider.models?.length ? (
+                        getVisibleModels(provider).map((modelConfig) => (
+                          <ModelEntry key={modelConfig.id} providerId={provider.id} modelConfig={modelConfig} />
+                        ))
+                      ) : (
+                        <div className="px-4 py-2 text-xs text-text-muted">No models available</div>
+                      )}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
           <div className="border-t border-border px-3 py-2">
             <button onClick={() => navigate('/onboarding')} className="text-xs text-accent-primary hover:underline">
               Manage providers

--- a/web/src/components/settings/ProviderSelector.tsx
+++ b/web/src/components/settings/ProviderSelector.tsx
@@ -483,7 +483,7 @@ export function ProviderSelector() {
   return (
     <div className="relative" ref={dropdownRef}>
       {isOpen && providers.length > 0 ? (
-        <div className="flex items-center gap-1 px-1.5 py-0.5 rounded bg-bg-tertiary">
+        <div className="flex items-center gap-1 px-1.5 py-0.5 rounded bg-bg-tertiary min-w-72">
           <SearchIcon className="w-3.5 h-3.5 text-text-muted flex-shrink-0" />
           <input
             ref={inputRef}
@@ -495,7 +495,7 @@ export function ProviderSelector() {
             }}
             onKeyDown={handleSearchKeyDown}
             placeholder="Search models..."
-            className="bg-transparent border-none outline-none text-sm text-text-primary w-28 placeholder:text-text-muted"
+            className="bg-transparent border-none outline-none text-sm text-text-primary w-full placeholder:text-text-muted"
           />
         </div>
       ) : (

--- a/web/src/components/settings/ProviderSelector.tsx
+++ b/web/src/components/settings/ProviderSelector.tsx
@@ -411,7 +411,8 @@ export function ProviderSelector() {
             const q = searchQuery.toLowerCase()
             const name = (m.name ?? '').toLowerCase()
             const id = m.id.toLowerCase()
-            return name.includes(q) || id.includes(q)
+            const idDisplay = id.replace(/-/g, ' ')
+            return name.includes(q) || id.includes(q) || idDisplay.includes(q)
           }),
         }))
         .filter((g) => g.models.length > 0)
@@ -428,7 +429,12 @@ export function ProviderSelector() {
       const q = query.toLowerCase()
       const matches = providers.flatMap((p) =>
         getVisibleModels(p)
-          .filter((m) => (m.name ?? '').toLowerCase().includes(q) || m.id.toLowerCase().includes(q))
+          .filter((m) => {
+            const n = (m.name ?? '').toLowerCase()
+            const i = m.id.toLowerCase()
+            const iDisplay = i.replace(/-/g, ' ')
+            return n.includes(q) || i.includes(q) || iDisplay.includes(q)
+          })
           .map((m) => ({ providerId: p.id, modelId: m.id })),
       )
       if (matches.length === 1) {

--- a/web/src/components/settings/ProviderSelector.tsx
+++ b/web/src/components/settings/ProviderSelector.tsx
@@ -66,7 +66,7 @@ export function ProviderSelector() {
     ? (effectiveModel.split('/').pop()?.replace(/-/g, ' ') ?? effectiveModel)
     : 'No model'
   const isSessionScoped = !!(currentSession && sessionModel)
-  const differsFromDefault = isSessionScoped && sessionModel !== defaultModel
+  const differsFromDefault = isSessionScoped && defaultModel !== null && sessionModel !== defaultModel
 
   const [settingDefault, setSettingDefault] = useState(false)
 
@@ -349,7 +349,15 @@ export function ProviderSelector() {
           <span className="text-sm text-accent-error animate-pulse">LLM offline</span>
         ) : (
           <>
-            <span className="text-sm text-accent-primary">{shortModelName}</span>
+            <span className="text-sm text-accent-primary">
+              {activeProvider ? (
+                <>
+                  {activeProvider.name} • {shortModelName}
+                </>
+              ) : (
+                shortModelName
+              )}
+            </span>
             <span
               className={`text-xs px-1.5 py-0.5 rounded-full ${
                 activeProvider?.isLocal
@@ -379,7 +387,13 @@ export function ProviderSelector() {
         ) : (
           <>
             <span className={`text-sm ${differsFromDefault ? 'text-accent-primary italic' : 'text-accent-primary'}`}>
-              {shortModelName}
+              {activeProvider ? (
+                <>
+                  {activeProvider.name} • {shortModelName}
+                </>
+              ) : (
+                shortModelName
+              )}
             </span>
             {differsFromDefault && (
               <span className="text-xs text-text-muted ml-0.5" title="Session-scoped model (different from default)">


### PR DESCRIPTION
### Summary

Affiche le nom du provider actif en préfixe (`ProviderName • modelName`) à côté du modèle dans le bouton ProviderSelector, pour distinguer les modèles quand plusieurs providers proposent le même nom.

Ajoute un mode **recherche par autocomplétion** : le bouton se transforme en champ de recherche au clic, filtrant les modèles de tous les providers (insensible à la casse, par nom et id). Les résultats sont groupés par provider. Enter avec un seul résultat sélectionne directement, Escape referme. L'input est auto-focus.

Corrige aussi :
- Bug italique : le modèle session-scopé n'apparaît plus en italique quand aucun défaut global n'est configuré
- Auto-focus manquant du champ de recherche

Modifications :
- `web/src/components/settings/ProviderSelector.tsx` — préfixe provider, recherche, extraction `ModelEntry`, auto-focus, correction italique
- `web/src/components/settings/ProviderSelector.test.tsx` — tests (14 tests) + fixes async ESM

### AI-Enhanced Development

- **AI Models:** DeepSeek V4 Flash

### Cache Impact

Does this PR affect anything cached — system prompts, tool definitions, skills, or other context?

- **No**