### PR TITLE
fix: hide workspace/branch UI and guard endpoints when project is not a git repo

### DIFF
--- a/e2e/workspace-rest.test.ts
+++ b/e2e/workspace-rest.test.ts
@@ -529,3 +529,89 @@ describe('Workspace Validation REST API', () => {
     expect(projectBranch).toBeUndefined()
   })
 })
+
+describe('Non-Git Repository Guard', () => {
+  let server: TestServerHandle
+  let testProject: TestProject
+  let projectId: string
+  let sessionId: string
+
+  beforeAll(async () => {
+    server = await createTestServer()
+  })
+
+  afterAll(async () => {
+    await server.close()
+  })
+
+  beforeEach(async () => {
+    testProject = await createTestProject({ template: 'git-repo' })
+    const createRes = await fetch(`${server.url}/api/projects`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Non-Git Test', workdir: testProject.path }),
+    })
+    const data: any = await createRes.json()
+    projectId = data.project.id
+
+    const sessionRes = await fetch(`${server.url}/api/sessions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ projectId, title: 'Non-Git Test Session' }),
+    })
+    const sessionData: any = await sessionRes.json()
+    sessionId = sessionData.session.id
+
+    // Remove .git directory to simulate a non-git project
+    const { rmSync } = await import('node:fs')
+    rmSync(`${testProject.path}/.git`, { recursive: true, force: true })
+  })
+
+  afterEach(async () => {
+    await testProject.cleanup()
+  })
+
+  it('POST /api/projects/:id/checkout returns 400 when project is not a git repo', async () => {
+    const res = await fetch(`${server.url}/api/projects/${projectId}/checkout`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ branch: 'main' }),
+    })
+    expect(res.status).toBe(400)
+    const data: any = await res.json()
+    expect(data.error).toContain('git')
+  })
+
+  it('POST /api/projects/:id/checkout-new returns 400 when project is not a git repo', async () => {
+    const res = await fetch(`${server.url}/api/projects/${projectId}/checkout-new`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'new-branch' }),
+    })
+    expect(res.status).toBe(400)
+    const data: any = await res.json()
+    expect(data.error).toContain('git')
+  })
+
+  it('POST /api/sessions/:id/switch-workspace returns 400 when project is not a git repo', async () => {
+    const res = await fetch(`${server.url}/api/sessions/${sessionId}/switch-workspace`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ target: 'test-workspace' }),
+    })
+    expect(res.status).toBe(400)
+    const data: any = await res.json()
+    expect(data.error).toContain('git')
+  })
+
+  it('POST /api/sessions/:id/delete-workspace returns 400 when project is not a git repo', async () => {
+    const res = await fetch(`${server.url}/api/sessions/${sessionId}/delete-workspace`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ target: 'nonexistent' }),
+    })
+    expect(res.status).toBe(400)
+    const data: any = await res.json()
+    expect(data.error).toContain('git')
+  })
+})

--- a/src/server/git/workspace.test.ts
+++ b/src/server/git/workspace.test.ts
@@ -10,6 +10,7 @@ import {
   listBranches,
   listWorkspaces,
   getWorkspacesDir,
+  isGitRepository,
 } from './workspace.js'
 
 vi.mock('node:child_process', () => ({
@@ -296,5 +297,45 @@ describe('resolveAndValidateSourceBranch', () => {
       .mockReturnValueOnce(makeMockProc('', '', 1) as any) // git rev-parse remote fails
       .mockReturnValueOnce(makeMockProc('') as any) // git ls-remote succeeds but returns empty (branch absent)
     await expect(resolveAndValidateSourceBranch(CWD, 'absent-branch', '/tmp/project')).rejects.toThrow('not found')
+  })
+})
+
+describe('isGitRepository', () => {
+  const TEST_DIR = '/tmp/test-project'
+
+  it('returns true when .git directory exists', async () => {
+    vi.mocked(stat).mockResolvedValue({ isDirectory: () => true } as any)
+    const result = await isGitRepository(TEST_DIR)
+    expect(result).toBe(true)
+    expect(stat).toHaveBeenCalledWith(expect.stringContaining('.git'))
+  })
+
+  it('returns true when git rev-parse succeeds (worktree with .git file)', async () => {
+    vi.mocked(stat).mockRejectedValue({ code: 'ENOENT' })
+    vi.mocked(spawn).mockReturnValueOnce(makeMockProc('/path/to/git-dir\n') as any)
+    const result = await isGitRepository(TEST_DIR)
+    expect(result).toBe(true)
+    expect(spawn).toHaveBeenCalledWith('git', ['rev-parse', '--git-dir'], expect.anything())
+  })
+
+  it('returns false when .git does not exist and git rev-parse fails', async () => {
+    vi.mocked(stat).mockRejectedValue({ code: 'ENOENT' })
+    vi.mocked(spawn).mockReturnValueOnce(makeMockProc('', 'fatal: not a git repository', 128) as any)
+    const result = await isGitRepository(TEST_DIR)
+    expect(result).toBe(false)
+  })
+
+  it('returns false when directory does not exist', async () => {
+    vi.mocked(stat).mockRejectedValue({ code: 'ENOENT' })
+    vi.mocked(spawn).mockReturnValueOnce(makeMockProc('', '', 1) as any)
+    const result = await isGitRepository(TEST_DIR)
+    expect(result).toBe(false)
+  })
+
+  it('returns true when git rev-parse succeeds despite .git not being a directory', async () => {
+    vi.mocked(stat).mockResolvedValue({ isDirectory: () => false } as any)
+    vi.mocked(spawn).mockReturnValueOnce(makeMockProc('/path/to/git-dir\n') as any)
+    const result = await isGitRepository(TEST_DIR)
+    expect(result).toBe(true)
   })
 })

--- a/src/server/git/workspace.ts
+++ b/src/server/git/workspace.ts
@@ -311,6 +311,18 @@ export async function deleteWorkspace(projectName: string, name: string, project
   logger.info('Deleted workspace', { projectName, name, path: wsPath })
 }
 
+export async function isGitRepository(cwd: string): Promise<boolean> {
+  const { stat } = await import('node:fs/promises')
+  try {
+    const st = await stat(join(cwd, '.git'))
+    if (st.isDirectory()) return true
+  } catch {
+    // .git doesn't exist or can't be read — fall through to rev-parse
+  }
+  const result = await captureStdout(cwd, ['rev-parse', '--git-dir'])
+  return result !== null
+}
+
 async function statSafe(p: string): Promise<{ isDirectory: () => boolean } | null> {
   try {
     const { stat } = await import('node:fs/promises')

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -410,7 +410,10 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
     if (!project) return res.status(404).json({ error: 'Project not found' })
     const { branch } = req.body
     if (!branch || typeof branch !== 'string') return res.status(400).json({ error: 'branch is required' })
-    const { checkoutBranch } = await import('./git/workspace.js')
+    const { checkoutBranch, isGitRepository } = await import('./git/workspace.js')
+    if (!(await isGitRepository(project.workdir))) {
+      return res.status(400).json({ error: 'Project is not a git repository' })
+    }
     try {
       await checkoutBranch(project.workdir, branch)
       // Update all sessions using this project tree
@@ -435,7 +438,11 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
     if (!project) return res.status(404).json({ error: 'Project not found' })
     const { name, sourceBranch } = req.body
     if (!name || typeof name !== 'string') return res.status(400).json({ error: 'name is required' })
-    const { createBranch, resolveAndValidateSourceBranch, validateRef } = await import('./git/workspace.js')
+    const { createBranch, resolveAndValidateSourceBranch, validateRef, isGitRepository } =
+      await import('./git/workspace.js')
+    if (!(await isGitRepository(project.workdir))) {
+      return res.status(400).json({ error: 'Project is not a git repository' })
+    }
     try {
       await validateRef(project.workdir, name)
       let sb: string | undefined
@@ -685,6 +692,13 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
     const { target, branch, sourceBranch } = req.body
     if (!target || typeof target !== 'string') return res.status(400).json({ error: 'target is required' })
 
+    const project = sessionManager.getProject(session.projectId)
+    if (!project) return res.status(404).json({ error: 'Project not found' })
+    const { isGitRepository } = await import('./git/workspace.js')
+    if (!(await isGitRepository(project.workdir))) {
+      return res.status(400).json({ error: 'Project is not a git repository' })
+    }
+
     try {
       const updated = await sessionManager.switchWorkspace(req.params.id, target, branch, sourceBranch)
       res.json({ session: updated })
@@ -700,6 +714,13 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
 
     const { target } = req.body
     if (!target || typeof target !== 'string') return res.status(400).json({ error: 'target is required' })
+
+    const project = sessionManager.getProject(session.projectId)
+    if (!project) return res.status(404).json({ error: 'Project not found' })
+    const { isGitRepository } = await import('./git/workspace.js')
+    if (!(await isGitRepository(project.workdir))) {
+      return res.status(400).json({ error: 'Project is not a git repository' })
+    }
 
     try {
       const updated = await sessionManager.deleteWorkspace(req.params.id, target)

--- a/src/server/tools/workspace.test.ts
+++ b/src/server/tools/workspace.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 const mockGetGitBranch = vi.fn()
 const mockListWorkspaces = vi.fn()
+const mockIsGitRepository = vi.fn()
 const mockSwitchWorkspace = vi.fn()
 const mockDeleteWorkspace = vi.fn()
 const mockGetSession = vi.fn()
@@ -11,6 +12,7 @@ const mockRegisterPathConfirmation = vi.fn()
 vi.mock('../git/workspace.js', () => ({
   getGitBranch: (...args: unknown[]) => mockGetGitBranch(...args),
   listWorkspaces: (...args: unknown[]) => mockListWorkspaces(...args),
+  isGitRepository: (...args: unknown[]) => mockIsGitRepository(...args),
 }))
 
 vi.mock('./path-security.js', () => ({
@@ -126,6 +128,14 @@ describe('workspaceTool', () => {
       const result = await workspaceTool.execute({ action: 'switch' }, makeContext())
       expect(result.success).toBe(false)
     })
+
+    it('returns error when project is not a git repository', async () => {
+      mockIsGitRepository.mockResolvedValue(false)
+      const result = await workspaceTool.execute({ action: 'switch', target: 'feat-x' }, makeContext())
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('git')
+      expect(mockSwitchWorkspace).not.toHaveBeenCalled()
+    })
   })
 
   describe('list', () => {
@@ -164,6 +174,7 @@ describe('workspaceTool', () => {
 
   describe('delete', () => {
     it('deletes a workspace after user confirmation', async () => {
+      mockIsGitRepository.mockResolvedValue(true)
       mockRegisterPathConfirmation.mockResolvedValue(true)
       mockDeleteWorkspace.mockResolvedValue({ workspace: null, workdir: '/tmp/project' })
 
@@ -174,6 +185,7 @@ describe('workspaceTool', () => {
     })
 
     it('returns error when user denies delete', async () => {
+      mockIsGitRepository.mockResolvedValue(true)
       mockRegisterPathConfirmation.mockResolvedValue(false)
 
       const result = await workspaceTool.execute({ action: 'delete', target: 'feat-x' }, makeContext())
@@ -190,6 +202,14 @@ describe('workspaceTool', () => {
     it('returns error when target is original', async () => {
       const result = await workspaceTool.execute({ action: 'delete', target: 'original' }, makeContext())
       expect(result.success).toBe(false)
+    })
+
+    it('returns error when project is not a git repository', async () => {
+      mockIsGitRepository.mockResolvedValue(false)
+      const result = await workspaceTool.execute({ action: 'delete', target: 'feat-x' }, makeContext())
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('git')
+      expect(mockDeleteWorkspace).not.toHaveBeenCalled()
     })
   })
 

--- a/src/server/tools/workspace.ts
+++ b/src/server/tools/workspace.ts
@@ -1,5 +1,5 @@
 import { createTool, requestUserConfirmation } from './tool-helpers.js'
-import { getGitBranch, listWorkspaces } from '../git/workspace.js'
+import { getGitBranch, listWorkspaces, isGitRepository } from '../git/workspace.js'
 
 interface WorkspaceArgs {
   action: 'switch' | 'list' | 'delete'
@@ -69,6 +69,10 @@ export const workspaceTool = createTool<WorkspaceArgs>(
           return helpers.error('Parameter "target" is required for action=switch ("original" or a workspace name)')
         }
 
+        if ((await isGitRepository(context.workdir)) === false) {
+          return helpers.error('Project is not a git repository')
+        }
+
         const currentSession = sessionManager.getSession(sessionId)
         const isBranchChange =
           args.branch !== undefined &&
@@ -132,6 +136,10 @@ export const workspaceTool = createTool<WorkspaceArgs>(
           return helpers.error('Parameter "target" is required for action=delete (the workspace name)')
         }
         if (args.target === 'original') return helpers.error('Cannot delete the original workspace')
+
+        if ((await isGitRepository(context.workdir)) === false) {
+          return helpers.error('Project is not a git repository')
+        }
 
         const approved = await requestUserConfirmation(context, 'workspace', `Delete workspace "${args.target}"`)
         if (!approved) return helpers.error(`User denied: delete workspace "${args.target}"`)

--- a/web/src/components/plan/SessionSidebar.test.tsx
+++ b/web/src/components/plan/SessionSidebar.test.tsx
@@ -1,24 +1,102 @@
 // @vitest-environment happy-dom
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { renderToStaticMarkup } from 'react-dom/server'
+import type { Mock } from 'vitest'
 import { SessionSidebar } from './SessionSidebar'
 
+/* ------------------------------------------------------------------ */
+/*  Store mocks — shared across all tests                             */
+/* ------------------------------------------------------------------ */
+
+const mockSessionStore = vi.fn() as Mock
+const mockSettingsStore = vi.fn() as Mock
+const mockConfigStore = vi.fn() as Mock
+const mockUpdateStore = vi.fn() as Mock
+
 vi.mock('../../stores/session', () => ({
-  useSessionStore: vi.fn(() => ({
-    currentSession: null,
-  })),
+  useSessionStore: (selector?: (s: unknown) => unknown) =>
+    selector ? selector(mockSessionStore()) : mockSessionStore(),
 }))
 
-describe('SessionSidebar', () => {
-  it('shows Criteria section header', () => {
-    const html = renderToStaticMarkup(<SessionSidebar messages={[]} />)
+vi.mock('../../stores/settings', () => ({
+  useSettingsStore: (selector?: (s: unknown) => unknown) =>
+    selector ? selector(mockSettingsStore()) : mockSettingsStore(),
+  SETTINGS_KEYS: { DISPLAY_SHOW_OPEN_IN_EDITOR: 'display.showOpenInEditor' },
+}))
 
-    expect(html).toContain('Acceptance Criteria')
+vi.mock('../../stores/config', () => ({
+  useConfigStore: (selector?: (s: unknown) => unknown) => (selector ? selector(mockConfigStore()) : mockConfigStore()),
+}))
+
+vi.mock('../../stores/update', () => ({
+  useUpdateStore: (selector?: (s: unknown) => unknown) => (selector ? selector(mockUpdateStore()) : mockUpdateStore()),
+}))
+
+const mockUseGitStatus = vi.fn() as Mock
+
+vi.mock('../../hooks/useGitStatus', () => ({
+  useGitStatus: (...args: unknown[]) => mockUseGitStatus(...args),
+}))
+
+vi.mock('../../hooks/useSessionStats', () => ({
+  useSessionStats: vi.fn(() => null),
+}))
+
+/* ------------------------------------------------------------------ */
+/*  Child component mocks                                             */
+/* ------------------------------------------------------------------ */
+
+vi.mock('./StatsModal', () => ({ default: () => null }))
+vi.mock('./CriteriaEditor', () => ({ CriteriaEditor: () => null }))
+vi.mock('../shared/MetadataEntries', () => ({
+  MetadataEntries: () => null,
+  MetadataSectionHeader: ({ title: _title }: { title: string }) => null,
+}))
+vi.mock('../shared/MetadataModal', () => ({ MetadataModal: () => null }))
+vi.mock('./DevServerFooter', () => ({ DevServerFooter: () => null }))
+vi.mock('./BackgroundProcesses', () => ({ BackgroundProcesses: () => null }))
+vi.mock('../shared/icons', () => ({
+  FolderIcon: () => null,
+  BranchIcon: () => null,
+  ReloadIcon: () => null,
+}))
+vi.mock('../AutoUpdateModal', () => ({ AutoUpdateModal: () => null }))
+vi.mock('./DiffViewer', () => ({ DiffViewer: () => null }))
+vi.mock('./BranchModal', () => ({ BranchModal: () => null }))
+vi.mock('./WorkspaceModal', () => ({ WorkspaceModal: () => null }))
+
+/* ------------------------------------------------------------------ */
+/*  Tests                                                             */
+/* ------------------------------------------------------------------ */
+
+beforeEach(() => {
+  vi.clearAllMocks()
+
+  mockSessionStore.mockReturnValue({
+    currentSession: { id: 's1', projectId: 'p1', metadataEntries: {}, workdir: '/tmp/project' },
   })
 
-  it('shows Criteria section in sidebar', () => {
+  mockSettingsStore.mockReturnValue({ settings: {} })
+  mockConfigStore.mockReturnValue({ version: '1.0.0' })
+  mockUpdateStore.mockReturnValue({ status: 'idle', check: vi.fn() })
+})
+
+describe('SessionSidebar — git repo guards', () => {
+  it('[AUTOMATED] shows workspace and branch Edit buttons when project is a git repository', () => {
+    mockUseGitStatus.mockReturnValue({ branch: 'main', diff: { files: [], loading: false, error: null } })
+
     const html = renderToStaticMarkup(<SessionSidebar messages={[]} />)
 
-    expect(html).toContain('Acceptance Criteria')
+    expect(html).toContain('Edit')
+    const editCount = (html.match(/Edit/g) ?? []).length
+    expect(editCount).toBe(2)
+  })
+
+  it('[AUTOMATED] hides Edit buttons when project is not a git repository', () => {
+    mockUseGitStatus.mockReturnValue({ branch: null, diff: { files: [], loading: false, error: null } })
+
+    const html = renderToStaticMarkup(<SessionSidebar messages={[]} />)
+
+    expect(html).not.toContain('Edit')
   })
 })

--- a/web/src/components/plan/SessionSidebar.tsx
+++ b/web/src/components/plan/SessionSidebar.tsx
@@ -122,45 +122,47 @@ export function SessionSidebar({ messages, workdir }: SessionSidebarProps) {
         </div>
       </div>
 
-      {/* Workspace & branch info — above separator */}
-      <div className="mt-4 space-y-1.5">
-        <div className="flex items-center gap-2 text-sm">
-          {showEditorLink && workdir ? (
-            <a
-              href={buildWorkspaceUrl(workdir)}
-              className="flex items-center gap-2 min-w-0 flex-1 no-underline group"
-              title="Open workspace in VSCode"
+      {/* Workspace & branch info — above separator. Only shown for git repos. */}
+      {branch !== null && (
+        <div className="mt-4 space-y-1.5">
+          <div className="flex items-center gap-2 text-sm">
+            {showEditorLink && workdir ? (
+              <a
+                href={buildWorkspaceUrl(workdir)}
+                className="flex items-center gap-2 min-w-0 flex-1 no-underline group"
+                title="Open workspace in VSCode"
+              >
+                <FolderIcon className="w-4 h-4 text-text-muted flex-shrink-0" />
+                <span className="truncate text-text-secondary group-hover:text-accent-primary transition-colors">
+                  {workspaceName ?? 'original'}
+                </span>
+              </a>
+            ) : (
+              <>
+                <FolderIcon className="w-4 h-4 text-text-muted flex-shrink-0" />
+                <span className="truncate text-text-secondary">{workspaceName ?? 'original'}</span>
+              </>
+            )}
+            <button
+              onClick={() => setShowWorkspaceModal(true)}
+              className="ml-auto px-2 py-0.5 text-xs rounded bg-bg-tertiary text-text-secondary hover:bg-bg-secondary transition-colors"
             >
-              <FolderIcon className="w-4 h-4 text-text-muted flex-shrink-0" />
-              <span className="truncate text-text-secondary group-hover:text-accent-primary transition-colors">
-                {workspaceName ?? 'original'}
-              </span>
-            </a>
-          ) : (
-            <>
-              <FolderIcon className="w-4 h-4 text-text-muted flex-shrink-0" />
-              <span className="truncate text-text-secondary">{workspaceName ?? 'original'}</span>
-            </>
-          )}
-          <button
-            onClick={() => setShowWorkspaceModal(true)}
-            className="ml-auto px-2 py-0.5 text-xs rounded bg-bg-tertiary text-text-secondary hover:bg-bg-secondary transition-colors"
-          >
-            Edit
-          </button>
+              Edit
+            </button>
+          </div>
+          <div className="h-px bg-border" />
+          <div className="flex items-center gap-2 text-sm">
+            <BranchIcon />
+            <span className="truncate text-text-secondary">{branch}</span>
+            <button
+              onClick={() => setShowBranchModal(true)}
+              className="ml-auto px-2 py-0.5 text-xs rounded bg-bg-tertiary text-text-secondary hover:bg-bg-secondary transition-colors"
+            >
+              Edit
+            </button>
+          </div>
         </div>
-        <div className="h-px bg-border" />
-        <div className="flex items-center gap-2 text-sm">
-          <BranchIcon />
-          <span className="truncate text-text-secondary">{branch ?? 'unknown'}</span>
-          <button
-            onClick={() => setShowBranchModal(true)}
-            className="ml-auto px-2 py-0.5 text-xs rounded bg-bg-tertiary text-text-secondary hover:bg-bg-secondary transition-colors"
-          >
-            Edit
-          </button>
-        </div>
-      </div>
+      )}
 
       {/* Diff viewer — between branch and dev server */}
       <DiffViewer />


### PR DESCRIPTION
### Summary

Quand on essaie de changer de workspace ou de branche sur un projet qui n'est pas un dépôt Git, **ça crashe complètement le serveur openfox.** 

Ce correctif :

- Ajoute une fonction utilitaire `isGitRepository()` qui détecte si un dossier est un dépôt git
- Protège les endpoints REST (`checkout`, `checkout-new`, `switch-workspace`, `delete-workspace`) — retournent 400 avec `"Project is not a git repository"`
- Protège le tool AI `workspace` — refuse switch/delete avec un message clair
- Masque complètement la section workspace/branche dans la sidebar (plus de "original" ni "unknown" visible) si nous ne sommes pas dans un dossier suivi par git.

Le comportement existant pour les projets git reste inchangé.

### AI-Enhanced Development

- **AI Models:** DeepSeek V4 Flash

### Cache Impact

- **No**
