### PR TITLE
feat: highlight remote command execution

### DIFF
--- a/web/src/components/shared/ToolCallDisplay.test.tsx
+++ b/web/src/components/shared/ToolCallDisplay.test.tsx
@@ -32,6 +32,56 @@ const pendingConfirmation = {
   reason: 'dangerous_command' as const,
 }
 
+describe('ToolCallDisplay — remote execution', () => {
+  beforeEach(() => {
+    useSessionStore.setState({ pendingPathConfirmations: [] })
+    useSettingsStore.setState({ settings: {} })
+  })
+
+  afterEach(cleanup)
+
+  it.each([
+    ['ssh host', 'SSH'],
+    ['scp file host:/tmp', 'SCP'],
+    ['sftp host', 'SFTP'],
+    ['mosh host', 'MOSH'],
+  ])('marks compact %s calls as remote', (command, protocol) => {
+    const { container } = render(
+      <ToolCallDisplay tool="run_command" args={{ command }} status="pending" variant="compact" />,
+    )
+
+    expect(container.textContent).toContain(`REMOTE · ${protocol}`)
+    expect(container.firstElementChild?.className).toContain('border-purple-500')
+  })
+
+  it('wraps an associated permission request in the remote frame', () => {
+    useSessionStore.setState({ pendingPathConfirmations: [pendingConfirmation] })
+
+    const { container } = render(
+      <ToolCallDisplay
+        tool="run_command"
+        args={{ command: 'ssh host cat /restricted/file' }}
+        status="pending"
+        variant="expandable"
+        callId="call-run-1"
+      />,
+    )
+
+    expect(container.textContent).toContain('REMOTE · SSH')
+    expect(container.textContent).toContain('Allow')
+    expect(container.firstElementChild?.className).toContain('border-purple-500')
+  })
+
+  it('does not mark a local command mentioning ssh as remote', () => {
+    const { container } = render(
+      <ToolCallDisplay tool="run_command" args={{ command: 'echo ssh' }} status="success" variant="expandable" />,
+    )
+
+    expect(container.textContent).not.toContain('REMOTE')
+    expect(container.firstElementChild?.className).not.toContain('border-purple-500')
+  })
+})
+
 describe('ToolCallDisplay — PathConfirmationButtons placement', () => {
   beforeEach(() => {
     useSessionStore.setState({ pendingPathConfirmations: [] })

--- a/web/src/components/shared/ToolCallDisplay.tsx
+++ b/web/src/components/shared/ToolCallDisplay.tsx
@@ -14,6 +14,7 @@ import { formatToolArgsFull, formatToolArgsWithMetadata } from '../../lib/format
 import { useSessionStore, type PendingPathConfirmation } from '../../stores/session'
 import { useSettingsStore, SETTINGS_KEYS } from '../../stores/settings'
 import { buildEditorUrl } from '../../lib/editor-link'
+import { detectRemoteExecution } from '../../lib/remote-execution'
 
 type ToolStatus = 'pending' | 'success' | 'error' | 'interrupted'
 
@@ -88,6 +89,12 @@ export const ToolCallDisplay = memo(function ToolCallDisplay({
   const shouldAutoExpand = !forceCompact
   const [expanded, setExpanded] = useState(shouldAutoExpand)
   const config = statusConfig[status]
+  const remoteProtocol = detectRemoteExecution(tool, args)
+  const remoteBadge = remoteProtocol ? (
+    <span className="shrink-0 rounded border border-purple-400/50 bg-purple-500/15 px-1.5 py-0.5 text-[10px] font-semibold tracking-wide text-purple-300">
+      REMOTE · {remoteProtocol}
+    </span>
+  ) : null
   const showEditorLink = useSettingsStore((s) => s.settings[SETTINGS_KEYS.DISPLAY_SHOW_OPEN_IN_EDITOR]) === 'true'
 
   const editorLine =
@@ -118,9 +125,12 @@ export const ToolCallDisplay = memo(function ToolCallDisplay({
   }
   if (variant === 'compact') {
     return (
-      <div className="flex items-center gap-1.5 text-xs bg-secondary rounded px-2 py-1.5">
+      <div
+        className={`flex items-center gap-1.5 text-xs rounded px-2 py-1.5 border ${remoteProtocol ? 'border-purple-500/60 bg-purple-950/30' : 'border-transparent bg-secondary'}`}
+      >
         <ToolIcon tool={tool} />
         <span className="text-accent-primary font-medium">{tool}</span>
+        {remoteBadge}
         <span className="text-text-muted truncate flex-1">{formatToolArgsWithMetadata(tool, args, metadata)}</span>
         <span className={`${config.color} ${config.animate ? 'animate-pulse' : ''}`}>
           {status === 'pending' ? '...' : 'done'}
@@ -130,13 +140,16 @@ export const ToolCallDisplay = memo(function ToolCallDisplay({
   }
 
   return (
-    <div className="border border-border rounded overflow-hidden my-1 min-w-0">
+    <div
+      className={`border rounded overflow-hidden my-1 min-w-0 ${remoteProtocol ? 'border-purple-500/60 shadow-[0_0_0_1px_rgb(168_85_247_/_0.12)]' : 'border-border'}`}
+    >
       <button
-        className="w-full flex items-center gap-1.5 p-2 bg-secondary hover:bg-secondary/80 text-left"
+        className={`w-full flex items-center gap-1.5 p-2 text-left ${remoteProtocol ? 'bg-purple-950/30 hover:bg-purple-950/40' : 'bg-secondary hover:bg-secondary/80'}`}
         onClick={() => setExpanded(!expanded)}
       >
         <span className={`${config.color} ${config.animate ? 'animate-pulse' : ''}`}>{config.icon}</span>
         <span className="font-mono text-accent-primary text-sm">{tool}</span>
+        {remoteBadge}
         <span className="text-text-muted text-xs flex-1 truncate">
           {formatToolArgsWithMetadata(tool, args, metadata)}
         </span>
@@ -144,7 +157,9 @@ export const ToolCallDisplay = memo(function ToolCallDisplay({
       </button>
 
       {expanded && (
-        <div className="p-2 bg-primary border-t border-border space-y-2 min-w-0">
+        <div
+          className={`p-2 border-t space-y-2 min-w-0 ${remoteProtocol ? 'border-purple-500/40 bg-purple-950/10' : 'border-border bg-primary'}`}
+        >
           {/* Specialized rendering for run_command with streaming output */}
           {tool === 'run_command' && (
             <RunCommandView

--- a/web/src/components/shared/ToolCallPreparing.test.tsx
+++ b/web/src/components/shared/ToolCallPreparing.test.tsx
@@ -1,0 +1,31 @@
+// @vitest-environment happy-dom
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { ToolCallPreparing } from './ToolCallPreparing'
+
+afterEach(cleanup)
+
+describe('ToolCallPreparing remote execution', () => {
+  it('shows the remote badge and purple frame for partial SSH arguments', () => {
+    const { container } = render(<ToolCallPreparing name="run_command" arguments={'{"command":"ssh host'} />)
+
+    expect(container.textContent).toContain('REMOTE · SSH')
+    expect(container.firstElementChild?.className).toContain('border-purple-500')
+  })
+
+  it('shows the remote badge for a nested shell command', () => {
+    const { container } = render(
+      <ToolCallPreparing name="run_command" arguments={JSON.stringify({ command: "bash -lc 'setsid ssh host'" })} />,
+    )
+
+    expect(container.textContent).toContain('REMOTE · SSH')
+    expect(container.firstElementChild?.className).toContain('border-purple-500')
+  })
+
+  it('does not mark local commands as remote', () => {
+    const { container } = render(<ToolCallPreparing name="run_command" arguments={'{"command":"echo ssh"'} />)
+
+    expect(container.textContent).not.toContain('REMOTE')
+    expect(container.firstElementChild?.className).not.toContain('border-purple-500')
+  })
+})

--- a/web/src/components/shared/ToolCallPreparing.tsx
+++ b/web/src/components/shared/ToolCallPreparing.tsx
@@ -1,6 +1,7 @@
 import { memo } from 'react'
 import { ToolIcon } from './ToolIcon'
 import { formatMetadataKeyLabelLower } from '../../lib/metadata-keys'
+import { detectRemoteCommand } from '../../lib/remote-execution'
 
 interface ToolCallPreparingProps {
   name: string
@@ -20,7 +21,6 @@ const toolDescriptions: Record<string, string> = {
   session_metadata: 'Managing',
   todo_write: 'Updating tasks',
 }
-
 
 function getToolDescription(name: string, args?: string): string {
   const base = toolDescriptions[name]
@@ -56,19 +56,28 @@ export const ToolCallPreparing = memo(function ToolCallPreparing({ name, argumen
   const description = getToolDescription(name, args)
 
   let detailText = description + '...'
+  let remoteProtocol = null
   if (name === 'run_command' && args) {
     const command = extractCommandFromArgs(args)
     if (command) {
       detailText = command
+      remoteProtocol = detectRemoteCommand(command)
     }
   }
 
   return (
-    <div className="border border-border rounded overflow-hidden my-1 min-w-0 animate-pulse">
-      <div className="flex items-center gap-1.5 p-2 bg-bg-tertiary">
+    <div
+      className={`border rounded overflow-hidden my-1 min-w-0 animate-pulse ${remoteProtocol ? 'border-purple-500/60 shadow-[0_0_0_1px_rgb(168_85_247_/_0.12)]' : 'border-border'}`}
+    >
+      <div className={`flex items-center gap-1.5 p-2 ${remoteProtocol ? 'bg-purple-950/30' : 'bg-bg-tertiary'}`}>
         <span className="text-accent-warning animate-pulse">...</span>
         <ToolIcon tool={name} />
         <span className="font-mono text-accent-primary text-sm">{name}</span>
+        {remoteProtocol && (
+          <span className="shrink-0 rounded border border-purple-400/50 bg-purple-500/15 px-1.5 py-0.5 text-[10px] font-semibold tracking-wide text-purple-300">
+            REMOTE · {remoteProtocol}
+          </span>
+        )}
         {name === 'run_command' && args ? (
           <code className="text-text-muted text-xs flex-1 truncate">{detailText}</code>
         ) : (

--- a/web/src/lib/remote-execution.test.ts
+++ b/web/src/lib/remote-execution.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest'
+import { detectRemoteExecution } from './remote-execution'
+
+describe('detectRemoteExecution', () => {
+  it.each([
+    ['ssh example.com', 'SSH'],
+    ['/usr/bin/scp file.txt example.com:/tmp', 'SCP'],
+    ['sftp example.com', 'SFTP'],
+    ['mosh example.com', 'MOSH'],
+    ['cd /tmp && ssh example.com', 'SSH'],
+    ['echo ready\nssh example.com', 'SSH'],
+    ['sleep 1 & ssh example.com', 'SSH'],
+    ['sudo -u deploy ssh example.com', 'SSH'],
+    ['sudo --chdir /tmp ssh example.com', 'SSH'],
+    ['sudo --chdir=/tmp ssh example.com', 'SSH'],
+    ['env TERM=xterm sftp example.com', 'SFTP'],
+    ['env -u SSH_AUTH_SOCK ssh example.com', 'SSH'],
+    ["env -S 'ssh example.com'", 'SSH'],
+    ["env --split-string='ssh example.com'", 'SSH'],
+    ['sudo -u deploy env TERM=x ssh example.com', 'SSH'],
+    ['nohup env ssh example.com', 'SSH'],
+    ['setsid ssh example.com', 'SSH'],
+    ['nohup scp file example.com:/tmp', 'SCP'],
+    ['timeout 10s sftp example.com', 'SFTP'],
+    ['command mosh example.com', 'MOSH'],
+    ['( ssh example.com )', 'SSH'],
+    ['{ scp file example.com:/tmp; }', 'SCP'],
+    ['if true; then sftp example.com; fi', 'SFTP'],
+    ['while true; do mosh example.com; done', 'MOSH'],
+    ["bash -lc 'ssh example.com'", 'SSH'],
+    ["bash -c -- 'ssh example.com'", 'SSH'],
+    ["bash -lc -- 'ssh example.com'", 'SSH'],
+    ['sh -c "setsid sftp example.com"', 'SFTP'],
+    ["zsh -lc 'nohup mosh example.com'", 'MOSH'],
+    ["fish -c 'timeout 5 scp file example.com:/tmp'", 'SCP'],
+    ["bash -lc 'cd /tmp && ssh example.com'", 'SSH'],
+    ['echo "$(ssh example.com)"', 'SSH'],
+    ['echo `sftp example.com`', 'SFTP'],
+    ['value=$(scp file example.com:/tmp)', 'SCP'],
+    ["printf '<<EOF\\n'\nssh example.com", 'SSH'],
+    ['echo <<<EOF\nssh example.com', 'SSH'],
+    ["cat <<'EOF-1'\ndata\nEOF-1\nssh example.com", 'SSH'],
+    ["cat <<'EO'F\ndata\nEOF\nssh example.com", 'SSH'],
+    ['cat <<E"O"F\ndata\nEOF\nssh example.com', 'SSH'],
+    ['cat <<\\EOF\ndata\nEOF\nssh example.com', 'SSH'],
+    ["cat <<$'EOF'\ndata\nEOF\nssh example.com", 'SSH'],
+    ['cat <<"E\\OF"\ndata\nE\\OF\nssh example.com', 'SSH'],
+    ["cat <<$'E\\x4fF'\ndata\nEOF\nssh example.com", 'SSH'],
+    ['cat <<EOF\n$(ssh example.com)\nEOF', 'SSH'],
+    ['cat <<EOF\n# $(ssh example.com)\nEOF', 'SSH'],
+    ['cat <<EOF\n# `ssh example.com`\nEOF', 'SSH'],
+    ['echo ""# $(ssh example.com)', 'SSH'],
+    ["echo ''# `ssh example.com`", 'SSH'],
+    ["echo '$(( '; ssh example.com; echo '))'", 'SSH'],
+    ['echo ""#local; ssh example.com', 'SSH'],
+    ["echo ''#local; ssh example.com", 'SSH'],
+    [
+      `bash -lc 'askpass=$(mktemp); trap "rm -f \\"$askpass\\"" EXIT; printf "#!/bin/sh\\nprintf %s\\n %s\\n" '"'"'example-password'"'"' > "$askpass"; chmod 700 "$askpass"; export SSH_ASKPASS="$askpass" SSH_ASKPASS_REQUIRE=force DISPLAY=:0; setsid ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=accept-new -o PreferredAuthentications=password -o PubkeyAuthentication=no user@example.test "echo PASS"'`,
+      'SSH',
+    ],
+  ])('detects %s as %s', (command, expected) => {
+    expect(detectRemoteExecution('run_command', { command })).toBe(expected)
+  })
+
+  it.each([
+    'echo ssh',
+    'cat ~/.ssh/config',
+    'grep sftp README.md',
+    'printf "mosh"',
+    'ssh-keygen -t ed25519',
+    'FOO="local; ssh host" echo ok',
+    "echo 'ssh host'",
+    'echo "ssh host"',
+    'echo local # ; ssh host',
+    'echo local # ssh host',
+    "bash -lc 'echo ssh'",
+    "sh -c 'cat ~/.ssh/config'",
+    "bash -lc 'echo local # ssh host'",
+    "printf '%s' \"bash -lc 'ssh host'\"",
+    'command -v ssh',
+    'command -V ssh',
+    "bash -n -c 'ssh host'",
+    "bash -nc 'ssh host'",
+    "'' ssh host",
+    "cat <<'EOF'\nssh production\nEOF",
+    'cat <<-EOF\n\tssh production\nEOF',
+    'cat <<"END"\nssh production\nEND',
+    "echo '\u0024(ssh host)'",
+    "echo '`ssh host`'",
+    'echo ok # $(ssh host)',
+    'echo ok # `ssh host`',
+    'echo $((ssh))',
+    "cat <<'EOF'\n$(ssh host)\nEOF",
+    'cat <<"EOF"\n`ssh host`\nEOF',
+    'for ssh in one two; do echo $ssh; done',
+    'select sftp in one two; do echo $sftp; done',
+    'case value in one) echo one;; ssh) echo match;; esac',
+  ])('does not treat %s as remote execution', (command) => {
+    expect(detectRemoteExecution('run_command', { command })).toBeNull()
+  })
+
+  it.each(['echo foo#bar; ssh host', 'echo "#"; ssh host', "echo '#'; ssh host"])(
+    'preserves literal hashes in %s',
+    (command) => {
+      expect(detectRemoteExecution('run_command', { command })).toBe('SSH')
+    },
+  )
+
+  it('only detects remote execution for run_command', () => {
+    expect(detectRemoteExecution('write_file', { command: 'ssh example.com' })).toBeNull()
+  })
+})

--- a/web/src/lib/remote-execution.ts
+++ b/web/src/lib/remote-execution.ts
@@ -1,0 +1,457 @@
+export type RemoteProtocol = 'SSH' | 'SCP' | 'SFTP' | 'MOSH'
+
+const remoteExecutables: Record<string, RemoteProtocol> = {
+  ssh: 'SSH',
+  scp: 'SCP',
+  sftp: 'SFTP',
+  mosh: 'MOSH',
+}
+
+const sudoOptionsWithValue = new Set([
+  '-C',
+  '--close-from',
+  '-D',
+  '--chdir',
+  '-g',
+  '--group',
+  '-h',
+  '--host',
+  '-p',
+  '--prompt',
+  '-R',
+  '--chroot',
+  '-T',
+  '--command-timeout',
+  '-u',
+  '--user',
+])
+const envOptionsWithValue = new Set(['-C', '--chdir', '-S', '--split-string', '-u', '--unset'])
+
+function executableName(token: string): string {
+  return token.split(/[\\/]/).pop() ?? token
+}
+
+interface Heredoc {
+  delimiter: string
+  stripTabs: boolean
+  expandable: boolean
+}
+
+function findHeredocs(line: string): Heredoc[] {
+  const heredocs: Heredoc[] = []
+  let quote: "'" | '"' | null = null
+  let escaped = false
+
+  for (let index = 0; index < line.length; index += 1) {
+    const char = line[index]!
+    if (escaped) {
+      escaped = false
+      continue
+    }
+    if (char === '\\' && quote !== "'") {
+      escaped = true
+      continue
+    }
+    if (char === "'" || char === '"') {
+      quote = quote === char ? null : quote === null ? char : quote
+      continue
+    }
+    if (quote) continue
+    if (char === '#' && (index === 0 || /\s|[;&|(){}]/.test(line[index - 1]!))) break
+    if (char !== '<' || line[index - 1] === '<' || line[index + 1] !== '<' || line[index + 2] === '<') continue
+
+    let cursor = index + 2
+    const stripTabs = line[cursor] === '-'
+    if (stripTabs) cursor += 1
+    while (/\s/.test(line[cursor] ?? '')) cursor += 1
+    let delimiter = ''
+    let wordQuote: "'" | '"' | null = null
+    let ansiCQuote = false
+    let expandable = true
+    while (cursor < line.length) {
+      const current = line[cursor]!
+      if (!wordQuote && /\s|[;&|(){}<>]/.test(current)) break
+      if (current === "'" || current === '"') {
+        expandable = false
+        if (wordQuote === current) {
+          wordQuote = null
+          ansiCQuote = false
+        } else if (wordQuote === null) {
+          wordQuote = current
+        }
+        cursor += 1
+        continue
+      }
+      if (!wordQuote && current === '$' && line[cursor + 1] === "'") {
+        expandable = false
+        ansiCQuote = true
+        wordQuote = "'"
+        cursor += 2
+        continue
+      }
+      if (current === '\\' && cursor + 1 < line.length) {
+        expandable = false
+        if (ansiCQuote) {
+          const escape = line.slice(cursor).match(/^\\(?:x([0-9A-Fa-f]{1,2})|([0-7]{1,3})|([abefnrtv\\'"?]))/)
+          if (escape) {
+            if (escape[1]) delimiter += String.fromCharCode(Number.parseInt(escape[1], 16))
+            else if (escape[2]) delimiter += String.fromCharCode(Number.parseInt(escape[2], 8))
+            else {
+              const simple: Record<string, string> = {
+                a: '\x07',
+                b: '\b',
+                e: '\x1b',
+                f: '\f',
+                n: '\n',
+                r: '\r',
+                t: '\t',
+                v: '\v',
+              }
+              delimiter += simple[escape[3]!] ?? escape[3]!
+            }
+            cursor += escape[0].length
+            continue
+          }
+        }
+        if (wordQuote !== '"' || ['$', '`', '"', '\\', '\n'].includes(line[cursor + 1]!)) {
+          cursor += 1
+        }
+      }
+      delimiter += line[cursor]!
+      cursor += 1
+    }
+    if (delimiter) heredocs.push({ delimiter, stripTabs, expandable })
+    index = cursor
+  }
+
+  return heredocs
+}
+
+function stripHeredocBodies(command: string): { command: string; expandableBodies: string[] } {
+  const lines = command.split('\n')
+  const result: string[] = []
+  const expandableBodies: string[] = []
+  const pending: Heredoc[] = []
+
+  for (const line of lines) {
+    if (pending.length > 0) {
+      const current = pending[0]!
+      const candidate = current.stripTabs ? line.replace(/^\t+/, '') : line
+      if (candidate === current.delimiter) pending.shift()
+      else if (current.expandable) expandableBodies.push(candidate)
+      continue
+    }
+
+    result.push(line)
+    pending.push(...findHeredocs(line))
+  }
+
+  return { command: result.join('\n'), expandableBodies }
+}
+
+function extractCommandSubstitutions(command: string, respectComments = true): string[] {
+  const substitutions: string[] = []
+  let quote: "'" | '"' | null = null
+  let escaped = false
+  let comment = false
+  let wordStarted = false
+
+  for (let index = 0; index < command.length; index += 1) {
+    const char = command[index]!
+    if (comment) {
+      if (char === '\n' || char === '\r') comment = false
+      continue
+    }
+    if (escaped) {
+      escaped = false
+      continue
+    }
+    if (char === '\\' && quote !== "'") {
+      wordStarted = true
+      escaped = true
+      continue
+    }
+    if (char === "'") {
+      wordStarted = true
+      quote = quote === "'" ? null : quote === null ? "'" : quote
+      continue
+    }
+    if (char === '"') {
+      wordStarted = true
+      quote = quote === '"' ? null : quote === null ? '"' : quote
+      continue
+    }
+    if (quote === "'") continue
+    if (!quote && /\s|[;&|(){}]/.test(char)) wordStarted = false
+    else if (char !== '#') wordStarted = true
+    if (respectComments && char === '#' && !wordStarted) {
+      comment = true
+      continue
+    }
+
+    if (char === '`') {
+      const end = command.indexOf('`', index + 1)
+      if (end !== -1) {
+        substitutions.push(command.slice(index + 1, end))
+        index = end
+      }
+      continue
+    }
+
+    if (char === '$' && command[index + 1] === '(' && command[index + 2] !== '(') {
+      let depth = 1
+      let innerQuote: "'" | '"' | null = null
+      let innerEscaped = false
+      for (let end = index + 2; end < command.length; end += 1) {
+        const inner = command[end]!
+        if (innerEscaped) {
+          innerEscaped = false
+          continue
+        }
+        if (inner === '\\' && innerQuote !== "'") {
+          innerEscaped = true
+          continue
+        }
+        if (inner === "'" || inner === '"') {
+          innerQuote = innerQuote === inner ? null : innerQuote === null ? inner : innerQuote
+          continue
+        }
+        if (innerQuote) continue
+        if (inner === '(') depth += 1
+        if (inner === ')') depth -= 1
+        if (depth === 0) {
+          substitutions.push(command.slice(index + 2, end))
+          index = end
+          break
+        }
+      }
+    }
+  }
+
+  return substitutions
+}
+
+function tokenize(command: string): string[] {
+  const tokens: string[] = []
+  let token = ''
+  let tokenStarted = false
+  let quote: "'" | '"' | null = null
+  let escaped = false
+  let comment = false
+
+  const flush = () => {
+    if (tokenStarted) tokens.push(token)
+    token = ''
+    tokenStarted = false
+  }
+
+  for (let index = 0; index < command.length; index += 1) {
+    const char = command[index]!
+    if (comment) {
+      if (char === '\n' || char === '\r') {
+        comment = false
+        if (tokens.at(-1) !== ';') tokens.push(';')
+      }
+      continue
+    }
+    if (escaped) {
+      tokenStarted = true
+      token += char
+      escaped = false
+      continue
+    }
+    if (char === '\\' && quote !== "'") {
+      escaped = true
+      continue
+    }
+    if (quote) {
+      if (char === quote) quote = null
+      else token += char
+      continue
+    }
+    if (char === "'" || char === '"') {
+      tokenStarted = true
+      quote = char
+      continue
+    }
+    if (char === '$' && command.slice(index, index + 3) === '$((') {
+      let depth = 1
+      const start = index
+      for (let end = index + 3; end < command.length - 1; end += 1) {
+        if (command.slice(end, end + 2) === '((') depth += 1
+        if (command.slice(end, end + 2) === '))') depth -= 1
+        if (depth === 0) {
+          tokenStarted = true
+          token += command.slice(start, end + 2)
+          index = end + 1
+          break
+        }
+      }
+      continue
+    }
+    if (char === '#' && !tokenStarted) {
+      comment = true
+      continue
+    }
+    if (/\s/.test(char)) {
+      flush()
+      if (char === '\n' || char === '\r') tokens.push(';')
+      continue
+    }
+    if (char === ';' || char === '|' || char === '&' || char === '(' || char === ')' || char === '{' || char === '}') {
+      flush()
+      const next = command[index + 1]
+      if (next === char) index += 1
+      tokens.push(char)
+      continue
+    }
+    tokenStarted = true
+    token += char
+  }
+  if (escaped) token += '\\'
+  flush()
+  return tokens
+}
+
+function skipOptions(tokens: string[], index: number, optionsWithValue: Set<string>): number {
+  while (index < tokens.length) {
+    const option = tokens[index]!
+    if (option === '--') return index + 1
+    if (!option.startsWith('-') || option === '-') return index
+    index += 1
+    if (!option.includes('=') && optionsWithValue.has(option)) index += 1
+  }
+  return index
+}
+
+function detectSegment(tokens: string[], depth = 0): RemoteProtocol | null {
+  if (depth > 8) return null
+
+  let index = 0
+  while (index < tokens.length && /^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[index]!)) index += 1
+
+  const initialExecutable = executableName(tokens[index] ?? '').toLowerCase()
+  if (initialExecutable === 'env') {
+    for (let optionIndex = index + 1; optionIndex < tokens.length; optionIndex += 1) {
+      const option = tokens[optionIndex]!
+      if (option === '-S' || option === '--split-string') {
+        const script = tokens[optionIndex + 1]
+        return script ? detectRemoteCommand(script, depth + 1) : null
+      }
+      const splitString = option.match(/^--split-string=(.*)$/s)
+      if (splitString) return detectRemoteCommand(splitString[1]!, depth + 1)
+    }
+    index = skipOptions(tokens, index + 1, envOptionsWithValue)
+    while (index < tokens.length && /^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[index]!)) index += 1
+    return detectSegment(tokens.slice(index), depth + 1)
+  }
+
+  if (initialExecutable === 'sudo') {
+    index = skipOptions(tokens, index + 1, sudoOptionsWithValue)
+    return detectSegment(tokens.slice(index), depth + 1)
+  }
+
+  const executable = initialExecutable
+  const remote = remoteExecutables[executable]
+  if (remote) return remote
+
+  if (executable === 'command') {
+    if (tokens.slice(index + 1).some((token) => token === '-v' || token === '-V')) return null
+    const commandIndex = skipOptions(tokens, index + 1, new Set())
+    return detectSegment(tokens.slice(commandIndex), depth + 1)
+  }
+
+  if (executable === 'setsid' || executable === 'nohup') {
+    const commandIndex = skipOptions(tokens, index + 1, new Set())
+    return detectSegment(tokens.slice(commandIndex), depth + 1)
+  }
+
+  if (executable === 'timeout') {
+    const durationIndex = skipOptions(tokens, index + 1, new Set(['-k', '--kill-after', '-s', '--signal']))
+    return detectSegment(tokens.slice(durationIndex + 1), depth + 1)
+  }
+
+  if (executable === 'bash' || executable === 'sh' || executable === 'zsh' || executable === 'fish') {
+    for (let optionIndex = index + 1; optionIndex < tokens.length; optionIndex += 1) {
+      const option = tokens[optionIndex]!
+      if (option === '--') continue
+      if (/^-[^-]*n/.test(option)) return null
+      if (/^-[^-]*c/.test(option)) {
+        const delimiterOffset = tokens[optionIndex + 1] === '--' ? 2 : 1
+        const script = tokens[optionIndex + delimiterOffset]
+        return script ? detectRemoteCommand(script, depth + 1) : null
+      }
+      if (!option.startsWith('-')) break
+    }
+  }
+
+  return null
+}
+
+export function detectRemoteCommand(command: string, depth = 0): RemoteProtocol | null {
+  if (depth > 8) return null
+  const { command: executableCommand, expandableBodies } = stripHeredocBodies(command)
+  const substitutions = [
+    ...extractCommandSubstitutions(executableCommand),
+    ...expandableBodies.flatMap((body) => extractCommandSubstitutions(body, false)),
+  ]
+  for (const substitution of substitutions) {
+    const detected = detectRemoteCommand(substitution, depth + 1)
+    if (detected) return detected
+  }
+  const tokens = tokenize(executableCommand)
+  let segment: string[] = []
+
+  const boundaries = new Set([';', '|', '&', '(', ')', '{', '}'])
+  const controlPrefixes = new Set(['then', 'do', 'else', 'elif', 'if', 'while', 'until'])
+  let skipLoopHeader = false
+  let inCase = false
+
+  for (const token of tokens) {
+    if (token === 'for' || token === 'select') {
+      const detected = detectSegment(segment, depth)
+      if (detected) return detected
+      segment = []
+      skipLoopHeader = true
+      continue
+    }
+    if (token === 'case') {
+      const detected = detectSegment(segment, depth)
+      if (detected) return detected
+      segment = []
+      inCase = true
+      continue
+    }
+    if (skipLoopHeader) {
+      if (token === 'do') skipLoopHeader = false
+      continue
+    }
+    if (inCase && token === ')') {
+      segment = []
+      continue
+    }
+    if (boundaries.has(token)) {
+      const detected = detectSegment(segment, depth)
+      if (detected) return detected
+      segment = []
+    } else if (controlPrefixes.has(token)) {
+      const detected = detectSegment(segment, depth)
+      if (detected) return detected
+      segment = []
+    } else if (token === 'fi' || token === 'done' || token === 'esac') {
+      const detected = detectSegment(segment, depth)
+      if (detected) return detected
+      segment = []
+      if (token === 'esac') inCase = false
+    } else {
+      segment.push(token)
+    }
+  }
+
+  return detectSegment(segment, depth)
+}
+
+export function detectRemoteExecution(tool: string, args: Record<string, unknown>): RemoteProtocol | null {
+  if (tool !== 'run_command' || typeof args.command !== 'string') return null
+  return detectRemoteCommand(args.command)
+}


### PR DESCRIPTION
### Summary

Adds a clear visual indicator for remote command execution, making it easier to distinguish operations running through SSH from local commands.

- Detects `ssh`, `scp`, `sftp`, and `mosh` commands, including commands nested behind common shells and wrappers such as `bash -lc`, `sudo`, `env`, `setsid`, `nohup`, and `timeout`.
- Displays a purple frame and a `REMOTE · SSH/SCP/SFTP/MOSH` badge on compact, expanded, and preparing tool-call cards.
- Keeps permission requests inside the remote-styled card, clarifying whether an access request is associated with remote execution.
- Avoids common false positives from quoted text, comments, heredocs, command lookups, arithmetic expressions, and shell control syntax.
- Adds comprehensive unit and component test coverage.

<img width="1497" height="367" alt="image" src="https://github.com/user-attachments/assets/435cdb47-8d47-402d-b425-d6395566a365" />

### AI-Enhanced Development

- **AI Models:** OpenAI GPT-5.4

### Cache Impact

- **No**