### PR TITLE
feat: per-session and per-project MCP server toggles

### DIFF
--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -124,6 +124,7 @@ const mcpServerSchema = z.object({
   disabledTools: z.array(z.string()).optional(),
   cachedTools: z.array(cachedToolSchema).optional(),
   timeout: z.number().positive().optional(),
+  disabled: z.boolean().optional(),
 })
 
 const llmConfigSchema = z.object({

--- a/src/server/chat/orchestrator.ts
+++ b/src/server/chat/orchestrator.ts
@@ -393,7 +393,7 @@ export async function runAgentTurn(
           toolChoice: input.toolChoice,
         })
       },
-      getToolRegistry: () => getToolRegistryForAgent(agentDef),
+      getToolRegistry: () => getToolRegistryForAgent(agentDef, options.sessionId),
       getConversationMessages: buildGetConversationMessages(options.sessionId, options.llmClient, append),
       injectAgentReminder: () => injectAgentReminder(options.sessionId, agentDef),
       ...(options.initialCompacting ? { initialCompacting: true } : {}),

--- a/src/server/db/index.ts
+++ b/src/server/db/index.ts
@@ -159,6 +159,12 @@ function runMigrations(db: Database.Database): void {
     db.exec(`ALTER TABLE projects ADD COLUMN workspace_root_dir TEXT`)
   }
 
+  // Migration: Add mcp_disabled_servers column to sessions table
+  if (!columnNames.includes('mcp_disabled_servers')) {
+    logger.info('Migrating sessions table: adding mcp_disabled_servers column')
+    db.exec(`ALTER TABLE sessions ADD COLUMN mcp_disabled_servers TEXT`)
+  }
+
   // Create events table for EventStore (single source of truth)
   // Note: EventStore creates this table with its own schema in initSchema()
   // We just ensure the index exists for the event_type column

--- a/src/server/db/sessions.ts
+++ b/src/server/db/sessions.ts
@@ -213,6 +213,13 @@ export function updateSessionMetadata(id: string, metadata: Partial<Session['met
   ).run(...values)
 }
 
+export function updateSessionMcpDisabledServers(id: string, disabledServers: string[]): void {
+  const db = getDatabase()
+  const now = new Date().toISOString()
+  const value = disabledServers.length > 0 ? JSON.stringify(disabledServers) : null
+  db.prepare(`UPDATE sessions SET mcp_disabled_servers = ?, updated_at = ? WHERE id = ?`).run(value, now, id)
+}
+
 export function updateSessionCachedPrompt(
   id: string,
   systemPrompt: string,

--- a/src/server/git/workspace-config.ts
+++ b/src/server/git/workspace-config.ts
@@ -16,6 +16,7 @@ export async function loadWorkspaceConfig(workdir: string): Promise<WorkspaceCon
     const parsed = JSON.parse(raw)
     const config: WorkspaceConfig = {}
     if (parsed.setup) config.setup = parsed.setup
+    if (parsed.mcpOverrides && typeof parsed.mcpOverrides === 'object') config.mcpOverrides = parsed.mcpOverrides
 
     // Migration: copy legacy rootDir from file to DB if project exists
     if (parsed.rootDir) {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -25,6 +25,7 @@ import {
   setMcpConfigPath,
   setNotifyMcpServersChanged,
 } from './tools/mcp-config.js'
+import { getSessionDisabledServers, setSessionDisabledServers } from './mcp/session-overrides.js'
 import { createServerMessage } from '../shared/protocol.js'
 import { createContextStateMessage } from './ws/protocol.js'
 import { createWebSocketServer } from './ws/index.js'
@@ -685,6 +686,30 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
 
     // maxTokens is no longer passed - it comes from providerManager.getCurrentModelContext() at query time
     const session = sessionManager.createSession(projectId, title, providerId ?? null, model ?? null)
+
+    // Inherit MCP overrides from project's workspace config for new sessions
+    try {
+      const { loadWorkspaceConfig } = await import('./git/workspace-config.js')
+      const wsConfig = await loadWorkspaceConfig(project.workdir)
+      let disabledServers: string[] = []
+      if (wsConfig?.mcpOverrides) {
+        disabledServers = Object.entries(wsConfig.mcpOverrides)
+          .filter(([, override]) => override.disabled)
+          .map(([name]) => name)
+      } else {
+        // No project overrides — inherit from global config
+        disabledServers = mcpManager
+          .getAllServers()
+          .filter((s) => s.config.disabled)
+          .map((s) => s.name)
+      }
+      if (disabledServers.length > 0) {
+        const { setSessionDisabledServers } = await import('./mcp/session-overrides.js')
+        setSessionDisabledServers(session.id, disabledServers)
+      }
+    } catch {
+      // Non-critical — session works without MCP overrides
+    }
     wssExports.broadcastForProject(projectId, session.id, {
       type: 'session.created',
       sessionId: session.id,
@@ -1039,6 +1064,31 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
     const updatedSession = sessionManager.getSession(sessionId)
 
     res.json({ session: updatedSession })
+  })
+
+  // Session MCP server overrides (per-session)
+  app.get('/api/sessions/:id/mcp/overrides', async (req, res) => {
+    const sessionId = req.params.id
+    const session = sessionManager.getSession(sessionId)
+    if (!session) {
+      return res.status(404).json({ error: 'Session not found' })
+    }
+    const disabledServers = getSessionDisabledServers(sessionId)
+    res.json({ disabledServers })
+  })
+
+  app.put('/api/sessions/:id/mcp/overrides', async (req, res) => {
+    const sessionId = req.params.id
+    const session = sessionManager.getSession(sessionId)
+    if (!session) {
+      return res.status(404).json({ error: 'Session not found' })
+    }
+    const { disabledServers } = req.body as { disabledServers?: string[] }
+    if (!Array.isArray(disabledServers)) {
+      return res.status(400).json({ error: 'disabledServers must be an array of strings' })
+    }
+    setSessionDisabledServers(sessionId, disabledServers)
+    res.json({ disabledServers: getSessionDisabledServers(sessionId) })
   })
 
   // Rename session (REST)
@@ -2245,6 +2295,9 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
         }
       }
 
+      const allServers = mcpManager.getAllServers()
+      wssExports.broadcastAll(createServerMessage('mcp.servers.changed', { servers: allServers }))
+
       res.status(201).json({ server })
     } catch (error) {
       res.status(400).json({ error: error instanceof Error ? error.message : String(error) })
@@ -2259,7 +2312,7 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
     }
 
     const body = req.body as Record<string, unknown>
-    const { transport: rawTransport, command, args, env, url, headers, timeout } = body
+    const { transport: rawTransport, command, args, env, url, headers, timeout, disabled } = body
 
     if (rawTransport !== undefined && rawTransport !== 'stdio' && rawTransport !== 'http') {
       return res.status(400).json({ error: `Invalid transport '${String(rawTransport)}'. Must be 'stdio' or 'http'.` })
@@ -2294,6 +2347,9 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
     if (timeout !== undefined && (typeof timeout !== 'number' || timeout <= 0)) {
       return res.status(400).json({ error: 'timeout must be a positive number' })
     }
+    if (disabled !== undefined && typeof disabled !== 'boolean') {
+      return res.status(400).json({ error: 'disabled must be a boolean' })
+    }
 
     try {
       const { loadGlobalConfig, saveGlobalConfig } = await import('../cli/config.js')
@@ -2313,6 +2369,7 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
         ...(url !== undefined ? { url: url as string } : {}),
         ...(headers !== undefined ? { headers: headers as Record<string, string> } : {}),
         ...(timeout !== undefined ? { timeout: timeout as number } : {}),
+        ...(disabled !== undefined ? { disabled: disabled as boolean } : {}),
       }
 
       const { error: updateError } = await applyMcpServerUpdate({
@@ -2336,6 +2393,7 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
       for (const s of sessions) {
         sessionManager.setDynamicContextChanged(s.id, true)
       }
+      wssExports.broadcastAll(createServerMessage('mcp.servers.changed', { servers: mcpManager.getAllServers() }))
       res.json({ server: mcpManager.getServer(name) })
     } catch (error) {
       res.status(400).json({ error: error instanceof Error ? error.message : String(error) })
@@ -2371,6 +2429,8 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
     for (const s of sessions) {
       sessionManager.setDynamicContextChanged(s.id, true)
     }
+
+    wssExports.broadcastAll(createServerMessage('mcp.servers.changed', { servers: mcpManager.getAllServers() }))
 
     res.json({ success: true })
   })
@@ -2413,6 +2473,8 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
       for (const s of sessions) {
         sessionManager.setDynamicContextChanged(s.id, true)
       }
+
+      wssExports.broadcastAll(createServerMessage('mcp.servers.changed', { servers: mcpManager.getAllServers() }))
 
       res.json({ success: true })
     } catch (error) {
@@ -2654,12 +2716,14 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
     () => providerManager.getActiveProvider(),
     sessionManager,
     providerManager,
+    () => mcpManager.getAllServers(),
   )
   const wss = wssExports.wss
 
   // Wire MCP config tool to broadcast changes to all connected UIs
   setNotifyMcpServersChanged((sessionId: string) => {
-    wssExports.broadcastAll(createServerMessage('mcp.servers.changed', {}))
+    const servers = mcpManager.getAllServers()
+    wssExports.broadcastAll(createServerMessage('mcp.servers.changed', { servers }))
     const state = sessionManager.getContextState(sessionId)
     wssExports.broadcastForSession(sessionId, createContextStateMessage(state))
   })

--- a/src/server/mcp/manager.test.ts
+++ b/src/server/mcp/manager.test.ts
@@ -138,6 +138,20 @@ describe('McpManager', () => {
       expect(server!.tools.find((t) => t.name === 'get_weather')!.enabled).toBe(true)
     })
 
