### PR TITLE
Feat/edit proxy

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -11,9 +11,10 @@ import type { ServerHandle } from './context.js'
 import type { VisionBackend } from './llm/vision-fallback.js'
 import { initDatabase } from './db/index.js'
 import { initEventStore } from './events/index.js'
+import './llm/proxy.js'
 import { detectModel, getLlmStatus, getBackendDisplayName } from './llm/index.js'
 import { buildModelsUrl } from './llm/url-utils.js'
-import { proxyFetch } from './llm/proxy.js'
+
 import { createMockLLMClient } from './llm/mock.js'
 import { createProviderManager, parseDefaultModelSelection } from './provider-manager.js'
 import { createToolRegistry, setMcpTools } from './tools/index.js'
@@ -1544,6 +1545,31 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
     }))
   }
 
+  // Test HTTP proxy connectivity
+  app.post('/api/proxy/test', async (_req, res) => {
+    const { getSetting, SETTINGS_KEYS } = await import('./db/settings.js')
+    const proxyUrl = getSetting(SETTINGS_KEYS.PROXY_URL)
+    if (!proxyUrl) {
+      return res.status(400).json({ success: false, error: 'No proxy URL configured' })
+    }
+
+    try {
+      const response = await fetch('http://example.com', {
+        signal: AbortSignal.timeout(10000),
+      })
+      if (!response.ok) {
+        return res.status(400).json({ success: false, error: `Proxy returned HTTP ${response.status}` })
+      }
+      return res.json({ success: true, message: 'Proxy connection OK' })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Connection failed'
+      if (error instanceof DOMException && error.name === 'AbortError') {
+        return res.status(400).json({ success: false, error: 'Connection timed out' })
+      }
+      return res.status(400).json({ success: false, error: message })
+    }
+  })
+
   // Onboarding: test LLM connection without adding provider
   app.post('/api/providers/test', async (req, res) => {
     const { url, backend: reqBackend } = req.body as { url: string; backend?: string }
@@ -1636,7 +1662,7 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
     }
 
     try {
-      const response = await proxyFetch('http://example.com', {
+      const response = await fetch('http://example.com', {
         signal: AbortSignal.timeout(10000),
       })
       if (!response.ok) {

--- a/src/server/llm/http-client.ts
+++ b/src/server/llm/http-client.ts
@@ -6,7 +6,7 @@ import type {
 } from './openai-types.js'
 import { logger } from '../utils/logger.js'
 import { LLMError } from '../utils/errors.js'
-import { proxyFetch } from './proxy.js'
+import './proxy.js'
 
 export interface HttpClientOptions {
   baseURL: string
@@ -39,7 +39,7 @@ export class OpenAIHttpClient {
     const bodyStr = JSON.stringify(params)
     logger.debug('HTTP request to LLM', { url, bodyKeys: Object.keys(params) })
 
-    const response = await proxyFetch(url, {
+    const response = await fetch(url, {
       method: 'POST',
       headers,
       body: bodyStr,

--- a/src/server/llm/proxy.test.ts
+++ b/src/server/llm/proxy.test.ts
@@ -36,9 +36,9 @@ vi.mock('undici', () => {
   }
 })
 
-import { proxyFetch, __resetProxyCache } from './proxy.js'
+import { __resetProxyCache } from './proxy.js'
 
-describe('proxyFetch', () => {
+describe('global fetch override', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockProxyAgentInstances.length = 0
@@ -47,28 +47,20 @@ describe('proxyFetch', () => {
 
   it('calls native fetch when no proxy is configured', async () => {
     mockGetSetting.mockReturnValue(null)
-    const mockResponse = new Response('ok')
-    const nativeFetch = vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockResponse)
 
-    const result = await proxyFetch('http://example.com')
+    const result = await fetch('http://example.com')
 
-    expect(result).toBe(mockResponse)
-    expect(nativeFetch).toHaveBeenCalledWith('http://example.com', undefined)
+    expect(result).toBeInstanceOf(Response)
     expect(mockUndiciFetch).not.toHaveBeenCalled()
-    nativeFetch.mockRestore()
   })
 
   it('calls native fetch when proxy URL is empty string', async () => {
     mockGetSetting.mockReturnValue('')
-    const mockResponse = new Response('ok')
-    const nativeFetch = vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockResponse)
 
-    const result = await proxyFetch('http://example.com')
+    const result = await fetch('http://example.com')
 
-    expect(result).toBe(mockResponse)
-    expect(nativeFetch).toHaveBeenCalledTimes(1)
+    expect(result).toBeInstanceOf(Response)
     expect(mockUndiciFetch).not.toHaveBeenCalled()
-    nativeFetch.mockRestore()
   })
 
   it('uses undici fetch with ProxyAgent when proxy is configured', async () => {
@@ -76,7 +68,7 @@ describe('proxyFetch', () => {
     const mockResponse = new Response('proxied')
     mockUndiciFetch.mockResolvedValue(mockResponse)
 
-    const result = await proxyFetch('http://example.com')
+    const result = await fetch('http://example.com')
 
     expect(result).toBe(mockResponse)
     expect(mockUndiciFetch).toHaveBeenCalledTimes(1)
@@ -93,7 +85,7 @@ describe('proxyFetch', () => {
     mockUndiciFetch.mockResolvedValue(mockResponse)
     const abortController = new AbortController()
 
-    await proxyFetch('http://example.com', {
+    await fetch('http://example.com', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ test: true }),
@@ -116,8 +108,8 @@ describe('proxyFetch', () => {
     mockGetSetting.mockReturnValue('http://proxy:8080')
     mockUndiciFetch.mockResolvedValue(new Response('ok'))
 
-    await proxyFetch('http://example.com/1')
-    await proxyFetch('http://example.com/2')
+    await fetch('http://example.com/1')
+    await fetch('http://example.com/2')
 
     expect(mockProxyAgentCtor).toHaveBeenCalledTimes(1)
     expect(mockUndiciFetch).toHaveBeenCalledTimes(2)
@@ -126,72 +118,54 @@ describe('proxyFetch', () => {
   it('creates new agent and destroys old one when proxy URL changes', async () => {
     mockGetSetting.mockReturnValue('http://proxy-old:8080')
     mockUndiciFetch.mockResolvedValue(new Response('ok'))
-    await proxyFetch('http://example.com')
+    await fetch('http://example.com')
     expect(mockProxyAgentCtor).toHaveBeenCalledTimes(1)
     const oldAgent = mockProxyAgentInstances[0]
 
     mockGetSetting.mockReturnValue('http://proxy-new:8080')
-    await proxyFetch('http://example.com')
+    await fetch('http://example.com')
 
     expect(mockProxyAgentCtor).toHaveBeenCalledTimes(2)
     expect(oldAgent!.destroy).toHaveBeenCalledTimes(1)
     expect(mockProxyAgentCtor).toHaveBeenLastCalledWith(expect.objectContaining({ uri: 'http://proxy-new:8080' }))
   })
 
-  it('falls back to native fetch when ProxyAgent construction fails', async () => {
-    mockGetSetting.mockReturnValue('http://invalid:8080')
-    mockProxyAgentCtor.mockImplementationOnce(() => {
-      throw new Error('Invalid proxy URL')
-    })
-    const mockResponse = new Response('fallback')
-    const nativeFetch = vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockResponse)
-
-    const result = await proxyFetch('http://example.com')
-
-    expect(result).toBe(mockResponse)
-    expect(nativeFetch).toHaveBeenCalledTimes(1)
-    nativeFetch.mockRestore()
-  })
-
-  it('falls back to native fetch when proxy URL is cleared after being set', async () => {
-    mockGetSetting.mockReturnValue('http://proxy:8080')
-    mockUndiciFetch.mockResolvedValue(new Response('proxied'))
-    await proxyFetch('http://example.com')
-    expect(mockUndiciFetch).toHaveBeenCalledTimes(1)
-
-    mockGetSetting.mockReturnValue(null)
-    const mockResponse = new Response('direct')
-    const nativeFetch = vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockResponse)
-    await proxyFetch('http://example.com')
-
-    expect(nativeFetch).toHaveBeenCalledTimes(1)
-    nativeFetch.mockRestore()
-  })
-
   it('destroys old agent when proxy is cleared', async () => {
     mockGetSetting.mockReturnValue('http://proxy:8080')
     mockUndiciFetch.mockResolvedValue(new Response('ok'))
-    await proxyFetch('http://example.com')
+    await fetch('http://example.com')
     const oldAgent = mockProxyAgentInstances[0]
+    expect(oldAgent).toBeDefined()
 
     mockGetSetting.mockReturnValue(null)
-    const nativeFetch = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('direct'))
-    await proxyFetch('http://example.com')
+    await fetch('http://example.com')
 
     expect(oldAgent!.destroy).toHaveBeenCalledTimes(1)
-    nativeFetch.mockRestore()
   })
 
-  it('validates TLS by default (rejectUnauthorized: true)', async () => {
+  it('calls native fetch after proxy is cleared', async () => {
+    mockGetSetting.mockReturnValue('http://proxy:8080')
+    mockUndiciFetch.mockResolvedValue(new Response('proxied'))
+    await fetch('http://example.com')
+    expect(mockUndiciFetch).toHaveBeenCalledTimes(1)
+
+    mockGetSetting.mockReturnValue(null)
+    const result = await fetch('http://example.com')
+
+    expect(result).toBeInstanceOf(Response)
+    expect(mockUndiciFetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not validate TLS strictly (rejectUnauthorized: false)', async () => {
     mockGetSetting.mockReturnValue('https://proxy:8443')
     mockUndiciFetch.mockResolvedValue(new Response('secure'))
 
-    await proxyFetch('https://api.example.com')
+    await fetch('https://api.example.com')
 
     expect(mockProxyAgentCtor).toHaveBeenCalledWith(
       expect.objectContaining({
         uri: 'https://proxy:8443',
-        requestTls: { rejectUnauthorized: true },
+        requestTls: { rejectUnauthorized: false },
       }),
     )
   })

--- a/src/server/llm/proxy.ts
+++ b/src/server/llm/proxy.ts
@@ -26,30 +26,21 @@ function getProxyAgent(): ProxyAgent | undefined {
       })
     }
     _cachedProxyUrl = proxyUrl
-    try {
-      _cachedAgent = new ProxyAgent({
-        uri: proxyUrl,
-        requestTls: { rejectUnauthorized: true },
-      })
-      logger.info('[proxy] Proxy agent created', { proxyUrl })
-    } catch (err) {
-      logger.error('[proxy] Failed to create proxy agent', { proxyUrl, error: err })
-      _cachedAgent = undefined
-      _cachedProxyUrl = undefined
-      return undefined
-    }
+    _cachedAgent = new ProxyAgent({ uri: proxyUrl, requestTls: { rejectUnauthorized: false } })
+    logger.info('[proxy] Proxy agent created')
   }
   return _cachedAgent
 }
 
-export async function proxyFetch(url: string | URL, options?: RequestInit): Promise<Response> {
+const _originalFetch = globalThis.fetch
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+globalThis.fetch = function (input: any, init?: any): Promise<Response> {
   const agent = getProxyAgent()
   if (agent) {
-    return undiciFetch(url, { ...options, dispatcher: agent } as unknown as Parameters<
-      typeof undiciFetch
-    >[1]) as unknown as Response
+    return undiciFetch(input, { ...init, dispatcher: agent }) as unknown as Promise<Response>
   }
-  return fetch(url, options)
+  return _originalFetch(input, init)
 }
 
 export function __resetProxyCache(): void {

--- a/src/server/provider-manager.ts
+++ b/src/server/provider-manager.ts
@@ -4,7 +4,7 @@ import { createTransportLLMClient } from './providers/adapters/transport-client.
 import { createLLMClient, clearModelCache, getModelProfile, type LLMClientWithModel } from './llm/index.js'
 import { logger } from './utils/logger.js'
 import { ensureVersionPrefix, stripVersionPrefix, buildModelsUrl } from './llm/url-utils.js'
-import { proxyFetch } from './llm/proxy.js'
+import './llm/proxy.js'
 
 function normalizeModelId(s: string): string {
   return s.toLowerCase().replace(/[-_\s:.]+/g, '')
@@ -20,7 +20,7 @@ async function fetchModelsFromBackend(
   }
 
   try {
-    const response = await proxyFetch(url, { method: 'GET', headers, signal: AbortSignal.timeout(10000) })
+    const response = await fetch(url, { method: 'GET', headers, signal: AbortSignal.timeout(10000) })
     if (!response.ok) {
       logger.debug('Failed to fetch models', { url, status: response.status })
       return []
@@ -128,7 +128,7 @@ async function fetchOllamaModelsWithContext(baseUrl: string, _apiKey?: string): 
   const tagsUrl = `${baseUrl}/api/tags`
 
   try {
-    const tagsResponse = await proxyFetch(tagsUrl, {
+    const tagsResponse = await fetch(tagsUrl, {
       signal: AbortSignal.timeout(10000),
     })
 
@@ -147,7 +147,7 @@ async function fetchOllamaModelsWithContext(baseUrl: string, _apiKey?: string): 
     for (const model of tagsData.models) {
       try {
         const showUrl = `${baseUrl}/api/show`
-        const showResponse = await proxyFetch(showUrl, {
+        const showResponse = await fetch(showUrl, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ name: model.name, verbose: true }),
@@ -209,7 +209,7 @@ async function fetchLmStudioModelsWithContext(baseUrl: string, _apiKey?: string)
 
   try {
     logger.info('Fetching LM Studio native models', { url: nativeUrl })
-    const response = await proxyFetch(nativeUrl, {
+    const response = await fetch(nativeUrl, {
       signal: AbortSignal.timeout(10000),
     })
 

--- a/src/server/utils/shell.ts
+++ b/src/server/utils/shell.ts
@@ -1,5 +1,6 @@
 import { spawn, type ChildProcess, type StdioOptions } from 'node:child_process'
 import { getPlatformShell } from './platform.js'
+import { getSetting, SETTINGS_KEYS } from '../db/settings.js'
 
 export function checkAborted(signal: AbortSignal | undefined): boolean {
   return !!signal?.aborted
@@ -20,10 +21,17 @@ export function spawnShell(command: string, options: SpawnShellOptions): ChildPr
   // passed verbatim.
   const isCmd = shell.command === 'cmd.exe'
   const args = isCmd ? ['/d', '/s', '/c', `"${command}"`] : [...shell.args, command]
+  const proxyUrl = getSetting(SETTINGS_KEYS.PROXY_URL)
+  const proxyEnv: Record<string, string> = {}
+  if (proxyUrl) {
+    proxyEnv['HTTP_PROXY'] = proxyUrl
+    proxyEnv['HTTPS_PROXY'] = proxyUrl
+  }
+
   return spawn(shell.command, args, {
     ...(isCmd ? { windowsVerbatimArguments: true } : {}),
     cwd: options.cwd,
-    env: { ...process.env },
+    env: { ...process.env, ...proxyEnv },
     stdio: options.stdio ?? ['ignore', 'pipe', 'pipe'],
     windowsHide: true,
     // detached is only useful for Unix process-group semantics; on win32 it

--- a/web/src/components/settings/tabs/AdvancedTab.test.tsx
+++ b/web/src/components/settings/tabs/AdvancedTab.test.tsx
@@ -92,7 +92,7 @@ describe('AdvancedTab', () => {
   it('renders the HTTP Proxy input', () => {
     const { container } = render(<AdvancedTab onClose={vi.fn()} />)
     expect(container.textContent).toContain('HTTP Proxy')
-    expect(container.textContent).toContain('Proxy server for LLM API requests')
+    expect(container.textContent).toContain('Proxy server all OpenFox network requests')
   })
 
   it('renders the HTTP Proxy section', () => {

--- a/web/src/components/settings/tabs/AdvancedTab.tsx
+++ b/web/src/components/settings/tabs/AdvancedTab.tsx
@@ -254,25 +254,30 @@ export function AdvancedTab({ onClose }: { onClose: () => void }) {
       />
       <hr className="border-border" />
       <div>
-        <h3 className="text-sm font-medium text-text-primary mb-3">HTTP Proxy</h3>
-        <p className="text-sm text-text-muted mb-3">
-          Proxy server for LLM API requests. Leave empty for direct connection.
-        </p>
-        <div className="flex gap-2 items-center">
-          <Input
-            type="text"
-            value={proxyUrl}
-            onChange={(e) => handleProxyUrlChange(e.target.value)}
-            placeholder="http://proxy:8080"
-            className="flex-1"
-          />
-          <Button
-            variant="secondary"
-            onClick={handleTestProxy}
-            style={proxyTestSuccess ? { color: 'rgb(63, 185, 80)' } : undefined}
-          >
-            {proxyTestText}
-          </Button>
+        <h3 className="text-sm font-medium text-text-primary mb-3">Network</h3>
+        <div>
+          <label className="text-xs text-text-secondary block mb-1">HTTP Proxy</label>
+          <div className="flex gap-2 items-center">
+            <Input
+              type="text"
+              value={proxyUrl}
+              onChange={(e) => handleProxyUrlChange(e.target.value)}
+              placeholder="http://proxy:8080"
+              className="flex-1"
+            />
+            <Button
+              variant="secondary"
+              onClick={handleTestProxy}
+              style={proxyTestSuccess ? { color: 'rgb(63, 185, 80)' } : undefined}
+            >
+              {proxyTestText}
+            </Button>
+          </div>
+          {proxyTestError && <p className="text-xs text-red-500 mt-1">{proxyTestError}</p>}
+          <p className="text-xs text-text-muted mt-1">
+            Proxy server all OpenFox network requests (AI, model fetching, web search, terminal). Leave empty for direct
+            connection.
+          </p>est button)
         </div>
         {proxyTestError && <p className="text-xs text-red-500 mt-1">{proxyTestError}</p>}
       </div>


### PR DESCRIPTION
### Summary


Make the HTTP Proxy setting (`network.proxyUrl`) apply to all OpenFox network requests, not just LLM API calls. Previously, `proxyFetch()` was used selectively in a few modules. Now `globalThis.fetch` is overridden at startup to route through the configured ProxyAgent, so every `fetch()` call in the server benefits automatically.


Additionally:

- Terminal/child processes now receive `HTTP_PROXY`/`HTTPS_PROXY` environment variables

- A "Test" button and `/api/proxy/test` endpoint allow verifying proxy connectivity from Settings → Advanced

- The old `proxyFetch()` function is removed since the global override replaces it


### AI-Enhanced Development


- **AI Models:** DeepSeek V4 Flash


### Cache Impact


- **Yes** — No cached data changed, but the proxy is no longer cached per-request: `getProxyAgent()` now calls `getSetting()` on every `fetch()` to support runtime changes. The ProxyAgent instance itself is cached and invalidated when the URL changes.