### PR TITLE
fix(providers): preserve advanced model params when reopening provider modal

### DIFF
--- a/web/src/components/shared/ProviderModal.test.tsx
+++ b/web/src/components/shared/ProviderModal.test.tsx
@@ -210,6 +210,56 @@ describe('ProviderModal - thinkingLevel persistence', () => {
     }
   })
 
+  it('preserves previously-saved advanced parameters when reopening the modal', async () => {
+    const editProvider = {
+      id: 'test-provider',
+      name: 'Test Provider',
+      url: 'http://localhost:8000/v1',
+      backend: 'vllm' as const,
+      models: [
+        {
+          id: 'test-model',
+          contextWindow: 200000,
+          thinkingEnabled: true,
+          temperature: 0.42,
+          topP: 0.9,
+          topK: 40,
+          maxTokens: 2048,
+          compactionThreshold: 0.7,
+        },
+      ],
+    }
+
+    await new Promise<void>((resolve) => {
+      root.render(
+        <ProviderModal
+          isOpen={true}
+          onClose={vi.fn()}
+          onSave={onSaveMock as (provider: ProviderFormData) => void}
+          initialStep={2}
+          editProvider={editProvider}
+          editModelId="test-model"
+        />,
+      )
+      setTimeout(resolve, 200)
+    })
+
+    // Save immediately without touching any field — reopening the modal must not
+    // silently reset previously-persisted advanced parameters to undefined/defaults.
+    const saveButton = container.querySelector('[data-testid="provider-modal-save"]') as HTMLButtonElement | null
+    saveButton?.click()
+
+    expect(onSaveMock).toHaveBeenCalledTimes(1)
+    const savedData: ProviderFormData = onSaveMock.mock.calls[0]![0]!
+    const savedModel = savedData.models.find((m) => m.id === 'test-model')
+    expect(savedModel).toBeDefined()
+    expect(savedModel?.temperature).toBe(0.42)
+    expect(savedModel?.topP).toBe(0.9)
+    expect(savedModel?.topK).toBe(40)
+    expect(savedModel?.maxTokens).toBe(2048)
+    expect(savedModel?.compactionThreshold).toBe(0.7)
+  })
+
   it('does not reset form step when editProvider reference changes (parent re-render)', async () => {
     await new Promise<void>((resolve) => {
       root.render(

--- a/web/src/components/shared/ProviderModal.tsx
+++ b/web/src/components/shared/ProviderModal.tsx
@@ -566,6 +566,11 @@ export function ProviderModal({
             defaultTopP: m.defaultTopP,
             defaultTopK: m.defaultTopK,
             defaultMaxTokens: m.defaultMaxTokens,
+            temperature: m.temperature,
+            topP: m.topP,
+            topK: m.topK,
+            maxTokens: m.maxTokens,
+            compactionThreshold: m.compactionThreshold,
           }
           if (m.selected) selected.add(m.id)
         }


### PR DESCRIPTION
### Summary
- Reopening the "Manage providers" edit modal for a configured model dropped `temperature`, `topP`, `topK`, `maxTokens`, and `compactionThreshold` from local state, since the reset-on-open effect never copied them from the loaded model config.
- This made the sliders/inputs silently reset to defaults on reopen, and saving again from that state would overwrite the previously persisted values with `undefined` — i.e. changing the auto-compaction threshold (or temperature/topP/topK/maxTokens) appeared not to save.

### AI-Enhanced Development

Tell what models helped shape this PR:

- **AI Models:** Claude Sonnet 5 (Claude Code)

### Cache Impact

Does this PR affect anything cached — system prompts, tool definitions, skills, or other context?

- **No**

### Test plan
- [x] Added a regression test (`preserves previously-saved advanced parameters when reopening the modal`) that renders the modal with a pre-configured model and asserts the save payload preserves temperature/topP/topK/maxTokens/compactionThreshold when reopened without touching any field.
- [x] Verified the new test fails without the fix (reverted the fix locally, confirmed `undefined` instead of the expected values) and passes with it.
- [x] Full `ProviderModal.test.tsx` suite passes (10/10).