+    it('should keep a disabled server connected', async () => {
+      await manager.addServer('disabled-server', {
+        transport: 'stdio',
+        command: 'node',
+        disabled: true,
+      })
+
+      const server = manager.getServer('disabled-server')
+      expect(server).toBeDefined()
+      expect(server!.status).toBe('connected')
+      expect(server!.config.disabled).toBe(true)
+      expect(server!.tools.length).toBeGreaterThan(0)
+    })
+
     it('should strip outputSchema from tool list responses to prevent AJV validation failure on broken $ref', async () => {
       await manager.addServer('test-server', {
         transport: 'stdio',
@@ -467,5 +481,51 @@ describe('McpManager token estimation', () => {
     const after = manager.getServer('test')!.estimatedTokens
 
     expect(after).toBeLessThan(before)
+  })
+
+  it('should not affect other servers when one server is disabled', async () => {
+    const manager = new McpManager()
+    await manager.addServer('alpha', { transport: 'stdio', command: 'node' })
+    await manager.addServer('beta', { transport: 'stdio', command: 'node' })
+
+    const alphaBefore = manager.getServer('alpha')!
+    const betaBefore = manager.getServer('beta')!
+    expect(alphaBefore.status).toBe('connected')
+    expect(betaBefore.status).toBe('connected')
+    expect(alphaBefore.tools.length).toBe(2)
+    expect(betaBefore.tools.length).toBe(2)
+
+    // Mark alpha as disabled — still connected, but filtered by getToolDefinitions
+    manager.removeServer('alpha')
+    await manager.addServer('alpha', { transport: 'stdio', command: 'node', disabled: true })
+
+    const alphaAfter = manager.getServer('alpha')!
+    const betaAfter = manager.getServer('beta')!
+
+    // alpha is still connected (disabled only affects visibility)
+    expect(alphaAfter.status).toBe('connected')
+    expect(alphaAfter.tools.length).toBe(2)
+    expect(alphaAfter.config.disabled).toBe(true)
+
+    // getToolDefinitions should filter alpha
+    const defs = manager.getToolDefinitions()
+    const alphaDefs = defs.filter((d) => d.function.name.startsWith('alpha_'))
+    expect(alphaDefs).toHaveLength(0)
+
+    // beta must be untouched
+    expect(betaAfter.status).toBe('connected')
+    expect(betaAfter.tools.length).toBe(2)
+
+    // Now re-enable alpha
+    manager.removeServer('alpha')
+    await manager.addServer('alpha', { transport: 'stdio', command: 'node' })
+
+    const alphaRe = manager.getServer('alpha')!
+    const betaRe = manager.getServer('beta')!
+
+    expect(alphaRe.status).toBe('connected')
+    expect(alphaRe.tools.length).toBe(2)
+    expect(betaRe.status).toBe('connected')
+    expect(betaRe.tools.length).toBe(2)
   })
 })

--- a/src/server/mcp/manager.ts
+++ b/src/server/mcp/manager.ts
@@ -194,14 +194,27 @@ export class McpManager {
   }
 
   getAllServers(): McpServerState[] {
-    return Array.from(this.servers.values()).map((e) => e.state)
+    return Array.from(this.servers.values())
+      .map((e) => e.state)
+      .sort((a, b) => a.name.localeCompare(b.name))
   }
 
-  getToolDefinitions(): LLMToolDefinition[] {
-    const defs: LLMToolDefinition[] = []
+  private *iterEnabledServers(override?: { disabledServers?: string[] }): Generator<ServerEntry> {
     for (const [, entry] of this.servers) {
+      if (override?.disabledServers?.includes(entry.state.name)) continue
+      const serverDisabled =
+        entry.config.disabled && (!override?.disabledServers || !override.disabledServers.includes(entry.state.name))
+      if (serverDisabled) continue
+      yield entry
+    }
+  }
+
+  getToolDefinitions(override?: { disabledServers?: string[]; disabledTools?: string[] }): LLMToolDefinition[] {
+    const defs: LLMToolDefinition[] = []
+    for (const entry of this.iterEnabledServers(override)) {
       for (const tool of entry.state.tools) {
         if (!tool.enabled) continue
+        if (override?.disabledTools?.includes(tool.name)) continue
         defs.push({
           type: 'function',
           function: {
@@ -266,9 +279,9 @@ export class McpManager {
     this.onServersChanged?.()
   }
 
-  getToolFingerprint(): string {
+  getToolFingerprint(override?: { disabledServers?: string[] }): string {
     const parts: string[] = []
-    for (const [, entry] of this.servers) {
+    for (const entry of this.iterEnabledServers(override)) {
       for (const tool of entry.state.tools) {
         if (tool.enabled) {
           parts.push(`${entry.state.name}:${tool.name}`)

--- a/src/server/mcp/session-overrides.ts
+++ b/src/server/mcp/session-overrides.ts
@@ -1,0 +1,63 @@
+import { getDatabase } from '../db/index.js'
+import { updateSessionMcpDisabledServers } from '../db/sessions.js'
+
+const sessionOverrides = new Map<string, Set<string>>()
+let initialized = false
+
+function ensureInitialized(): void {
+  if (initialized) return
+  initialized = true
+  try {
+    const db = getDatabase()
+    const rows = db
+      .prepare(
+        `SELECT id, mcp_disabled_servers FROM sessions WHERE mcp_disabled_servers IS NOT NULL AND mcp_disabled_servers != ''`,
+      )
+      .all() as { id: string; mcp_disabled_servers: string }[]
+    for (const row of rows) {
+      try {
+        const servers = JSON.parse(row.mcp_disabled_servers) as string[]
+        if (Array.isArray(servers) && servers.length > 0) {
+          sessionOverrides.set(row.id, new Set(servers))
+        }
+      } catch {
+        // ignore parse errors
+      }
+    }
+  } catch {
+    // DB might not be ready yet
+  }
+}
+
+export function getSessionDisabledServers(sessionId: string): string[] {
+  ensureInitialized()
+  return Array.from(sessionOverrides.get(sessionId) ?? [])
+}
+
+export function setSessionDisabledServers(sessionId: string, servers: string[]): void {
+  ensureInitialized()
+  if (servers.length === 0) {
+    sessionOverrides.delete(sessionId)
+  } else {
+    sessionOverrides.set(sessionId, new Set(servers))
+  }
+  try {
+    updateSessionMcpDisabledServers(sessionId, servers)
+  } catch {
+    // Non-critical — in-memory state still correct
+  }
+}
+
+export function clearSessionOverrides(sessionId: string): void {
+  sessionOverrides.delete(sessionId)
+  try {
+    updateSessionMcpDisabledServers(sessionId, [])
+  } catch {
+    // ignore
+  }
+}
+
+export function getAllSessionOverrides(): Map<string, Set<string>> {
+  ensureInitialized()
+  return sessionOverrides
+}

--- a/src/server/mcp/types.ts
+++ b/src/server/mcp/types.ts
@@ -17,12 +17,13 @@ export interface McpServerConfig {
   disabledTools?: string[]
   cachedTools?: CachedToolInfo[]
   timeout?: number
+  disabled?: boolean
 }
 
 export interface McpServerState {
   name: string
   config: McpServerConfig
-  status: 'connected' | 'disconnected' | 'error'
+  status: 'connected' | 'disconnected' | 'error' | 'disabled'
   tools: McpToolInfo[]
   estimatedTokens: number
   error?: string

--- a/src/server/mcp/update-server.test.ts
+++ b/src/server/mcp/update-server.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { McpManager } from './manager.js'
+import { applyMcpServerUpdate } from './update-server.js'
+import type { McpServerConfig } from './types.js'
+
+vi.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
+  Client: vi.fn(function () {
+    return {
+      connect: vi.fn().mockResolvedValue(undefined),
+      close: vi.fn().mockResolvedValue(undefined),
+      listTools: vi.fn().mockResolvedValue({
+        tools: [
+          {
+            name: 'get_weather',
+            description: 'Get weather',
+            inputSchema: { type: 'object', properties: { location: { type: 'string' } } },
+          },
+          {
+            name: 'write_file',
+            description: 'Write file',
+            inputSchema: { type: 'object', properties: { path: { type: 'string' } } },
+          },
+        ],
+      }),
+      callTool: vi.fn().mockResolvedValue({ content: [{ type: 'text', text: 'ok' }], isError: false }),
+    }
+  }),
+}))
+
+vi.mock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
+  StdioClientTransport: vi.fn(function () {
+    return {
+      start: vi.fn().mockResolvedValue(undefined),
+      close: vi.fn().mockResolvedValue(undefined),
+    }
+  }),
+}))
+
+const defaultCfg: McpServerConfig = { transport: 'stdio', command: 'node' }
+
+describe('applyMcpServerUpdate server isolation', () => {
+  let manager: McpManager
+  let savedCfg: McpServerConfig | undefined
+  const save = vi.fn(async (cfg: McpServerConfig) => {
+    savedCfg = cfg
+  })
+
+  beforeEach(async () => {
+    savedCfg = undefined
+    manager = new McpManager()
+    await manager.addServer('alpha', defaultCfg)
+    await manager.addServer('beta', defaultCfg)
+  })
+
+  it('both servers should be connected after setup', () => {
+    const alpha = manager.getServer('alpha')!
+    const beta = manager.getServer('beta')!
+    // Debug: if beta has an error, its .error field contains the error message
+    expect(beta.status).toBe('connected')
+    // This assertion will show the error message when it fails
+    expect(alpha.status).toBe('connected')
+    expect(alpha.tools).toHaveLength(2)
+    expect(beta.tools).toHaveLength(2)
+  })
+
+  it('should toggle alpha disabled without affecting beta', async () => {
+    const existing = manager.getServer('alpha')!
+
+    const { error } = await applyMcpServerUpdate({
+      name: 'alpha',
+      patch: { disabled: true },
+      existing,
+      persistedCfg: defaultCfg,
+      mcpManager: manager,
+      save,
+    })
+
+    expect(error).toBeUndefined()
+
+    const alpha = manager.getServer('alpha')!
+    const beta = manager.getServer('beta')!
+    // alpha is still connected (disabled only affects visibility)
+    expect(alpha.status).toBe('connected')
+    expect(alpha.config.disabled).toBe(true)
+    expect(alpha.tools.length).toBeGreaterThan(0)
+    expect(beta.status).toBe('connected')
+    expect(beta.tools).toHaveLength(2)
+  })
+
+  it('should re-enable alpha without affecting beta', async () => {
+    const existing = manager.getServer('alpha')!
+    await applyMcpServerUpdate({
+      name: 'alpha',
+      patch: { disabled: true },
+      existing,
+      persistedCfg: defaultCfg,
+      mcpManager: manager,
+      save,
+    })
+
+    const existingAfter = manager.getServer('alpha')!
+    await applyMcpServerUpdate({
+      name: 'alpha',
+      patch: { disabled: false },
+      existing: existingAfter,
+      persistedCfg: savedCfg,
+      mcpManager: manager,
+      save,
+    })
+
+    const alpha = manager.getServer('alpha')!
+    const beta = manager.getServer('beta')!
+    expect(alpha.status).toBe('connected')
+    expect(alpha.tools).toHaveLength(2)
+    expect(beta.status).toBe('connected')
+    expect(beta.tools).toHaveLength(2)
+  })
+
+  it('should not affect beta after patch with no disabled field', async () => {
+    const existing = manager.getServer('alpha')!
+
+    const { error } = await applyMcpServerUpdate({
+      name: 'alpha',
+      patch: {},
+      existing,
+      persistedCfg: defaultCfg,
+      mcpManager: manager,
+      save,
+    })
+
+    expect(error).toBeUndefined()
+
+    const alpha = manager.getServer('alpha')!
+    const beta = manager.getServer('beta')!
+    expect(alpha.status).toBe('connected')
+    expect(alpha.tools).toHaveLength(2)
+    expect(beta.status).toBe('connected')
+    expect(beta.tools).toHaveLength(2)
+  })
+})

--- a/src/server/mcp/update-server.ts
+++ b/src/server/mcp/update-server.ts
@@ -9,6 +9,7 @@ export interface McpServerPatch {
   url?: string
   headers?: Record<string, string>
   timeout?: number
+  disabled?: boolean
 }
 
 export interface ApplyMcpServerUpdateOptions {
@@ -37,6 +38,7 @@ export function buildUpdatedServerConfig(
   const mergedHeaders =
     patch.headers !== undefined ? patch.headers : transportChanged ? undefined : existing.config.headers
   const mergedTimeout = patch.timeout !== undefined ? patch.timeout : existing.config.timeout
+  const mergedDisabled = patch.disabled !== undefined ? patch.disabled : existing.config.disabled
 
   if (patch.timeout !== undefined && (typeof patch.timeout !== 'number' || patch.timeout <= 0)) {
     return { serverCfg: {} as McpServerConfig, error: 'timeout must be a positive number' }
@@ -57,6 +59,7 @@ export function buildUpdatedServerConfig(
     ...(mergedUrl ? { url: mergedUrl } : {}),
     ...(mergedHeaders && Object.keys(mergedHeaders).length > 0 ? { headers: mergedHeaders } : {}),
     ...(mergedTimeout !== undefined ? { timeout: mergedTimeout } : {}),
+    ...(mergedDisabled !== undefined ? { disabled: mergedDisabled } : {}),
     ...(persistedCfg?.disabledTools && persistedCfg.disabledTools.length > 0
       ? { disabledTools: persistedCfg.disabledTools }
       : {}),

--- a/src/server/routes/workspace-config.ts
+++ b/src/server/routes/workspace-config.ts
@@ -76,16 +76,31 @@ export function createWorkspaceConfigRoutes(): Router {
   router.post('/config', async (req, res) => {
     const workdir = req.query['workdir'] as string
     if (!workdir) return res.status(400).json({ error: 'workdir required' })
-    const { setup, rootDir } = req.body
-    if (!Array.isArray(setup) && typeof rootDir !== 'string') {
-      return res.status(400).json({ error: 'At least one of setup or rootDir must be provided' })
+    const { setup, rootDir, mcpOverrides } = req.body
+    if (!Array.isArray(setup) && typeof rootDir !== 'string' && mcpOverrides === undefined) {
+      return res.status(400).json({ error: 'At least one of setup, rootDir, or mcpOverrides must be provided' })
     }
     if (setup !== undefined && !Array.isArray(setup)) {
       return res.status(400).json({ error: 'setup must be an array of strings' })
     }
-    const config: WorkspaceConfig = {}
+    if (
+      mcpOverrides !== undefined &&
+      (typeof mcpOverrides !== 'object' || mcpOverrides === null || Array.isArray(mcpOverrides))
+    ) {
+      return res.status(400).json({ error: 'mcpOverrides must be an object mapping server names to overrides' })
+    }
+    // Merge with existing config to preserve fields not in this request
+    const existing = await loadWorkspaceConfig(workdir)
+    const config: WorkspaceConfig = { ...existing }
     if (Array.isArray(setup)) {
       config.setup = setup
+    }
+    if (mcpOverrides !== undefined) {
+      if (Object.keys(mcpOverrides).length > 0) {
+        config.mcpOverrides = mcpOverrides
+      } else {
+        delete config.mcpOverrides
+      }
     }
     let savedRootDir: string | null | undefined // null=clear, string=set, undefined=skip
     if (typeof rootDir === 'string') {

--- a/src/server/tools/index.ts
+++ b/src/server/tools/index.ts
@@ -1,6 +1,7 @@
 import type { ToolResult } from '../../shared/types.js'
 import type { Tool, ToolRegistry, ToolContext } from './types.js'
 import type { AgentDefinition } from '../agents/types.js'
+import { getSessionDisabledServers } from '../mcp/session-overrides.js'
 import { readFileTool } from './read.js'
 import { writeFileTool } from './write.js'
 import { editFileTool } from './edit.js'
@@ -351,7 +352,7 @@ export function getToolRegistryForSubAgent(toolNames: string[]): ToolRegistry {
  *
  * Logs warnings for unknown tool names.
  */
-export function getToolRegistryForAgent(agentDef: AgentDefinition): ToolRegistry {
+export function getToolRegistryForAgent(agentDef: AgentDefinition, sessionId?: string): ToolRegistry {
   if (agentDef.metadata.subagent) {
     return getToolRegistryForSubAgent(agentDef.metadata.allowedTools)
   }
@@ -361,10 +362,21 @@ export function getToolRegistryForAgent(agentDef: AgentDefinition): ToolRegistry
   const allTools = getAllToolsMap()
   const tools: Tool[] = []
 
+  // Get session-level MCP disabled servers to filter out
+  const disabledMcpServers = sessionId ? new Set(getSessionDisabledServers(sessionId)) : new Set<string>()
+
   for (const [name, tool] of allTools.entries()) {
     // Exclude return_value from top-level agents
     if (name === 'return_value') {
       continue
+    }
+    // Filter out MCP tools disabled for this session
+    if (disabledMcpServers.size > 0) {
+      const underscoreIdx = name.indexOf('_')
+      if (underscoreIdx > 0) {
+        const serverName = name.slice(0, underscoreIdx)
+        if (disabledMcpServers.has(serverName)) continue
+      }
     }
     tools.push(tool)
   }

--- a/src/server/ws/server.ts
+++ b/src/server/ws/server.ts
@@ -347,6 +347,7 @@ export function createWebSocketServer(
   getActiveProvider: (() => Provider | undefined) | undefined,
   sessionManager: SessionManager,
   providerManager?: ProviderManager,
+  getMcpServers?: () => import('../mcp/types.js').McpServerState[],
 ): WebSocketServerExports {
   const wss = new WebSocketServer({ server: httpServer })
   const clients = new Map<WebSocket, ClientConnection>()
@@ -782,6 +783,7 @@ export function createWebSocketServer(
           startTurnWithCompletionChain,
           cleanupAfterTurn,
           enqueueSend,
+          getMcpServers,
         )
       } catch (error) {
         logger.error('Error handling client message', { error, type: message.type })
@@ -871,6 +873,7 @@ async function handleClientMessage(
     setRunningOnEarlyReturn: boolean,
   ) => void,
   enqueueSendFn: (client: ClientConnection, data: string, seq: number) => void,
+  getMcpServers?: () => import('../mcp/types.js').McpServerState[],
 ): Promise<void> {
   const send = (msg: ServerMessage) => {
     if (ws.readyState === WebSocket.OPEN) {
@@ -963,11 +966,21 @@ async function handleClientMessage(
       sendContextState()
 
       // Re-detect dynamic context changes on load (survives server restart)
+      // Also send MCP server state once MCP is ready
       const cachedHash = sessionManager.getCachedPrompt(session.id)?.hash
-      if (cachedHash) {
-        ;(async () => {
-          try {
-            await mcpReadyPromise
+      ;(async () => {
+        try {
+          await mcpReadyPromise
+
+          // Send current MCP server state
+          if (getMcpServers) {
+            const servers = getMcpServers()
+            if (servers.length > 0) {
+              send(createServerMessage('mcp.servers.changed', { servers }))
+            }
+          }
+
+          if (cachedHash) {
             const currentHash = await computeSessionHash(sessionManager, session.id)
             if (currentHash !== cachedHash) {
               sessionManager.setDynamicContextChanged(session.id, true)
@@ -976,11 +989,11 @@ async function handleClientMessage(
               sessionManager.setDynamicContextChanged(session.id, false)
               sendContextState()
             }
-          } catch {
-            // Non-critical — banner just won't appear on reload
           }
-        })()
-      }
+        } catch {
+          // Non-critical — banners and MCP state just won't be sent
+        }
+      })()
       break
     }
 

--- a/src/shared/workspace.ts
+++ b/src/shared/workspace.ts
@@ -1,5 +1,11 @@
+export interface McpProjectOverride {
+  disabled?: boolean
+  disabledTools?: string[]
+}
+
 export interface WorkspaceConfig {
   setup?: string[]
+  mcpOverrides?: Record<string, McpProjectOverride>
 }
 
 /**

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6,6 +6,7 @@ import { useWebSocket } from './hooks/useWebSocket'
 import { useSessionStore } from './stores/session'
 import { useProjectStore } from './stores/project'
 import { useConfigStore } from './stores/config'
+import { useMcpStore } from './stores/mcp'
 import { useThemeStore } from './stores/theme'
 import { useProjectLoader } from './hooks/useProjectLoader'
 import { useSessionLoader } from './hooks/useSessionLoader'
@@ -167,6 +168,8 @@ function App() {
             SETTINGS_KEYS.DISPLAY_USER_PRESETS,
             SETTINGS_KEYS.KEYBINDINGS,
           ])
+        // Eagerly load MCP servers for the chat MCP indicator
+        useMcpStore.getState().fetchServers()
       })
     }
   }, [connectionStatus, hasToken, fetchConfig])

--- a/web/src/components/plan/AgentSelector.tsx
+++ b/web/src/components/plan/AgentSelector.tsx
@@ -4,6 +4,7 @@ import { ChevronDownIcon, CheckIcon } from '../shared/icons'
 import { useAgentsStore, getAgentColor } from '../../stores/agents'
 import { AgentsModal } from '../settings/AgentsModal'
 import { useKeybindings } from '../../hooks/useKeybindings'
+import { useClickOutside } from '../../hooks/useClickOutside'
 import { formatKeybinding } from '../../lib/keybindings'
 export function AgentSelector() {
   const currentMode = useSessionStore((state) => state.currentSession?.mode)
@@ -22,15 +23,7 @@ export function AgentSelector() {
   }, [fetchAgents])
 
   // Close dropdown when clicking outside
-  useEffect(() => {
-    function handleClickOutside(event: MouseEvent) {
-      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
-        setIsOpen(false)
-      }
-    }
-    document.addEventListener('mousedown', handleClickOutside)
-    return () => document.removeEventListener('mousedown', handleClickOutside)
-  }, [])
+  useClickOutside(dropdownRef, () => setIsOpen(false))
 
   const keybindings = useKeybindings()
 

--- a/web/src/components/plan/ChatInput.tsx
+++ b/web/src/components/plan/ChatInput.tsx
@@ -17,6 +17,7 @@ import { QueuedMessages } from './QueuedMessages'
 import { AgentSelector } from './AgentSelector'
 import { DangerLevelSelector } from './DangerLevelSelector'
 import { ProviderSelector } from '../settings/ProviderSelector'
+import { McpSelector } from './McpSelector'
 import {
   AtMentionAutocomplete,
   type AtMentionAutocompleteHandle,
@@ -508,7 +509,10 @@ export function ChatInput({
           <AgentSelector />
           <DangerLevelSelector />
         </div>
-        <ProviderSelector />
+        <div className="flex items-center gap-2">
+          <McpSelector />
+          <ProviderSelector />
+        </div>
       </div>
     </form>
   )

--- a/web/src/components/plan/McpSelector.test.tsx
+++ b/web/src/components/plan/McpSelector.test.tsx
@@ -1,0 +1,155 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { McpSelector } from './McpSelector'
+import { useMcpStore } from '../../stores/mcp'
+
+// State shared between mock and tests
+let mockServers: Array<{
+  name: string
+  status: string
+  tools: { name: string; enabled: boolean; description?: string; estimatedTokens: number }[]
+  estimatedTokens: number
+  config: { disabled?: boolean }
+}> = [
+  {
+    name: 'alpha',
+    status: 'connected',
+    tools: [{ name: 'tool-a', enabled: true, estimatedTokens: 100 }],
+    estimatedTokens: 100,
+    config: {},
+  },
+  {
+    name: 'beta',
+    status: 'connected',
+    tools: [{ name: 'tool-b', enabled: true, estimatedTokens: 200 }],
+    estimatedTokens: 200,
+    config: {},
+  },
+]
+
+let sessionDisabledServers: string[] = []
+
+vi.mock('../../lib/api', () => ({
+  authFetch: vi.fn(async (url: string, options?: RequestInit) => {
+    const urlStr = String(url)
+    if (urlStr.includes('/mcp/overrides')) {
+      if (options?.method === 'PUT') {
+        const body = JSON.parse(options.body as string) as { disabledServers?: string[] }
+        sessionDisabledServers = body.disabledServers ?? []
+        return { ok: true, json: async () => ({ disabledServers: sessionDisabledServers }) }
+      }
+      return { ok: true, json: async () => ({ disabledServers: sessionDisabledServers }) }
+    }
+    if (options?.method === 'PUT') {
+      const match = urlStr.match(/\/api\/mcp\/servers\/([^/]+)/)
+      if (match) {
+        const serverName = decodeURIComponent(match[1]!)
+        const body = JSON.parse(options.body as string) as { disabled: boolean }
+        const server = mockServers.find((s) => s.name === serverName)
+        if (server) {
+          server.config = { ...server.config, disabled: body.disabled }
+        }
+      }
+      return { ok: true, json: async () => ({}) }
+    }
+    return { ok: true, json: async () => ({ servers: [...mockServers] }) }
+  }),
+}))
+
+vi.mock('../../stores/session', () => ({
+  useSessionStore: vi.fn((selector) => {
+    const state = { currentSession: { id: 'session-1' } }
+    return selector(state)
+  }),
+  useIsRunning: vi.fn(() => false),
+}))
+
+describe('McpSelector server toggle isolation', () => {
+  beforeEach(() => {
+    mockServers = [
+      {
+        name: 'alpha',
+        status: 'connected',
+        tools: [{ name: 'tool-a', enabled: true, estimatedTokens: 100 }],
+        estimatedTokens: 100,
+        config: {},
+      },
+      {
+        name: 'beta',
+        status: 'connected',
+        tools: [{ name: 'tool-b', enabled: true, estimatedTokens: 200 }],
+        estimatedTokens: 200,
+        config: {},
+      },
+    ]
+    sessionDisabledServers = []
+    useMcpStore.getState().setServers(mockServers)
+  })
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('toggling alpha via session API', async () => {
+    const user = userEvent.setup()
+    render(<McpSelector />)
+
+    const trigger = screen.getByText(/MCP/)
+    await user.click(trigger)
+
+    const toggles = screen.getAllByRole('switch')
+    const { authFetch } = await import('../../lib/api')
+    const mockFn = authFetch as ReturnType<typeof vi.fn>
+    mockFn.mockClear()
+
+    await user.click(toggles[0]!)
+
+    const putCalls = mockFn.mock.calls.filter(
+      (call: unknown[]) => (call[1] as Record<string, unknown>)?.method === 'PUT',
+    )
+    expect(putCalls.length).toBeGreaterThanOrEqual(1)
+    const putCall = putCalls.find((c: unknown[]) => String(c[0]).includes('session-1'))
+    expect(putCall).toBeDefined()
+    expect(JSON.parse((putCall![1] as Record<string, string>).body as string)).toEqual({ disabledServers: ['alpha'] })
+  })
+
+  it('toggling beta via session API', async () => {
+    const user = userEvent.setup()
+    render(<McpSelector />)
+
+    const trigger = screen.getByText(/MCP/)
+    await user.click(trigger)
+    const toggles = screen.getAllByRole('switch')
+
+    const { authFetch } = await import('../../lib/api')
+    const mockFn = authFetch as ReturnType<typeof vi.fn>
+    mockFn.mockClear()
+
+    await user.click(toggles[1]!)
+
+    const putCalls = mockFn.mock.calls.filter(
+      (call: unknown[]) => (call[1] as Record<string, unknown>)?.method === 'PUT',
+    )
+    expect(putCalls.length).toBeGreaterThanOrEqual(1)
+    const putCall = putCalls.find((c: unknown[]) => String(c[0]).includes('session-1'))
+    expect(putCall).toBeDefined()
+    expect(JSON.parse((putCall![1] as Record<string, string>).body as string)).toEqual({ disabledServers: ['beta'] })
+  })
+
+  it('state isolation: toggling alpha does not affect beta store state', async () => {
+    const user = userEvent.setup()
+    render(<McpSelector />)
+
+    const trigger = screen.getByText(/MCP/)
+    await user.click(trigger)
+    const toggles = screen.getAllByRole('switch')
+
+    await user.click(toggles[0]!)
+
+    // After toggling alpha, alpha should be session-disabled
+    expect(sessionDisabledServers).toEqual(['alpha'])
+  })
+})

--- a/web/src/components/plan/McpSelector.tsx
+++ b/web/src/components/plan/McpSelector.tsx
@@ -1,0 +1,160 @@
+import { useState, useRef, useEffect, useCallback } from 'react'
+import { ChevronDownIcon } from '../shared/icons'
+import { Toggle } from '../shared/Toggle'
+import { useMcpStore } from '../../stores/mcp'
+import { useSessionStore } from '../../stores/session'
+import { mcpStatusColor, mcpStatusDot, formatTokens } from '../../lib/mcp-utils'
+import { authFetch } from '../../lib/api'
+import { useClickOutside } from '../../hooks/useClickOutside'
+
+export function McpSelector() {
+  const servers = useMcpStore((s) => s.servers)
+  const fetchServers = useMcpStore((s) => s.fetchServers)
+  const currentSession = useSessionStore((s) => s.currentSession)
+  const sessionId = currentSession?.id
+  const [isOpen, setIsOpen] = useState(false)
+  const [toggleError, setToggleError] = useState<string | null>(null)
+  const [togglingServers, setTogglingServers] = useState<Set<string>>(new Set())
+  const [sessionDisabledServers, setSessionDisabledServers] = useState<Set<string>>(new Set())
+  const dropdownRef = useRef<HTMLDivElement>(null)
+
+  const fetchSessionOverrides = useCallback(async () => {
+    if (!sessionId) return
+    try {
+      const res = await authFetch(`/api/sessions/${sessionId}/mcp/overrides`)
+      if (res.ok) {
+        const data = await res.json()
+        setSessionDisabledServers(new Set(data.disabledServers ?? []))
+      }
+    } catch {
+      // ignore
+    }
+  }, [sessionId])
+
+  const refresh = useCallback(async () => {
+    await fetchServers()
+    await fetchSessionOverrides()
+  }, [fetchServers, fetchSessionOverrides])
+
+  useEffect(() => {
+    const handler = () => refresh()
+    window.addEventListener('mcp-servers-changed', handler)
+    return () => window.removeEventListener('mcp-servers-changed', handler)
+  }, [refresh])
+
+  useEffect(() => {
+    fetchSessionOverrides()
+  }, [fetchSessionOverrides])
+
+  useEffect(() => {
+    if (isOpen) {
+      fetchSessionOverrides()
+    }
+  }, [isOpen, fetchSessionOverrides])
+
+  useClickOutside(dropdownRef, () => setIsOpen(false))
+
+  const isServerEffectiveDisabled = (server: { name: string }) => {
+    return sessionDisabledServers.has(server.name)
+  }
+
+  const connected = servers.filter((s) => s.status === 'connected' && !isServerEffectiveDisabled(s))
+  const connectedCount = connected.length
+  const totalTokens = connected.reduce((sum, s) => sum + s.estimatedTokens, 0)
+
+  const handleToggleServer = async (serverName: string, newDisabled: boolean) => {
+    if (!sessionId) return
+    setToggleError(null)
+    setTogglingServers((prev) => new Set(prev).add(serverName))
+    try {
+      const newSet = new Set(sessionDisabledServers)
+      if (newDisabled) {
+        newSet.add(serverName)
+      } else {
+        newSet.delete(serverName)
+      }
+      const res = await authFetch(`/api/sessions/${sessionId}/mcp/overrides`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ disabledServers: Array.from(newSet) }),
+      })
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}))
+        throw new Error((data as { error?: string }).error ?? 'Toggle failed')
+      }
+      setSessionDisabledServers(newSet)
+      await fetchServers()
+    } catch (err) {
+      setToggleError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setTogglingServers((prev) => {
+        const next = new Set(prev)
+        next.delete(serverName)
+        return next
+      })
+    }
+  }
+
+  return (
+    <div className="relative" ref={dropdownRef}>
+      <button
+        type="button"
+        onClick={() => setIsOpen(!isOpen)}
+        className="flex items-center gap-1 px-1.5 py-0.5 rounded hover:bg-bg-tertiary transition-colors group"
+        title={connectedCount > 0 ? `${connectedCount} MCP server(s) active` : 'No MCP server active'}
+      >
+        <span className="text-sm text-accent-primary whitespace-nowrap">
+          {connectedCount > 0 ? `● ${connectedCount} MCP (${formatTokens(totalTokens)})` : 'MCP'}
+        </span>
+        <ChevronDownIcon className="w-3 h-3 text-text-muted transition-transform" rotate={isOpen ? 180 : 0} />
+      </button>
+
+      {isOpen && (
+        <div className="absolute bottom-full right-0 mb-1 min-w-72 max-w-[100vw] bg-bg-secondary border border-border rounded-lg shadow-lg z-50 flex flex-col max-h-[80vh]">
+          <div className="overflow-y-auto flex-1 min-h-0">
+            {servers.length === 0 ? (
+              <div className="px-4 py-3 text-sm text-text-muted text-center">No MCP servers configured</div>
+            ) : (
+              servers.map((server) => {
+                const effectiveDisabled = isServerEffectiveDisabled(server)
+                const isToggling = togglingServers.has(server.name)
+                return (
+                  <div key={server.name}>
+                    <div className="px-3 py-2 flex items-center justify-between hover:bg-bg-tertiary">
+                      <div className="flex flex-col min-w-0 flex-1">
+                        <div className="flex items-center gap-1.5 min-w-0">
+                          <span className={`text-sm ${mcpStatusColor(effectiveDisabled ? 'disabled' : server.status)}`}>
+                            {mcpStatusDot(effectiveDisabled ? 'disabled' : server.status)}
+                          </span>
+                          <span className="text-sm font-medium text-text-primary truncate">{server.name}</span>
+                        </div>
+                        <div className="flex items-center gap-2 text-xs text-text-muted ml-3.5">
+                          <span>{server.tools.length} tools</span>
+                          {server.estimatedTokens > 0 && <span>{formatTokens(server.estimatedTokens)} tokens</span>}
+                        </div>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        {isToggling && <span className="text-xs text-text-muted animate-pulse">...</span>}
+                        <Toggle
+                          enabled={!effectiveDisabled}
+                          onClick={() => handleToggleServer(server.name, !effectiveDisabled)}
+                        />
+                      </div>
+                    </div>
+                  </div>
+                )
+              })
+            )}
+          </div>
+          <div className="border-t border-border px-3 py-2 flex-shrink-0">
+            {toggleError ? (
+              <div className="text-xs text-accent-error">{toggleError}</div>
+            ) : (
+              <span className="text-xs text-text-muted">{servers.length} server(s) configured</span>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/settings/McpServerCard.tsx
+++ b/web/src/components/settings/McpServerCard.tsx
@@ -1,0 +1,90 @@
+import { Toggle } from '../shared/Toggle'
+import { formatTokens } from '../../lib/mcp-utils'
+import type { McpServerInfo } from '../../stores/mcp'
+
+interface McpServerCardTool {
+  name: string
+  description?: string
+  estimatedTokens: number
+  enabled: boolean
+}
+
+interface McpServerCardProps {
+  server: McpServerInfo
+  expanded: boolean
+  onToggleExpand: (name: string) => void
+  serverToggleEnabled: boolean
+  onServerToggle: () => void
+  tools: McpServerCardTool[]
+  onToolToggle: (toolName: string) => void
+  statusDot: string
+  statusColor: string
+  actions?: React.ReactNode
+}
+
+export function McpServerCard({
+  server,
+  expanded,
+  onToggleExpand,
+  serverToggleEnabled,
+  onServerToggle,
+  tools,
+  onToolToggle,
+  statusDot,
+  statusColor,
+  actions,
+}: McpServerCardProps) {
+  const name = server.name
+  return (
+    <div key={name} className="rounded border border-border bg-bg-tertiary overflow-hidden">
+      <div className="flex items-center justify-between p-3 hover:bg-bg-primary/50 transition-colors">
+        <div
+          className="flex items-center gap-2 min-w-0 flex-1 cursor-pointer"
+          onClick={() => onToggleExpand(name)}
+        >
+          <span className={`text-sm ${statusColor}`}>{statusDot}</span>
+          <span className="text-sm font-medium text-text-primary">{name}</span>
+          <span className="text-xs text-text-muted">{server.config.transport}</span>
+          <span className="text-xs text-text-muted">({tools.length} tools)</span>
+          <span className="text-xs text-text-muted">{formatTokens(server.estimatedTokens)} tokens</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <Toggle enabled={serverToggleEnabled} onClick={onServerToggle} />
+          {actions}
+          <span className="text-xs text-text-muted">{expanded ? '▲' : '▼'}</span>
+        </div>
+      </div>
+
+      {expanded && (
+        <div className="border-t border-border px-3 py-2 space-y-1.5">
+          {server.config.command && (
+            <div className="text-xs text-text-muted font-mono">
+              {server.config.command} {server.config.args?.join(' ') ?? ''}
+            </div>
+          )}
+          {server.config.url && <div className="text-xs text-text-muted font-mono">{server.config.url}</div>}
+          {tools.length === 0 ? (
+            <div className="text-xs text-text-muted">No tools available</div>
+          ) : (
+            <div className="space-y-1">
+              {tools.map((tool) => (
+                <div key={tool.name} className="py-1">
+                  <div className="flex items-center justify-between">
+                    <div className="min-w-0 flex-1 mr-2">
+                      <span className="text-xs text-text-primary font-mono">{tool.name}</span>
+                      {tool.description && <span className="text-xs text-text-muted ml-2">{tool.description}</span>}
+                    </div>
+                    <span className="text-xs text-text-muted mr-2 flex-shrink-0">
+                      {formatTokens(tool.estimatedTokens)}
+                    </span>
+                    <Toggle enabled={tool.enabled} onClick={() => onToolToggle(tool.name)} />
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/settings/ProjectSettingsModal.tsx
+++ b/web/src/components/settings/ProjectSettingsModal.tsx
@@ -1,9 +1,12 @@
 import { useState, useEffect, useCallback } from 'react'
 import type { Project, DangerLevel } from '@shared/types.js'
 import { Modal } from '../shared/SelfContainedModal'
+import { McpServerCard } from './McpServerCard'
 import { ModalFooter } from '../shared/ModalFooter'
 import { useProjectStore } from '../../stores/project'
 import { useWorkspaceConfigStore } from '../../stores/workspace-config'
+import { useMcpStore } from '../../stores/mcp'
+import { mcpStatusColor, mcpStatusDot } from '../../lib/mcp-utils'
 import { wsClient } from '../../lib/ws'
 import { authFetch } from '../../lib/api'
 import { getRootDirBlockReason } from '@shared/workspace.js'
@@ -48,7 +51,11 @@ export function ProjectSettingsModal({ isOpen, onClose, project }: ProjectSettin
   const [pendingWorkspaces, setPendingWorkspaces] = useState<{ name: string }[]>([])
   const [resolvedPath, setResolvedPath] = useState('')
 
-  const isDirty = instructionsDirty || dangerLevelDirty || setupDirty || rootDirDirty
+  const [mcpOverrides, setMcpOverrides] = useState<Record<string, { disabled?: boolean; disabledTools?: string[] }>>({})
+  const [mcpDirty, setMcpDirty] = useState(false)
+  const [expandedServers, setExpandedServers] = useState<Set<string>>(new Set())
+
+  const isDirty = instructionsDirty || dangerLevelDirty || setupDirty || rootDirDirty || mcpDirty
 
   useEffect(() => {
     if (isOpen) {
@@ -58,6 +65,8 @@ export function ProjectSettingsModal({ isOpen, onClose, project }: ProjectSettin
       setDangerLevelDirty(false)
       setSetupDirty(false)
       setRootDirDirty(false)
+      setMcpDirty(false)
+      setExpandedServers(new Set())
       fetchWsConfig(project.workdir)
     }
   }, [isOpen, project, fetchWsConfig])
@@ -69,7 +78,49 @@ export function ProjectSettingsModal({ isOpen, onClose, project }: ProjectSettin
       setSetupCmd('')
     }
     setRootDir(wsConfig?.rootDir ?? '')
+    setMcpOverrides(wsConfig?.mcpOverrides ?? {})
   }, [wsConfig])
+
+  const mcpServers = useMcpStore((s) => s.servers)
+
+  const getServerOverride = (name: string) => mcpOverrides[name] ?? {}
+  const isServerDisabled = (name: string) => {
+    const override = getServerOverride(name)
+    if (override.disabled !== undefined) return override.disabled
+    const server = mcpServers.find((s) => s.name === name)
+    return !!server?.config?.disabled
+  }
+  const isToolDisabled = (serverName: string, toolName: string) => {
+    const override = getServerOverride(serverName)
+    return override.disabledTools?.includes(toolName) ?? false
+  }
+  const toggleServer = (name: string) => {
+    setMcpOverrides((prev) => ({
+      ...prev,
+      [name]: { ...prev[name], disabled: !isServerDisabled(name) },
+    }))
+    setMcpDirty(true)
+  }
+  const toggleTool = (serverName: string, toolName: string) => {
+    setMcpOverrides((prev) => {
+      const override = prev[serverName] ?? {}
+      const currentDisabled = override.disabledTools ?? []
+      const newDisabled = currentDisabled.includes(toolName)
+        ? currentDisabled.filter((t) => t !== toolName)
+        : [...currentDisabled, toolName]
+      return {
+        ...prev,
+        [serverName]: { ...override, disabledTools: newDisabled.length > 0 ? newDisabled : undefined },
+      }
+    })
+    setMcpDirty(true)
+  }
+  const toggleExpand = (name: string) => {
+    setExpandedServers((prev) => {
+      if (prev.has(name)) { const n = new Set(prev); n.delete(name); return n }
+      const n = new Set(prev); n.add(name); return n
+    })
+  }
 
   const handleInstructionsChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     setCustomInstructions(e.target.value)
@@ -106,11 +157,13 @@ export function ProjectSettingsModal({ isOpen, onClose, project }: ProjectSettin
     await saveWsConfig(project.workdir, {
       ...(setup.length > 0 ? { setup } : {}),
       rootDir: rootDir.trim(),
+      ...(Object.keys(mcpOverrides).length > 0 ? { mcpOverrides } : { mcpOverrides: undefined }),
     })
     setInstructionsDirty(false)
     setDangerLevelDirty(false)
     setSetupDirty(false)
     setRootDirDirty(false)
+    setMcpDirty(false)
     handleClose()
   }, [
     project.id,
@@ -118,6 +171,7 @@ export function ProjectSettingsModal({ isOpen, onClose, project }: ProjectSettin
     customInstructions,
     setupCmd,
     rootDir,
+    mcpOverrides,
     updateProject,
     saveWsConfig,
     project.workdir,
@@ -382,6 +436,35 @@ export function ProjectSettingsModal({ isOpen, onClose, project }: ProjectSettin
             disabled={wsLoading || saving}
           />
         </div>
+
+        {mcpServers.length > 0 && (
+          <div>
+            <label className="block text-sm font-medium text-text-primary mb-1 flex-shrink-0">MCP Servers</label>
+            <p className="text-sm text-text-muted mb-3">
+              Override MCP server availability for this project. These overrides apply to new conversations in this
+              project and can be further overridden per conversation from the chat MCP selector.
+            </p>
+                        <div className="space-y-2">
+              {mcpServers.map((server) => {
+                const effectiveDisabled = isServerDisabled(server.name)
+                return (
+                  <McpServerCard
+                    key={server.name}
+                    server={server}
+                    expanded={expandedServers.has(server.name)}
+                    onToggleExpand={toggleExpand}
+                    serverToggleEnabled={!effectiveDisabled}
+                    onServerToggle={() => toggleServer(server.name)}
+                    tools={server.tools.map((t) => ({ ...t, enabled: !isToolDisabled(server.name, t.name) }))}
+                    onToolToggle={(toolName) => toggleTool(server.name, toolName)}
+                    statusDot={mcpStatusDot(effectiveDisabled ? "disabled" : server.status)}
+                    statusColor={mcpStatusColor(effectiveDisabled ? "disabled" : server.status)}
+                  />
+                )
+              })}
+            </div>
+          </div>
+        )}
 
         {saveError && (
           <div className="text-sm text-red-400 bg-red-500/10 border border-red-500/20 rounded px-3 py-2">

--- a/web/src/components/settings/tabs/ToolsTab.test.tsx
+++ b/web/src/components/settings/tabs/ToolsTab.test.tsx
@@ -1,0 +1,182 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ToolsTab } from './ToolsTab'
+
+const mockSettings: Record<string, string> = {}
+const mockGetSetting = vi.fn()
+const mockSetSetting = vi.fn()
+
+vi.mock('../../../stores/settings', () => ({
+  SETTINGS_KEYS: {
+    SEARCH_ENGINE: 'search.engine',
+    SEARCH_TAVILY_API_KEY: 'search.tavilyApiKey',
+    SEARCH_SEARXNG_URL: 'search.searxngUrl',
+    SEARCH_SEARXNG_API_KEY: 'search.searxngApiKey',
+    TOOLS_USE_RTK: 'tools.useRtk',
+    CONFIRM_ON_WORKSPACE_ACTIONS: 'confirm.onWorkspaceActions',
+    TOOLS_SHELL: 'tools.shell',
+  },
+  useSettingsStore: vi.fn((selector) => {
+    const state = { settings: mockSettings, getSetting: mockGetSetting, setSetting: mockSetSetting }
+    return selector(state)
+  }),
+}))
+
+vi.mock('../useSettingsStore', () => ({
+  useSettingsStoreState: () => ({
+    settings: mockSettings,
+    getSetting: mockGetSetting,
+    setSetting: mockSetSetting,
+  }),
+}))
+
+vi.mock('wouter', () => ({ useLocation: () => ['/', vi.fn()] }))
+
+vi.mock('../../../lib/api', () => ({
+  authFetch: vi.fn(async (_url: string, _options?: RequestInit) => ({
+    ok: true,
+    json: async () => ({
+      servers: [
+        {
+          name: 'server-a',
+          status: 'connected',
+          tools: [{ name: 'tool1', enabled: true }],
+          estimatedTokens: 100,
+          config: { transport: 'stdio' },
+        },
+        {
+          name: 'server-b',
+          status: 'connected',
+          tools: [{ name: 'tool2', enabled: true }],
+          estimatedTokens: 200,
+          config: { transport: 'stdio' },
+        },
+      ],
+    }),
+  })),
+}))
+
+vi.mock('../../../hooks/useTestButton', () => ({
+  useTestButton: () => ['Test', null, false, vi.fn()],
+}))
+
+vi.mock('../../shared/CRUDListView', () => ({
+  CRUDListView: ({
+    children,
+    loading,
+    hasItems,
+    loadingLabel,
+    emptyLabel,
+  }: {
+    children: React.ReactNode
+    loading: boolean
+    hasItems: boolean
+    loadingLabel: string
+    emptyLabel: string
+  }) => {
+    if (loading) return <div>{loadingLabel}</div>
+    if (!hasItems) return <div>{emptyLabel}</div>
+    return <div>{children}</div>
+  },
+}))
+
+vi.mock('../../shared/Button', () => ({
+  Button: ({ children, onClick }: { children: React.ReactNode; onClick?: () => void }) => (
+    <button onClick={onClick}>{children}</button>
+  ),
+}))
+
+vi.mock('../../shared/Input', () => ({
+  Input: ({
+    value,
+    onChange,
+    placeholder,
+  }: {
+    value: string
+    onChange: (e: React.ChangeEvent<HTMLInputElement>) => void
+    placeholder?: string
+  }) => <input value={value} onChange={onChange} placeholder={placeholder} />,
+}))
+
+vi.mock('../CRUDModal', () => ({
+  useConfirmDialog: () => ({ requestDelete: vi.fn(), clearConfirm: vi.fn(), isConfirming: vi.fn(() => false) }),
+  FormField: ({ label, value, onChange }: { label: string; value: string; onChange: (v: string) => void }) => (
+    <div>
+      <label>{label}</label>
+      <input value={value} onChange={(e) => onChange(e.target.value)} />
+    </div>
+  ),
+  ErrorBanner: ({ message }: { message: string }) => <div role="alert">{message}</div>,
+}))
+
+vi.mock('../../shared/SelfContainedModal', () => ({
+  Modal: ({ isOpen, children, title }: { isOpen: boolean; children: React.ReactNode; title: string }) => {
+    if (!isOpen) return null
+    return (
+      <div role="dialog" aria-label={title}>
+        {children}
+      </div>
+    )
+  },
+}))
+
+describe('ToolsTab MCP server toggle isolation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('should render server list', async () => {
+    render(<ToolsTab />)
+    await screen.findByText('server-a')
+    expect(screen.getByText('server-b')).toBeDefined()
+  })
+
+  it('toggling server-a sends PUT to correct endpoint with disabled:true', async () => {
+    const user = userEvent.setup()
+    render(<ToolsTab />)
+    await screen.findByText('server-a')
+
+    // The first MCP server toggle is inside the server-a row. Find all toggles
+    // in the MCP section (skip RTK and confirmation toggles before it).
+    const mcpSectionEl = screen.getByTestId('mcp-servers-heading').closest('div')!.parentElement!
+    const toggles = mcpSectionEl.querySelectorAll('button[role="switch"]')
+    expect(toggles.length).toBe(2)
+    await user.click(toggles[0]!)
+
+    const { authFetch } = await import('../../../lib/api')
+    const mockFn = authFetch as ReturnType<typeof vi.fn>
+    const putCalls = mockFn.mock.calls.filter(
+      (call: unknown[]) => (call[1] as Record<string, unknown>)?.method === 'PUT',
+    )
+    expect(putCalls.length).toBe(1)
+    expect(putCalls[0]![0] as string).toContain('server-a')
+    expect(JSON.parse((putCalls[0]![1] as Record<string, string>).body as string)).toEqual({ disabled: true })
+  })
+
+  it('toggling server-b sends PUT to correct endpoint with disabled:true', async () => {
+    const user = userEvent.setup()
+    render(<ToolsTab />)
+    await screen.findByText('server-b')
+
+    const mcpSectionEl = screen.getByTestId('mcp-servers-heading').closest('div')!.parentElement!
+    const toggles = mcpSectionEl.querySelectorAll('button[role="switch"]')
+    expect(toggles.length).toBe(2)
+    await user.click(toggles[1]!)
+
+    const { authFetch } = await import('../../../lib/api')
+    const mockFn = authFetch as ReturnType<typeof vi.fn>
+    const putCalls = mockFn.mock.calls.filter(
+      (call: unknown[]) => (call[1] as Record<string, unknown>)?.method === 'PUT',
+    )
+    expect(putCalls.length).toBe(1)
+    expect(putCalls[0]![0] as string).toContain('server-b')
+    expect(JSON.parse((putCalls[0]![1] as Record<string, string>).body as string)).toEqual({ disabled: true })
+  })
+})

--- a/web/src/components/settings/tabs/ToolsTab.tsx
+++ b/web/src/components/settings/tabs/ToolsTab.tsx
@@ -3,13 +3,14 @@ import { authFetch } from '../../../lib/api'
 import { Button } from '../../shared/Button'
 import { Toggle } from '../../shared/Toggle'
 import { Input } from '../../shared/Input'
-import { ChevronDownIcon } from '../../shared/icons'
+import { mcpStatusColor, mcpStatusDot } from '../../../lib/mcp-utils'
 import { SETTINGS_KEYS } from '../../../stores/settings'
 import { useSettingsStoreState } from '../useSettingsStore'
 import { useTestButton } from '../../../hooks/useTestButton'
 import { CRUDListView } from '../CRUDListView'
 import { useConfirmDialog, FormField, ErrorBanner } from '../CRUDModal'
 import { Modal } from '../../shared/SelfContainedModal'
+import { McpServerCard } from '../McpServerCard'
 
 function parseKeyValueLines(text: string): Record<string, string> {
   const result: Record<string, string> = {}
@@ -147,16 +148,12 @@ interface McpServerState {
     url?: string
     headers?: Record<string, string>
     timeout?: number
+    disabled?: boolean
   }
-  status: 'connected' | 'disconnected' | 'error'
+  status: 'connected' | 'disconnected' | 'error' | 'disabled'
   tools: McpToolInfo[]
   estimatedTokens: number
   error?: string
-}
-
-function formatTokens(n: number): string {
-  if (n >= 1000) return `~${(n / 1000).toFixed(1)}K`
-  return `~${n}`
 }
 
 function useDebouncedSave(
@@ -300,7 +297,6 @@ export function ToolsTab() {
   const [showAddForm, setShowAddForm] = useState(false)
   const [editingServer, setEditingServer] = useState<string | null>(null)
   const [expandedServers, setExpandedServers] = useState<Set<string>>(new Set())
-  const [expandedDescs, setExpandedDescs] = useState<Set<string>>(new Set())
   const [formData, setFormData] = useState<McpFormData>({
     name: '',
     transport: 'stdio' as 'stdio' | 'http',
@@ -320,7 +316,8 @@ export function ToolsTab() {
     try {
       const res = await authFetch('/api/mcp/servers')
       const data = await res.json()
-      setServers(data.servers ?? [])
+      const sorted = (data.servers ?? []).sort((a: McpServerState, b: McpServerState) => a.name.localeCompare(b.name))
+      setServers(sorted)
     } catch {
       /* ignore */
     }
@@ -340,8 +337,8 @@ export function ToolsTab() {
   const toggleExpand = (name: string) => {
     setExpandedServers((prev) => {
       const next = new Set(prev)
-      if (next.has(name)) next.delete(name)
-      else next.add(name)
+      if (next.has(name)) { next.delete(name); return next }
+      next.add(name)
       return next
     })
   }
@@ -511,25 +508,21 @@ export function ToolsTab() {
     }
   }
 
-  const statusColor = (status: string) => {
-    switch (status) {
-      case 'connected':
-        return 'text-accent-success'
-      case 'error':
-        return 'text-accent-error'
-      default:
-        return 'text-text-muted'
-    }
-  }
-
-  const statusDot = (status: string) => {
-    switch (status) {
-      case 'connected':
-        return '●'
-      case 'error':
-        return '●'
-      default:
-        return '○'
+  const handleToggleServer = async (serverName: string, newDisabled: boolean) => {
+    try {
+      const res = await authFetch(`/api/mcp/servers/${encodeURIComponent(serverName)}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ disabled: newDisabled }),
+      })
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}))
+        throw new Error((data as { error?: string }).error ?? 'Failed to toggle server')
+      }
+      setMcpError('')
+      await loadServers()
+    } catch (err) {
+      setMcpError(err instanceof Error ? err.message : String(err))
     }
   }
 
@@ -734,13 +727,18 @@ export function ToolsTab() {
       {/* ── MCP Servers Section ── */}
       <div>
         <div className="flex items-center justify-between mb-3">
-          <h3 className="text-sm font-medium text-text-primary">MCP Servers</h3>
+          <h3 className="text-sm font-medium text-text-primary" data-testid="mcp-servers-heading">
+            MCP Servers
+          </h3>
           <Button variant="primary" size="sm" onClick={() => setShowAddForm(true)}>
             + Add Server
           </Button>
         </div>
         <p className="text-sm text-text-muted mb-3">
           MCP servers provide external tools that extend OpenFox's capabilities.
+        </p>
+        <p className="text-xs text-text-muted mb-3">
+          Changes here apply as defaults for new projects only — existing projects and conversations are not affected.
         </p>
         {mcpError && <ErrorBanner message={mcpError} />}
 
@@ -750,137 +748,63 @@ export function ToolsTab() {
           loadingLabel="Loading MCP servers..."
           emptyLabel="No MCP servers configured."
         >
-          {servers.map((server) => (
-            <div key={server.name} className="rounded border border-border bg-bg-tertiary overflow-hidden">
-              <div
-                className="flex items-center justify-between p-3 cursor-pointer hover:bg-bg-primary/50 transition-colors"
-                onClick={() => toggleExpand(server.name)}
-              >
-                <div className="flex items-center gap-2 min-w-0">
-                  <span className={`text-sm ${statusColor(server.status)}`}>{statusDot(server.status)}</span>
-                  <span className="text-sm font-medium text-text-primary">{server.name}</span>
-                  <span className="text-xs text-text-muted">{server.config.transport}</span>
-                  <span className="text-xs text-text-muted">({server.tools.length} tools)</span>
-                  <span className="text-xs text-text-muted">{formatTokens(server.estimatedTokens)} tokens</span>
-                </div>
-                <div className="flex items-center gap-2">
-                  {server.status === 'error' && server.error && (
-                    <span className="text-xs text-accent-error truncate max-w-[200px]" title={server.error}>
-                      {server.error}
-                    </span>
-                  )}
-                  {expandedServers.has(server.name) &&
-                    (isConfirming(server.name, 'delete') ? (
-                      <>
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation()
-                            handleRemove(server.name)
-                          }}
-                          className="px-2 py-1 rounded text-xs font-medium hover:opacity-90 transition-colors bg-accent-error/20 text-accent-error hover:bg-accent-error/30"
-                        >
-                          Delete
-                        </button>
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation()
-                            clearConfirm()
-                          }}
-                          className="px-2 py-1 rounded text-xs text-text-muted hover:bg-bg-primary transition-colors"
-                        >
-                          Cancel
-                        </button>
-                      </>
-                    ) : (
-                      <>
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation()
-                            handleEdit(server)
-                          }}
-                          className="px-2 py-1 rounded text-xs font-medium text-text-muted hover:text-text-primary hover:bg-bg-primary transition-colors"
-                        >
-                          Edit
-                        </button>
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation()
-                            requestDelete(server.name)
-                          }}
-                          className="px-2 py-1 rounded text-xs font-medium text-accent-error/80 hover:text-accent-error hover:bg-accent-error/10 transition-colors"
-                        >
-                          Remove
-                        </button>
-                      </>
-                    ))}
-                  <span className="text-xs text-text-muted">{expandedServers.has(server.name) ? '▲' : '▼'}</span>
-                </div>
-              </div>
+          {servers.map((server) => {
+            const actions = expandedServers.has(server.name) ? (
+              isConfirming(server.name, 'delete') ? (
+                <>
+                  <button
+                    onClick={(e) => { e.stopPropagation(); handleRemove(server.name) }}
+                    className="px-2 py-1 rounded text-xs font-medium hover:opacity-90 transition-colors bg-accent-error/20 text-accent-error hover:bg-accent-error/30"
+                  >
+                    Delete
+                  </button>
+                  <button
+                    onClick={(e) => { e.stopPropagation(); clearConfirm() }}
+                    className="px-2 py-1 rounded text-xs text-text-muted hover:bg-bg-primary transition-colors"
+                  >
+                    Cancel
+                  </button>
+                </>
+              ) : (
+                <>
+                  <button
+                    onClick={(e) => { e.stopPropagation(); handleEdit(server) }}
+                    className="px-2 py-1 rounded text-xs font-medium text-text-muted hover:text-text-primary hover:bg-bg-primary transition-colors"
+                  >
+                    Edit
+                  </button>
+                  <button
+                    onClick={(e) => { e.stopPropagation(); requestDelete(server.name) }}
+                    className="px-2 py-1 rounded text-xs font-medium text-accent-error/80 hover:text-accent-error hover:bg-accent-error/10 transition-colors"
+                  >
+                    Remove
+                  </button>
+                </>
+              )
+            ) : null
 
-              {expandedServers.has(server.name) && (
-                <div className="border-t border-border px-3 py-2 space-y-1.5">
-                  {server.config.command && (
-                    <div className="text-xs text-text-muted font-mono">
-                      {server.config.command} {server.config.args?.join(' ') ?? ''}
-                    </div>
-                  )}
-                  {server.config.url && <div className="text-xs text-text-muted font-mono">{server.config.url}</div>}
-                  {server.config.timeout !== undefined && (
-                    <div className="text-xs text-text-muted">Timeout: {server.config.timeout}s</div>
-                  )}
-                  {server.tools.length === 0 ? (
-                    <div className="text-xs text-text-muted">No tools available</div>
-                  ) : (
-                    <div className="space-y-1">
-                      {server.tools.map((tool) => (
-                        <div key={tool.name} className="py-1">
-                          <div className="flex items-center justify-between">
-                            <div className="min-w-0 flex-1 mr-2">
-                              <span className="text-xs text-text-primary font-mono">{tool.name}</span>
-                              {tool.description && tool.description.length > 80 ? (
-                                <button
-                                  onClick={() => {
-                                    const key = `${server.name}:${tool.name}`
-                                    setExpandedDescs((prev) => {
-                                      const next = new Set(prev)
-                                      if (next.has(key)) next.delete(key)
-                                      else next.add(key)
-                                      return next
-                                    })
-                                  }}
-                                  className="inline-flex items-center gap-0.5 text-xs text-text-muted hover:text-text-primary transition-colors ml-2"
-                                >
-                                  <span className="truncate max-w-[300px]">{tool.description}</span>
-                                  <ChevronDownIcon
-                                    rotate={expandedDescs.has(`${server.name}:${tool.name}`) ? 180 : 0}
-                                    className="w-3 h-3 flex-shrink-0"
-                                  />
-                                </button>
-                              ) : tool.description ? (
-                                <span className="text-xs text-text-muted ml-2">{tool.description}</span>
-                              ) : null}
-                            </div>
-                            <span className="text-xs text-text-muted mr-2 flex-shrink-0">
-                              {formatTokens(tool.estimatedTokens)}
-                            </span>
-                            <Toggle
-                              enabled={tool.enabled}
-                              onClick={() => handleToggleTool(server.name, tool.name, !tool.enabled)}
-                            />
-                          </div>
-                          {tool.description &&
-                            tool.description.length > 80 &&
-                            expandedDescs.has(`${server.name}:${tool.name}`) && (
-                              <div className="text-xs text-text-muted mt-1 ml-1">{tool.description}</div>
-                            )}
-                        </div>
-                      ))}
-                    </div>
-                  )}
-                </div>
-              )}
-            </div>
-          ))}
+            const errorEl = server.status === "error" && server.error ? (
+              <span className="text-xs text-accent-error truncate max-w-[200px]" title={server.error}>
+                {server.error}
+              </span>
+            ) : null
+
+            return (
+              <McpServerCard
+                key={server.name}
+                server={server}
+                expanded={expandedServers.has(server.name)}
+                onToggleExpand={toggleExpand}
+                serverToggleEnabled={!server.config.disabled}
+                onServerToggle={() => handleToggleServer(server.name, !server.config.disabled)}
+                tools={server.tools}
+                onToolToggle={(toolName) => handleToggleTool(server.name, toolName, !server.tools.find((t) => t.name === toolName)?.enabled)}
+                statusDot={mcpStatusDot(server.status)}
+                statusColor={mcpStatusColor(server.status)}
+                actions={<>{errorEl}{actions}</>}
+              />
+            )
+          })}
         </CRUDListView>
 
         {showAddForm && (

--- a/web/src/components/shared/Toggle.tsx
+++ b/web/src/components/shared/Toggle.tsx
@@ -1,14 +1,24 @@
-export function Toggle({ enabled, onClick, label }: { enabled: boolean; onClick: () => void; label?: string }) {
+export function Toggle({
+  enabled,
+  onClick,
+  label,
+  disabled,
+}: {
+  enabled: boolean
+  onClick: () => void
+  label?: string
+  disabled?: boolean
+}) {
   return (
     <button
       type="button"
       role="switch"
       aria-checked={enabled}
       aria-label={label}
-      onClick={onClick}
+      onClick={disabled ? undefined : onClick}
       className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
         enabled ? 'bg-accent-primary' : 'bg-bg-tertiary'
-      }`}
+      } ${disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
     >
       <span
         className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${

--- a/web/src/lib/mcp-utils.ts
+++ b/web/src/lib/mcp-utils.ts
@@ -1,0 +1,28 @@
+export function mcpStatusColor(status: string): string {
+  switch (status) {
+    case 'connected':
+      return 'text-accent-success'
+    case 'error':
+      return 'text-accent-error'
+    case 'disabled':
+      return 'text-text-muted'
+    default:
+      return 'text-text-muted'
+  }
+}
+
+export function mcpStatusDot(status: string): string {
+  switch (status) {
+    case 'connected':
+      return '●'
+    case 'error':
+      return '✕'
+    default:
+      return '○'
+  }
+}
+
+export function formatTokens(n: number): string {
+  if (n >= 1000) return `~${(n / 1000).toFixed(1)}K`
+  return `~${n}`
+}

--- a/web/src/stores/mcp.ts
+++ b/web/src/stores/mcp.ts
@@ -1,0 +1,45 @@
+import { create } from 'zustand'
+import { authFetch } from '../lib/api'
+
+export interface McpToolInfo {
+  name: string
+  description?: string
+  enabled: boolean
+  estimatedTokens: number
+}
+
+export interface McpServerInfo {
+  name: string
+  status: string
+  tools: McpToolInfo[]
+  estimatedTokens: number
+  config: {
+    transport?: string
+    command?: string
+    args?: string[]
+    url?: string
+    disabled?: boolean
+  }
+}
+
+interface McpStore {
+  servers: McpServerInfo[]
+  setServers: (servers: McpServerInfo[]) => void
+  fetchServers: () => Promise<void>
+}
+
+export const useMcpStore = create<McpStore>((set) => ({
+  servers: [],
+  setServers: (servers) => set({ servers }),
+  fetchServers: async () => {
+    try {
+      const res = await authFetch('/api/mcp/servers')
+      if (!res.ok) return
+      const data = await res.json()
+      const sorted = (data.servers ?? []).sort((a: McpServerInfo, b: McpServerInfo) => a.name.localeCompare(b.name))
+      set({ servers: sorted })
+    } catch {
+      // ignore
+    }
+  },
+}))

--- a/web/src/stores/session/messageHandler.ts
+++ b/web/src/stores/session/messageHandler.ts
@@ -35,6 +35,7 @@ import type { AgentType } from '../notifications'
 import type { SessionState } from './types'
 import { handleGlobalSoundEffects, resolveAgentType } from './sounds'
 import { getBuffer, scheduleStreamingFlush, cancelStreamingFlush } from './streamingBuffer'
+import { useMcpStore, type McpServerInfo } from '../mcp'
 
 const triggeredNewMessageSound = new Set<string>()
 
@@ -764,7 +765,13 @@ export function handleServerMessage(
     }
 
     case 'mcp.servers.changed': {
-      window.dispatchEvent(new CustomEvent('mcp-servers-changed'))
+      const payload = message.payload as { servers?: McpServerInfo[] }
+      if (payload?.servers) {
+        const sorted = [...payload.servers].sort((a, b) => a.name.localeCompare(b.name))
+        useMcpStore.getState().setServers(sorted)
+      } else {
+        window.dispatchEvent(new CustomEvent('mcp-servers-changed'))
+      }
       break
     }
 


### PR DESCRIPTION
### Summary


Add per-session and per-project MCP server toggle system with 3-layer resolution (Global → Project → Session).


**Key changes:**

- McpManager always connects servers regardless of `disabled` flag (disabled becomes a visibility filter at tool-definition level, not a connection blocker)

- Session MCP overrides: new `PUT /api/sessions/:id/mcp/overrides` endpoint, stored in DB via `mcp_disabled_servers` column, survives restarts

- Project MCP overrides: `mcpOverrides` field in WorkspaceConfig (`.openfox/workspace.json`), with expandable server card UI and individual tool toggles in ProjectSettingsModal

- Chat McpSelector dropdown now uses session-level API instead of global API — toggling only affects the current conversation

- Tool definitions filtered per-session via `getToolRegistryForAgent(sessionId)`: MCP tools from session-disabled servers are excluded from LLM tool definitions

- New sessions inherit project mcpOverrides (or global `config.disabled` as fallback)


### AI-Enhanced Development


- **AI Models:** Claude 3.5 Sonnet


### Cache Impact


- **Yes** — Tool definitions sent to the LLM now depend on session MCP overrides, affecting the cached tool fingerprint for sessions with overridden MCP server states.