### PR TITLE
fix: add 'validated' status icon for custom session metadata

### DIFF
--- a/web/src/components/shared/MetadataStatusIcon.test.tsx
+++ b/web/src/components/shared/MetadataStatusIcon.test.tsx
@@ -1,0 +1,41 @@
+// @vitest-environment happy-dom
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import { MetadataStatusIcon, getStatusConfig } from './MetadataStatusIcon'
+
+describe('MetadataStatusIcon', () => {
+  describe('getStatusConfig', () => {
+    it('returns ✓ icon for validated status', () => {
+      const config = getStatusConfig('validated')
+      expect(config).toEqual({ icon: '✓', color: 'text-accent-success' })
+    })
+
+    it('returns ◉ icon with purple color for completed status', () => {
+      const config = getStatusConfig('completed')
+      expect(config).toEqual({ icon: '◉', color: 'text-purple-400' })
+    })
+
+    it('does not alter completed config when validated is added', () => {
+      const completed = getStatusConfig('completed')
+      expect(completed.icon).toBe('◉')
+      expect(completed.color).toBe('text-purple-400')
+    })
+
+    it('returns default config for unknown status', () => {
+      const config = getStatusConfig('unknown_status')
+      expect(config).toEqual({ icon: '○', color: 'text-text-muted' })
+    })
+  })
+
+  describe('component rendering', () => {
+    it('renders ✓ for validated status', () => {
+      const { container } = render(<MetadataStatusIcon status="validated" />)
+      expect(container.textContent).toBe('✓')
+    })
+
+    it('renders ◉ for completed status', () => {
+      const { container } = render(<MetadataStatusIcon status="completed" />)
+      expect(container.textContent).toBe('◉')
+    })
+  })
+})

--- a/web/src/components/shared/MetadataStatusIcon.tsx
+++ b/web/src/components/shared/MetadataStatusIcon.tsx
@@ -9,9 +9,20 @@ const statusConfig: Record<string, { icon: string; color: string }> = {
   open: { icon: '○', color: 'text-accent-warning' },
   pending: { icon: '○', color: 'text-text-muted' },
   in_progress: { icon: '◌', color: 'text-accent-warning' },
+  validated: { icon: '✓', color: 'text-accent-success' },
 }
 
-export const statusOrder = ['open', 'in_progress', 'pending', 'completed', 'resolved', 'dismissed', 'passed', 'failed']
+export const statusOrder = [
+  'open',
+  'in_progress',
+  'pending',
+  'completed',
+  'validated',
+  'resolved',
+  'dismissed',
+  'passed',
+  'failed',
+]
 
 export function getStatusConfig(status: string): { icon: string; color: string } {
   return statusConfig[status] ?? { icon: '○', color: 'text-text-muted' }


### PR DESCRIPTION
### Summary

Custom session metadata keys  use status values outside the predefined `criteria`/`review_findings` cycles. The status `validated` was missing from `MetadataStatusIcon`'s `statusConfig`, causing it to render as a gray fallback circle — visually indistinguishable from `pending`, making it impossible to tell if a custom metadata entry was validated.

Added `validated → ✓ green checkmark` to the status config, matching the same icon/color as `passed` and `resolved`.

### AI-Enhanced Development

- **AI Models:** DeepSeek V4 Flash

### Cache Impact

- **No**  UI-only change to an icon mapping constant.