### PR TITLE
feat(workspace): Move workspace config from project tree to global config directory

### DIFF
--- a/src/server/git/workspace-config.test.ts
+++ b/src/server/git/workspace-config.test.ts
@@ -8,53 +8,167 @@ vi.mock('node:fs/promises', () => ({
   mkdir: vi.fn(),
 }))
 
+vi.mock('node:os', () => ({
+  homedir: vi.fn(() => '/home/user'),
+}))
+
+vi.mock('node:crypto', () => ({
+  createHash: vi.fn(() => ({
+    update: vi.fn().mockReturnThis(),
+    digest: vi.fn().mockReturnValue('abc123def4567890abcdef1234567890'),
+  })),
+}))
+
 import { readFile, writeFile, mkdir } from 'node:fs/promises'
+import { createHash } from 'node:crypto'
 
 const WORKDIR = '/tmp/project'
+const HASH = 'abc123def4567890'
+const OLD_PATH = join(WORKDIR, '.openfox', 'workspace.json')
+const NEW_DIR = join('/home/user', '.config', 'openfox', 'projects', HASH)
+const NEW_PATH = join(NEW_DIR, 'workspace.json')
 
 beforeEach(() => {
   vi.clearAllMocks()
 })
 
 describe('loadWorkspaceConfig', () => {
-  it('returns null when file does not exist', async () => {
+  it('reads from new config location first', async () => {
+    vi.mocked(readFile).mockResolvedValue(JSON.stringify({ setup: ['npm install'] }))
+
+    const result = await loadWorkspaceConfig(WORKDIR)
+
+    expect(result).toEqual({ setup: ['npm install'] })
+    const readPaths = vi.mocked(readFile).mock.calls.map((c) => c[0])
+    expect(readPaths[0]).toContain('.config/openfox/projects/')
+    expect(readPaths[0]).toContain('workspace.json')
+  })
+
+  it('returns null when file does not exist at new location and no old config', async () => {
     vi.mocked(readFile).mockRejectedValue({ code: 'ENOENT' })
+
     const result = await loadWorkspaceConfig(WORKDIR)
+
     expect(result).toBeNull()
   })
 
-  it('returns null when JSON is invalid', async () => {
+  it('returns null when JSON is invalid at new location and no old config', async () => {
     vi.mocked(readFile).mockResolvedValue('not json')
+
     const result = await loadWorkspaceConfig(WORKDIR)
+
     expect(result).toBeNull()
   })
 
-  it('returns null when setup is missing', async () => {
+  it('returns null when config is empty obj at new location', async () => {
     vi.mocked(readFile).mockResolvedValue(JSON.stringify({}))
+
     const result = await loadWorkspaceConfig(WORKDIR)
+
     expect(result).toBeNull()
   })
 
-  it('parses valid config with setup array', async () => {
+  it('parses valid config with setup array from new location', async () => {
     vi.mocked(readFile).mockResolvedValue(JSON.stringify({ setup: ['npm install --prefer-offline'] }))
+
     const result = await loadWorkspaceConfig(WORKDIR)
+
     expect(result).toEqual({ setup: ['npm install --prefer-offline'] })
+  })
+
+  it('parses valid config with rootDir from new location', async () => {
+    vi.mocked(readFile).mockResolvedValue(JSON.stringify({ rootDir: '/custom/workspaces' }))
+
+    const result = await loadWorkspaceConfig(WORKDIR)
+
+    expect(result).toEqual({ rootDir: '/custom/workspaces' })
+  })
+})
+
+describe('auto-migration from old location', () => {
+  it('migrates config from old .openfox/workspace.json when new location does not exist', async () => {
+    vi.mocked(readFile)
+      .mockRejectedValueOnce({ code: 'ENOENT' })
+      .mockResolvedValueOnce(JSON.stringify({ setup: ['npm install'] }))
+    vi.mocked(mkdir).mockResolvedValue(undefined)
+    vi.mocked(writeFile).mockResolvedValue(undefined)
+
+    const result = await loadWorkspaceConfig(WORKDIR)
+
+    expect(result).toEqual({ setup: ['npm install'] })
+    expect(readFile).toHaveBeenCalledTimes(2)
+    expect(readFile).toHaveBeenNthCalledWith(2, OLD_PATH, 'utf-8')
+    expect(mkdir).toHaveBeenCalledWith(NEW_DIR, { recursive: true })
+    expect(writeFile).toHaveBeenCalledWith(
+      NEW_PATH,
+      JSON.stringify({ setup: ['npm install'] }, null, 2) + '\n',
+      'utf-8',
+    )
+  })
+
+  it('does NOT migrate when config already exists at new location', async () => {
+    vi.mocked(readFile).mockResolvedValue(JSON.stringify({ setup: ['already migrated'] }))
+
+    const result = await loadWorkspaceConfig(WORKDIR)
+
+    expect(result).toEqual({ setup: ['already migrated'] })
+    expect(readFile).toHaveBeenCalledTimes(1)
+    expect(writeFile).not.toHaveBeenCalled()
+  })
+
+  it('does NOT migrate when old config is empty', async () => {
+    vi.mocked(readFile).mockRejectedValueOnce({ code: 'ENOENT' }).mockResolvedValueOnce(JSON.stringify({}))
+
+    const result = await loadWorkspaceConfig(WORKDIR)
+
+    expect(result).toBeNull()
+    expect(writeFile).not.toHaveBeenCalled()
+  })
+
+  it('does NOT migrate when old config has invalid JSON', async () => {
+    vi.mocked(readFile).mockRejectedValueOnce({ code: 'ENOENT' }).mockResolvedValueOnce('not json')
+
+    const result = await loadWorkspaceConfig(WORKDIR)
+
+    expect(result).toBeNull()
+    expect(writeFile).not.toHaveBeenCalled()
+  })
+
+  it('does NOT migrate when old config file does not exist', async () => {
+    vi.mocked(readFile).mockRejectedValueOnce({ code: 'ENOENT' }).mockRejectedValueOnce({ code: 'ENOENT' })
+
+    const result = await loadWorkspaceConfig(WORKDIR)
+
+    expect(result).toBeNull()
+    expect(writeFile).not.toHaveBeenCalled()
   })
 })
 
 describe('saveWorkspaceConfig', () => {
-  it('creates .openfox directory and writes config', async () => {
+  it('creates new config directory and writes to new location only', async () => {
     vi.mocked(mkdir).mockResolvedValue(undefined)
     vi.mocked(writeFile).mockResolvedValue(undefined)
 
     await saveWorkspaceConfig(WORKDIR, { setup: ['npm install --prefer-offline'] })
 
-    expect(mkdir).toHaveBeenCalledWith(expect.stringContaining('.openfox'), { recursive: true })
+    expect(mkdir).toHaveBeenCalledWith(NEW_DIR, { recursive: true })
     expect(writeFile).toHaveBeenCalledWith(
-      expect.stringContaining(join('.openfox', 'workspace.json')),
+      NEW_PATH,
       JSON.stringify({ setup: ['npm install --prefer-offline'] }, null, 2) + '\n',
       'utf-8',
     )
+  })
+
+  it('does NOT write to old .openfox/workspace.json location', async () => {
+    vi.mocked(mkdir).mockResolvedValue(undefined)
+    vi.mocked(writeFile).mockResolvedValue(undefined)
+
+    await saveWorkspaceConfig(WORKDIR, { setup: ['npm install'] })
+
+    const writePaths = vi.mocked(writeFile).mock.calls.map((c) => c[0])
+    for (const path of writePaths) {
+      expect(path).not.toContain(join(WORKDIR, '.openfox'))
+    }
   })
 
   it('saves config without setup', async () => {
@@ -63,6 +177,72 @@ describe('saveWorkspaceConfig', () => {
 
     await saveWorkspaceConfig(WORKDIR, {})
 
-    expect(writeFile).toHaveBeenCalledWith(expect.any(String), JSON.stringify({}, null, 2) + '\n', 'utf-8')
+    expect(writeFile).toHaveBeenCalledWith(NEW_PATH, JSON.stringify({}, null, 2) + '\n', 'utf-8')
+  })
+
+  it('saves config with rootDir', async () => {
+    vi.mocked(mkdir).mockResolvedValue(undefined)
+    vi.mocked(writeFile).mockResolvedValue(undefined)
+
+    await saveWorkspaceConfig(WORKDIR, { rootDir: '/custom/workspaces' })
+
+    expect(writeFile).toHaveBeenCalledWith(
+      NEW_PATH,
+      JSON.stringify({ rootDir: '/custom/workspaces' }, null, 2) + '\n',
+      'utf-8',
+    )
+  })
+
+  it('saves config with both rootDir and setup', async () => {
+    vi.mocked(mkdir).mockResolvedValue(undefined)
+    vi.mocked(writeFile).mockResolvedValue(undefined)
+
+    await saveWorkspaceConfig(WORKDIR, { rootDir: '/custom/workspaces', setup: ['npm install'] })
+
+    expect(writeFile).toHaveBeenCalledWith(
+      NEW_PATH,
+      JSON.stringify({ rootDir: '/custom/workspaces', setup: ['npm install'] }, null, 2) + '\n',
+      'utf-8',
+    )
+  })
+})
+
+describe('config path computation', () => {
+  it('uses sha256(workdir).slice(0,16) for the projects subdirectory', async () => {
+    vi.mocked(readFile).mockResolvedValue(JSON.stringify({ setup: ['npm install'] }))
+
+    await loadWorkspaceConfig(WORKDIR)
+
+    expect(createHash).toHaveBeenCalledWith('sha256')
+    const readPaths = vi.mocked(readFile).mock.calls.map((c) => c[0])
+    expect(readPaths[0]).toContain(HASH)
+  })
+
+  it('resolves workdir before hashing', async () => {
+    vi.mocked(readFile).mockResolvedValue(JSON.stringify({ setup: ['npm install'] }))
+
+    await loadWorkspaceConfig(WORKDIR)
+
+    const hashInstance = (createHash as ReturnType<typeof vi.fn>).mock.results[0]?.value
+    expect(hashInstance.update).toHaveBeenCalled()
+  })
+
+  it('stores config under XDG_CONFIG_HOME/openfox/projects/{hash}/', async () => {
+    vi.mocked(readFile).mockResolvedValue(JSON.stringify({ setup: ['lint'] }))
+
+    await loadWorkspaceConfig(WORKDIR)
+
+    const readPaths = vi.mocked(readFile).mock.calls.map((c) => c[0])
+    expect(readPaths[0]).toContain('.config/openfox/projects/')
+  })
+})
+
+describe('signature compatibility', () => {
+  it('loadWorkspaceConfig accepts single workdir argument', () => {
+    expect(loadWorkspaceConfig).toHaveLength(1)
+  })
+
+  it('saveWorkspaceConfig accepts two arguments (workdir, config)', () => {
+    expect(saveWorkspaceConfig).toHaveLength(2)
   })
 })

--- a/src/server/git/workspace-config.ts
+++ b/src/server/git/workspace-config.ts
@@ -1,17 +1,29 @@
 import { readFile, writeFile, mkdir } from 'node:fs/promises'
 import { resolve, join } from 'node:path'
+import { homedir } from 'node:os'
+import { createHash } from 'node:crypto'
 import type { WorkspaceConfig } from '../../shared/workspace.js'
 
-const CONFIG_FILENAME = '.openfox/workspace.json'
-
-function getConfigPath(workdir: string): string {
-  return join(resolve(workdir), CONFIG_FILENAME)
+function getGlobalConfigDir(): string {
+  const suffix = process.env['OPENFOX_DEV'] === 'true' ? '-dev' : ''
+  return join(homedir(), '.config', `openfox${suffix}`)
 }
 
-export async function loadWorkspaceConfig(workdir: string): Promise<WorkspaceConfig | null> {
+function getOldConfigPath(workdir: string): string {
+  return join(resolve(workdir), '.openfox', 'workspace.json')
+}
+
+function getNewConfigDir(workdir: string): string {
+  const hash = createHash('sha256').update(resolve(workdir)).digest('hex').slice(0, 16)
+  return join(getGlobalConfigDir(), 'projects', hash)
+}
+
+function getNewConfigPath(workdir: string): string {
+  return join(getNewConfigDir(workdir), 'workspace.json')
+}
+
+function parseRaw(raw: string): WorkspaceConfig | null {
   try {
-    const configPath = getConfigPath(workdir)
-    const raw = await readFile(configPath, 'utf-8')
     const parsed = JSON.parse(raw)
     const config: WorkspaceConfig = {}
     if (parsed.setup) config.setup = parsed.setup
@@ -22,10 +34,33 @@ export async function loadWorkspaceConfig(workdir: string): Promise<WorkspaceCon
   }
 }
 
+export async function loadWorkspaceConfig(workdir: string): Promise<WorkspaceConfig | null> {
+  const newPath = getNewConfigPath(workdir)
+  try {
+    const raw = await readFile(newPath, 'utf-8')
+    return parseRaw(raw)
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code !== 'ENOENT') return null
+  }
+
+  try {
+    const oldPath = getOldConfigPath(workdir)
+    const raw = await readFile(oldPath, 'utf-8')
+    const config = parseRaw(raw)
+    if (!config) return null
+
+    const dir = getNewConfigDir(workdir)
+    await mkdir(dir, { recursive: true })
+    await writeFile(newPath, JSON.stringify(config, null, 2) + '\n', 'utf-8')
+    return config
+  } catch {
+    return null
+  }
+}
+
 export async function saveWorkspaceConfig(workdir: string, config: WorkspaceConfig): Promise<void> {
-  const resolved = resolve(workdir)
-  const dirPath = join(resolved, '.openfox')
-  await mkdir(dirPath, { recursive: true })
-  const configPath = getConfigPath(workdir)
+  const dir = getNewConfigDir(workdir)
+  await mkdir(dir, { recursive: true })
+  const configPath = getNewConfigPath(workdir)
   await writeFile(configPath, JSON.stringify(config, null, 2) + '\n', 'utf-8')
 }


### PR DESCRIPTION
### Summary

Le fichier de configuration du workspace OpenFox (`{project}/.openfox/workspace.json`), qui définit notamment le `rootDir` (répertoire racine où sont créés les workspaces d'un projet), est déplacé dans le répertoire de configuration global de l'utilisateur.

**Pourquoi ?** Ce fichier contient des paramètres utilisateur-spécifiques qui n'ont pas leur place dans l'arbre du projet. En le déplaçant dans le répertoire global d'OpenFox :
- Chaque utilisateur peut configurer son propre `rootDir` sans risquer de le commiter
- Le projet reste propre (pas de fichier de config utilisateur d'openfox dans le dépôt)
- La configuration reste attachée au projet via un hash déterministe de son chemin

**Comment ?** La config est désormais stockée dans `~/.config/openfox[-dev]/projects/{sha256(workdir).slice(0,16)}/workspace.json` :

- Indexation par **hash du chemin absolu du projet** → déterministe, pas de collision entre projets
- Migration auto : si l'ancien `.openfox/workspace.json` existe dans le projet, son contenu est relu et réécrit au nouvel emplacement à la première lecture de `loadWorkspaceConfig`
- Respect de `OPENFOX_DEV` → utilise `openfox-dev/` en mode développement
- **Aucune rupture** : `loadWorkspaceConfig(workdir)` et `saveWorkspaceConfig(workdir, config)` gardent la même signature

### Informations pour la review

**Fichier modifié :** `src/server/git/workspace-config.ts`

- `getGlobalConfigDir()` → `~/.config/openfox` ou `~/.config/openfox-dev`
- `getNewConfigDir(workdir)` → `~/.config/openfox/projects/{sha256(workdir).slice(0,16)}`
- `loadWorkspaceConfig` : nouveau fichier autoritaire, migration depuis l'ancien si absent
- `saveWorkspaceConfig` : écrit uniquement au nouvel emplacement

**Tests :** 21 tests couvrant lecture, migration, cas vides/invalides, non-écriture dans l'ancien chemin, format du chemin, signatures

**Validations :**
- `workspace-config.test.ts` : 21/21
- `workspace.test.ts` : 30/30
- `routes/workspace-config.test.ts` : 22/22
- Typecheck : clean
- Suite unitaire complète : 2599 pass

### AI-Enhanced Development

- **AI Models:** DeepSeek V4 Flash

### Cache Impact

- **No** — seuls les chemins de stockage de la config workspace changent ; rien de ce qui est mis en cache (system prompts, tool definitions, skills) n'est affecté.