### PR TITLE
fix: new workspace branches use active branch instead of remote default when no source branch specified

### DIFF
--- a/src/server/git/workspace.test.ts
+++ b/src/server/git/workspace.test.ts
@@ -231,7 +231,7 @@ describe('ensureWorkspace', () => {
 })
 
 describe('getDefaultBranch', () => {
-  it('returns origin/HEAD after fetch', async () => {
+  it('returns local origin/HEAD when defined (criterion 0)', async () => {
     vi.mocked(spawn)
       .mockReturnValueOnce(makeMockProc('') as any) // git fetch (runGit)
       .mockReturnValueOnce(makeMockProc('refs/remotes/origin/main\n') as any) // git symbolic-ref
@@ -239,22 +239,37 @@ describe('getDefaultBranch', () => {
     expect(result).toBe('main')
   })
 
-  it('falls back to current branch when origin/HEAD is not set', async () => {
+  it('queries remote via ls-remote when origin/HEAD is not set locally (criterion 1)', async () => {
     vi.mocked(spawn)
       .mockReturnValueOnce(makeMockProc('') as any) // git fetch (runGit)
       .mockReturnValueOnce(makeMockProc('', '', 1) as any) // git symbolic-ref fails
-      .mockReturnValueOnce(makeMockProc('develop\n') as any) // git rev-parse (current branch)
-    const result = await getDefaultBranch(CWD)
-    expect(result).toBe('develop')
-  })
-
-  it('falls back to "main" when nothing else works', async () => {
-    vi.mocked(spawn)
-      .mockReturnValueOnce(makeMockProc('') as any) // git fetch (runGit)
-      .mockReturnValueOnce(makeMockProc('', '', 1) as any) // git symbolic-ref fails
-      .mockReturnValueOnce(makeMockProc('', '', 1) as any) // git rev-parse fails
+      .mockReturnValueOnce(makeMockProc('ref: refs/heads/main\tHEAD\nabc123\tHEAD\n') as any) // git ls-remote --symref origin HEAD
     const result = await getDefaultBranch(CWD)
     expect(result).toBe('main')
+  })
+
+  it('falls back to "main" when both origin/HEAD and ls-remote fail (criterion 2)', async () => {
+    vi.mocked(spawn)
+      .mockReturnValueOnce(makeMockProc('') as any) // git fetch (runGit)
+      .mockReturnValueOnce(makeMockProc('', '', 1) as any) // git symbolic-ref fails
+      .mockReturnValueOnce(makeMockProc('', '', 1) as any) // git ls-remote fails
+    const result = await getDefaultBranch(CWD)
+    expect(result).toBe('main')
+  })
+
+  it('never falls back to the current working directory branch (criterion 3)', async () => {
+    vi.mocked(spawn)
+      .mockReturnValueOnce(makeMockProc('') as any) // git fetch (runGit)
+      .mockReturnValueOnce(makeMockProc('', '', 1) as any) // git symbolic-ref fails
+      .mockReturnValueOnce(makeMockProc('', '', 1) as any) // git ls-remote fails
+    const result = await getDefaultBranch(CWD)
+    expect(result).toBe('main')
+    const revParseCalls = vi
+      .mocked(spawn)
+      .mock.calls.filter(
+        (call) => Array.isArray(call[1]) && call[1][0] === 'rev-parse' && call[1][1] === '--abbrev-ref',
+      )
+    expect(revParseCalls).toHaveLength(0)
   })
 })
 

--- a/src/server/git/workspace.ts
+++ b/src/server/git/workspace.ts
@@ -115,17 +115,23 @@ export function validateRef(cwd: string, name: string): Promise<void> {
 /**
  * Resolve the default branch for a project directory.
  * Fetches origin to ensure remote refs are up to date, then reads origin/HEAD.
- * Falls back to the current branch, then 'main'.
+ * Falls back to querying the remote HEAD via ls-remote, then 'main'.
  */
 export async function getDefaultBranch(projectDir: string): Promise<string> {
   await runGit(projectDir, ['fetch', 'origin', '--no-tags', '--quiet']).catch(() => {})
+
   const originHead = await captureStdout(projectDir, ['symbolic-ref', 'refs/remotes/origin/HEAD'])
   if (originHead) {
     const branch = originHead.trim().replace('refs/remotes/origin/', '')
     if (branch) return branch
   }
-  const current = await getGitBranch(projectDir)
-  if (current) return current
+
+  const remoteHead = await captureStdout(projectDir, ['ls-remote', '--symref', 'origin', 'HEAD'])
+  if (remoteHead) {
+    const match = remoteHead.match(/^ref: refs\/heads\/(\S+)\tHEAD$/m)
+    if (match?.[1]) return match[1]
+  }
+
   return 'main'
 }
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -435,12 +435,15 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
     if (!project) return res.status(404).json({ error: 'Project not found' })
     const { name, sourceBranch } = req.body
     if (!name || typeof name !== 'string') return res.status(400).json({ error: 'name is required' })
-    const { createBranch, resolveAndValidateSourceBranch, validateRef } = await import('./git/workspace.js')
+    const { createBranch, resolveAndValidateSourceBranch, validateRef, getDefaultBranch } =
+      await import('./git/workspace.js')
     try {
       await validateRef(project.workdir, name)
       let sb: string | undefined
       if (sourceBranch) {
         sb = await resolveAndValidateSourceBranch(project.workdir, sourceBranch, project.workdir)
+      } else {
+        sb = await getDefaultBranch(project.workdir)
       }
       await createBranch(project.workdir, name, sb)
       // Update all sessions using this project tree
@@ -522,8 +525,10 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
         const sb = await resolveAndValidateSourceBranch(effectiveWorkdir, sourceBranch, session.workdir)
         await createBranch(effectiveWorkdir, name, sb)
       } else {
-        const { createBranch } = await import('./git/workspace.js')
-        await createBranch(effectiveWorkdir, name)
+        const { createBranch, getDefaultBranch, resolveAndValidateSourceBranch } = await import('./git/workspace.js')
+        const defaultBranch = await getDefaultBranch(session.workdir)
+        const sb = await resolveAndValidateSourceBranch(effectiveWorkdir, defaultBranch, session.workdir)
+        await createBranch(effectiveWorkdir, name, sb)
       }
       updateSessionBranch(req.params.id, name)
 


### PR DESCRIPTION
### Résumé

Corrige `getDefaultBranch()` dans `src/server/git/workspace.ts` : quand `origin/HEAD` n'est pas défini localement, la fonction tombait en fallback sur la **branche courante** du projet original (`git rev-parse --abbrev-ref HEAD`). Résultat : une nouvelle branche créée sans `sourceBranch` pouvait être basée sur une branche feature quelconque au lieu de la branche par défaut du remote.

Le fix remplace ce fallback par `git ls-remote --symref origin HEAD` qui interroge le remote pour obtenir sa vraie branche par défaut, sans être influencé par le checkout local.

**Deuxième endroit** : les endpoints REST `/checkout-new` (projet et session) avaient le même problème — ils appelaient `createBranch(workdir, name)` sans start-point, créant la branche depuis HEAD. Ils utilisent maintenant `getDefaultBranch()` pour déterminer la source, puis `resolveAndValidateSourceBranch()` pour résoudre la branche dans le contexte du workspace.

### Modifications

- `src/server/git/workspace.ts` — `getDefaultBranch()` : remplace le fallback `getGitBranch()` par `ls-remote --symref` ; met à jour le JSDoc
- `src/server/index.ts` — endpoints `POST /api/projects/:id/checkout-new` et `POST /api/sessions/:id/checkout-new` : utilisent `getDefaultBranch()` quand `sourceBranch` n'est pas fourni, avec résolution via `resolveAndValidateSourceBranch()`
- `src/server/git/workspace.test.ts` — tests mis à jour pour couvrir les 3 niveaux de fallback

### AI-Enhanced Development

- **AI Models:** DeepSeek V4 Flash

### Cache Impact

- **No**
