### PR TITLE
feat: add 'Open project folder' button in header

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -372,6 +372,21 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
     res.json({ project })
   })
 
+  app.get('/api/projects/:id/open-folder', async (req, res) => {
+    const { getProject } = await import('./db/projects.js')
+    const project = getProject(req.params.id)
+    if (!project) {
+      return res.status(404).json({ error: 'Project not found' })
+    }
+    try {
+      const { openFolder } = await import('./utils/openFolder.js')
+      await openFolder(project.workdir)
+      res.json({ success: true })
+    } catch (err) {
+      res.status(500).json({ error: err instanceof Error ? err.message : 'Failed to open folder' })
+    }
+  })
+
   app.put('/api/projects/:id', async (req, res) => {
     const { updateProject } = await import('./db/projects.js')
     const { name, customInstructions, dangerLevel } = req.body

--- a/src/server/routes/plugins.ts
+++ b/src/server/routes/plugins.ts
@@ -3,7 +3,6 @@ import { fileURLToPath, pathToFileURL } from 'node:url'
 import { dirname, resolve, join } from 'node:path'
 import { existsSync } from 'node:fs'
 import { readFile, readdir, rm, rename } from 'node:fs/promises'
-import { platform } from 'node:os'
 import { execFile } from 'node:child_process'
 import { promisify } from 'node:util'
 import type { ProviderPluginRegistry } from '../../provider/index.js'
@@ -19,9 +18,11 @@ interface Logger {
   error: (message: string, context?: Record<string, unknown>) => void
 }
 
+import { openFolder } from '../utils/openFolder.js'
+
 const execFileP = promisify(execFile)
 
-async function openFolder(
+async function openFolderRoute(
   dir: string,
   res: {
     json: (data: unknown) => void
@@ -29,9 +30,7 @@ async function openFolder(
   },
 ): Promise<void> {
   try {
-    await execFileP('mkdir', ['-p', dir], { timeout: 5000 })
-    const cmd = platform() === 'darwin' ? 'open' : platform() === 'win32' ? 'explorer' : 'xdg-open'
-    await execFileP(cmd, [dir], { timeout: 5000 })
+    await openFolder(dir)
     res.json({ success: true })
   } catch (err) {
     res.status(500).json({ error: err instanceof Error ? err.message : 'Failed to open folder' })
@@ -209,14 +208,14 @@ export function createPluginRoutes(options: {
 
   router.get('/open-folder', async (_req, res) => {
     const pluginsDir = join(getGlobalConfigDir(config.mode ?? 'production'), 'plugins')
-    await openFolder(pluginsDir, res)
+    await openFolderRoute(pluginsDir, res)
   })
 
   router.get('/:name/open-folder', async (req, res) => {
     const name = req.params.name as string
     if (!/^[a-zA-Z0-9_-]+$/.test(name)) return res.status(400).json({ error: 'Invalid plugin name' })
     const targetDir = join(getGlobalConfigDir(config.mode ?? 'production'), 'plugins', name)
-    await openFolder(targetDir, res)
+    await openFolderRoute(targetDir, res)
   })
 
   router.delete('/:name', async (req, res) => {

--- a/src/server/utils/openFolder.ts
+++ b/src/server/utils/openFolder.ts
@@ -1,0 +1,11 @@
+import { platform } from 'node:os'
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+
+const execFileP = promisify(execFile)
+
+export async function openFolder(dir: string): Promise<void> {
+  await execFileP('mkdir', ['-p', dir], { timeout: 5000 })
+  const cmd = platform() === 'darwin' ? 'open' : platform() === 'win32' ? 'explorer' : 'xdg-open'
+  await execFileP(cmd, [dir], { timeout: 5000 })
+}

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -1,5 +1,13 @@
 import { useState, useEffect } from 'react'
-import { MenuIcon, SettingsIcon, LogoutIcon, TerminalIcon, FullscreenIcon, FullscreenExitIcon } from '../shared/icons'
+import {
+  MenuIcon,
+  SettingsIcon,
+  LogoutIcon,
+  TerminalIcon,
+  FullscreenIcon,
+  FullscreenExitIcon,
+  FolderIcon,
+} from '../shared/icons'
 import { Link, useLocation } from 'wouter'
 import { useSessionStore } from '../../stores/session'
 import { useProjectStore } from '../../stores/project'
@@ -8,6 +16,7 @@ import { useTerminalStore } from '../../stores/terminal'
 import { useUpdateStore } from '../../stores/update'
 import { useKeybindings, useBinding } from '../../hooks/useKeybindings'
 import { formatKeybinding } from '../../lib/keybindings'
+import { authFetch } from '../../lib/api'
 import { GlobalSettingsModal } from '../settings/GlobalSettingsModal'
 import { TerminalDrawer } from '../terminal/TerminalDrawer'
 import { ProjectDropdown } from './ProjectDropdown'
@@ -155,6 +164,16 @@ export function Header({ onMenuClick, onCriteriaToggle }: HeaderProps) {
             title="Toggle terminal (double Ctrl)"
           >
             <TerminalIcon />
+          </button>
+        )}
+
+        {isProjectPage && project && (
+          <button
+            onClick={() => authFetch(`/api/projects/${project.id}/open-folder`).catch(() => {})}
+            className="p-2.5 rounded hover:bg-bg-tertiary text-text-muted hover:text-text-primary transition-colors"
+            title="Open project folder"
+          >
+            <FolderIcon className="w-4 h-4" />
           </button>
         )}
 


### PR DESCRIPTION
### Summary

Add an "Open project folder" button in the header that opens the current project's working directory in the OS file explorer.

### Changes

#### Backend
- New route `GET /api/projects/:id/open-folder` — opens `project.workdir` with `xdg-open` / `open` / `explorer`
- Extracted `openFolder` helper to `src/server/utils/openFolder.ts` (with `mkdir -p` guard)
- Refactored `plugins.ts` to use the shared utility instead of inline logic

#### Frontend
- Added `FolderIcon` button in `Header.tsx`, right next to the terminal toggle
- Guarded by `isProjectPage && project` (same as terminal button)
- Calls the new endpoint via `authFetch`

#### Files changed
| File | Change |
|---|---|
| `src/server/utils/openFolder.ts` | **New** — shared utility |
| `src/server/routes/plugins.ts` | Refactored to use shared utility |
| `src/server/index.ts` | New `open-folder` endpoint |
| `web/src/components/layout/Header.tsx` | New button + icon |

### AI-Enhanced Development

- **AI Models:** DeepSeek V4

### Cache Impact

- **No**