### PR TITLE
fix: prevent scroll-to-bottom on message search navigation

### DIFF
--- a/web/src/components/plan/PlanPanel.test.tsx
+++ b/web/src/components/plan/PlanPanel.test.tsx
@@ -1,6 +1,8 @@
 // @vitest-environment happy-dom
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { act } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
+import { createRoot } from 'react-dom/client'
 
 vi.mock('../../stores/session', () => ({
   useSessionStore: (selector: (state: unknown) => unknown) =>
@@ -26,9 +28,13 @@ vi.mock('../../stores/commands', () => ({
   useCommandsStore: (selector?: (state: unknown) => unknown) => (selector ? selector({ items: [] }) : { items: [] }),
 }))
 
+const mockFetchWorkflows = vi.fn()
+const mockWorkflowsState = { defaults: [], userItems: [], fetchWorkflows: mockFetchWorkflows, getState: vi.fn() }
 vi.mock('../../stores/workflows', () => ({
-  useWorkflowsStore: (selector?: (state: unknown) => unknown) =>
-    selector ? selector({ fetchWorkflows: vi.fn() }) : { fetchWorkflows: vi.fn() },
+  useWorkflowsStore: Object.assign(
+    (selector?: (state: unknown) => unknown) => (selector ? selector(mockWorkflowsState) : mockWorkflowsState),
+    { getState: vi.fn(() => mockWorkflowsState) },
+  ),
 }))
 
 vi.mock('../../stores/settings', () => ({
@@ -67,9 +73,25 @@ vi.mock('./SessionHeader', () => ({
   SessionHeader: () => <div>SessionHeader</div>,
 }))
 
+let capturedMsgSearchOnClose: (() => void) | null = null
+let capturedMsgSearchOnNavigate: ((index: number) => void) | null = null
+
 vi.mock('./MessageSearchModal', () => ({
-  default: () => null,
-  MessageSearchModal: () => null,
+  default: (props: { onClose: () => void; onNavigate: (index: number) => void }) => {
+    capturedMsgSearchOnClose = props.onClose
+    capturedMsgSearchOnNavigate = props.onNavigate
+    return null
+  },
+  MessageSearchModal: (props: { onClose: () => void; onNavigate: (index: number) => void }) => {
+    capturedMsgSearchOnClose = props.onClose
+    capturedMsgSearchOnNavigate = props.onNavigate
+    return null
+  },
+}))
+
+const mockFocusChatTextarea = vi.fn()
+vi.mock('../../lib/focusChatTextarea', () => ({
+  focusChatTextarea: (...args: unknown[]) => mockFocusChatTextarea(...args),
 }))
 
 vi.mock('./ChatInput', () => ({
@@ -161,5 +183,70 @@ describe('PlanPanel — server-side truncation integration', () => {
       <PlanPanel rawMessages={[{ id: 'msg-1', role: 'user', content: 'Hi', timestamp: new Date().toISOString() }]} />,
     )
     expect(html).not.toContain('older items hidden')
+  })
+})
+
+describe('PlanPanel — message search navigation', () => {
+  beforeEach(() => {
+    capturedMsgSearchOnClose = null
+    capturedMsgSearchOnNavigate = null
+    mockFocusChatTextarea.mockClear()
+    document.body.innerHTML = ''
+  })
+
+  it('[AUTOMATED] MessageSearchModal onClose calls focusChatTextarea(true) — Criterion 0+4', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+
+    await act(async () => {
+      root.render(<PlanPanel />)
+    })
+
+    const searchEvent = new KeyboardEvent('keydown', { key: 'f', metaKey: true, cancelable: true })
+    act(() => {
+      window.dispatchEvent(searchEvent)
+    })
+
+    expect(capturedMsgSearchOnClose).not.toBeNull()
+
+    capturedMsgSearchOnClose!()
+    expect(mockFocusChatTextarea).toHaveBeenCalledTimes(1)
+    expect(mockFocusChatTextarea).toHaveBeenCalledWith(true)
+  })
+
+  it('[AUTOMATED] handleTimelineNavigate uses scrollIntoView({block:"center",behavior:"smooth"}) without scrollBy — Criterion 1', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+
+    await act(async () => {
+      root.render(<PlanPanel />)
+    })
+
+    const scrollContainer = document.createElement('div')
+    scrollContainer.setAttribute('data-testid', 'chat-scroll-container')
+    const target = document.createElement('div')
+    target.setAttribute('data-item-index', '0')
+    scrollContainer.appendChild(target)
+    document.body.appendChild(scrollContainer)
+
+    const scrollIntoViewMock = vi.fn()
+    target.scrollIntoView = scrollIntoViewMock
+    const scrollByMock = vi.fn()
+    scrollContainer.scrollBy = scrollByMock
+
+    const searchEvent = new KeyboardEvent('keydown', { key: 'f', metaKey: true, cancelable: true })
+    act(() => {
+      window.dispatchEvent(searchEvent)
+    })
+
+    expect(capturedMsgSearchOnNavigate).not.toBeNull()
+
+    capturedMsgSearchOnNavigate!(0)
+
+    expect(scrollIntoViewMock).toHaveBeenCalledTimes(1)
+    expect(scrollIntoViewMock).toHaveBeenCalledWith({ behavior: 'smooth', block: 'center' })
+    expect(scrollByMock).not.toHaveBeenCalled()
   })
 })

--- a/web/src/components/plan/PlanPanel.tsx
+++ b/web/src/components/plan/PlanPanel.tsx
@@ -125,8 +125,7 @@ export function PlanPanel({
       setAutoScroll(false)
       const element = document.querySelector(`[data-item-index="${index}"]`)
       if (element) {
-        element.scrollIntoView({ behavior: 'smooth', block: 'start' })
-        element.closest('[data-testid="chat-scroll-container"]')?.scrollBy(0, -80)
+        element.scrollIntoView({ behavior: 'smooth', block: 'center' })
       }
     },
     [setAutoScroll],
@@ -277,7 +276,7 @@ export function PlanPanel({
           isOpen={showMessageSearch}
           onClose={() => {
             setShowMessageSearch(false)
-            focusChatTextarea()
+            focusChatTextarea(true)
           }}
           displayItems={displayItems}
           onNavigate={handleTimelineNavigate}

--- a/web/src/lib/focusChatTextarea.test.ts
+++ b/web/src/lib/focusChatTextarea.test.ts
@@ -1,0 +1,51 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { focusChatTextarea, CHAT_TEXTAREA_ID } from './focusChatTextarea'
+
+describe('focusChatTextarea', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('calls element.focus() without preventScroll when called with no arguments', () => {
+    const textarea = document.createElement('textarea')
+    textarea.id = CHAT_TEXTAREA_ID
+    document.body.appendChild(textarea)
+    const focusSpy = vi.spyOn(textarea, 'focus')
+
+    focusChatTextarea()
+
+    expect(focusSpy).toHaveBeenCalledTimes(1)
+    expect(focusSpy).toHaveBeenCalledWith()
+  })
+
+  it('calls element.focus({ preventScroll: true }) when called with true', () => {
+    const textarea = document.createElement('textarea')
+    textarea.id = CHAT_TEXTAREA_ID
+    document.body.appendChild(textarea)
+    const focusSpy = vi.spyOn(textarea, 'focus')
+
+    focusChatTextarea(true)
+
+    expect(focusSpy).toHaveBeenCalledTimes(1)
+    expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true })
+  })
+
+  it('calls element.focus({ preventScroll: false }) when called with false', () => {
+    const textarea = document.createElement('textarea')
+    textarea.id = CHAT_TEXTAREA_ID
+    document.body.appendChild(textarea)
+    const focusSpy = vi.spyOn(textarea, 'focus')
+
+    focusChatTextarea(false)
+
+    expect(focusSpy).toHaveBeenCalledTimes(1)
+    expect(focusSpy).toHaveBeenCalledWith({ preventScroll: false })
+  })
+
+  it('silently does nothing when textarea element does not exist', () => {
+    expect(() => focusChatTextarea()).not.toThrow()
+    expect(() => focusChatTextarea(true)).not.toThrow()
+    expect(() => focusChatTextarea(false)).not.toThrow()
+  })
+})

--- a/web/src/lib/focusChatTextarea.ts
+++ b/web/src/lib/focusChatTextarea.ts
@@ -1,8 +1,12 @@
 export const CHAT_TEXTAREA_ID = 'openfox-chat-textarea'
 
-export function focusChatTextarea(): void {
+export function focusChatTextarea(preventScroll?: boolean): void {
   const textarea = document.getElementById(CHAT_TEXTAREA_ID) as HTMLTextAreaElement | null
   if (textarea) {
-    textarea.focus()
+    if (preventScroll === undefined) {
+      textarea.focus()
+    } else {
+      textarea.focus({ preventScroll })
+    }
   }
 }


### PR DESCRIPTION
### Résumé

Corrige un bug où le scroll vers le message sélectionné dans la timeline (via Browse History / MessageSearchModal) était immédiatement annulé par le retour du focus dans la zone de saisie en bas du chat.

**Causes :**
- `focusChatTextarea()` appelle `element.focus()` sans `preventScroll`, ce qui force le navigateur à scroller vers la textarea (bas du chat), annulant le scroll initié par la navigation.
- `handleTimelineNavigate` utilisait `scrollBy(0, -80)` après `scrollIntoView`, ce qui entrait en compétition avec l'animation smooth.

**Correctifs :**
1. Ajout d'un paramètre optionnel `preventScroll` à `focusChatTextarea(preventScroll?)`.
2. Passage de `preventScroll: true` dans le `onClose` de `MessageSearchModal`.
3. Passage à `scrollIntoView({ block: 'center', behavior: 'smooth' })` — centrer l'élément évite naturellement le chevauchement du header, sans `scrollBy` supplémentaire.

### AI-Enhanced Development

- **AI Models :** DeepSeek V4 Flash

### Cache Impact

- **Non**
