### PR TITLE
fix(security): use execFileSync instead of execSync in deleteWorkspace

### DIFF
--- a/src/server/git/workspace.test.ts
+++ b/src/server/git/workspace.test.ts
@@ -11,17 +11,20 @@ import {
   listWorkspaces,
   getWorkspacesDir,
   isGitRepository,
+  deleteWorkspace,
 } from './workspace.js'
 
 vi.mock('node:child_process', () => ({
   spawn: vi.fn(),
   execSync: vi.fn(),
+  execFileSync: vi.fn(),
 }))
 
 vi.mock('node:fs/promises', () => ({
   readFile: vi.fn(),
   readdir: vi.fn(),
   mkdir: vi.fn(),
+  rm: vi.fn(),
   stat: vi.fn(),
 }))
 
@@ -37,8 +40,8 @@ vi.mock('../db/projects.js', () => ({
   getProjectByWorkdir: vi.fn(),
 }))
 
-import { spawn, execSync } from 'node:child_process'
-import { readFile, readdir, mkdir, stat } from 'node:fs/promises'
+import { spawn, execSync, execFileSync } from 'node:child_process'
+import { readFile, readdir, mkdir, rm, stat } from 'node:fs/promises'
 import { loadWorkspaceConfig } from './workspace-config.js'
 import { getProjectByWorkdir } from '../db/projects.js'
 
@@ -358,5 +361,72 @@ describe('isGitRepository', () => {
     vi.mocked(spawn).mockReturnValueOnce(makeMockProc('/path/to/git-dir\n') as any)
     const result = await isGitRepository(TEST_DIR)
     expect(result).toBe(true)
+  })
+})
+
+describe('deleteWorkspace', () => {
+  it('uses execFileSync instead of execSync for safe deletion', async () => {
+    vi.mocked(stat).mockResolvedValue({ isDirectory: () => true } as any)
+
+    await deleteWorkspace(PROJECT_NAME, 'test-ws', CWD)
+
+    expect(execFileSync).toHaveBeenCalledWith('rm', ['-rf', expect.stringContaining('test-ws')], expect.any(Object))
+    expect(execSync).not.toHaveBeenCalled()
+  })
+
+  it('falls back to fs.rm when execFileSync fails', async () => {
+    vi.mocked(stat).mockResolvedValue({ isDirectory: () => true } as any)
+    vi.mocked(execFileSync).mockImplementation(() => {
+      throw new Error('Simulated rm failure')
+    })
+
+    await deleteWorkspace(PROJECT_NAME, 'test-ws', CWD)
+
+    expect(rm).toHaveBeenCalledWith(expect.stringContaining('test-ws'), { recursive: true, force: true })
+  })
+
+  it('does not create files when workspace name contains shell injection - semicolon', async () => {
+    const maliciousName = 'test; touch ~/.malicious_semicolon'
+    vi.mocked(stat).mockResolvedValue({ isDirectory: () => true } as any)
+
+    // execFileSync passes args directly, no shell interpretation
+    await deleteWorkspace(PROJECT_NAME, maliciousName, CWD)
+
+    expect(execFileSync).toHaveBeenCalledWith('rm', ['-rf', expect.stringContaining(maliciousName)], expect.any(Object))
+  })
+
+  it('does not create files when workspace name contains shell injection - backticks', async () => {
+    const maliciousName = '`touch ~/.malicious_backtick`'
+    vi.mocked(stat).mockResolvedValue({ isDirectory: () => true } as any)
+
+    await deleteWorkspace(PROJECT_NAME, maliciousName, CWD)
+
+    expect(execFileSync).toHaveBeenCalledWith('rm', ['-rf', expect.stringContaining(maliciousName)], expect.any(Object))
+  })
+
+  it('does not create files when workspace name contains shell injection - dollar sign', async () => {
+    const maliciousName = '$HOME/test'
+    vi.mocked(stat).mockResolvedValue({ isDirectory: () => true } as any)
+
+    await deleteWorkspace(PROJECT_NAME, maliciousName, CWD)
+
+    expect(execFileSync).toHaveBeenCalledWith('rm', ['-rf', expect.stringContaining(maliciousName)], expect.any(Object))
+  })
+
+  it('does not create files when workspace name contains shell injection - command substitution', async () => {
+    const maliciousName = '$(touch ~/.malicious_substitution)'
+    vi.mocked(stat).mockResolvedValue({ isDirectory: () => true } as any)
+
+    await deleteWorkspace(PROJECT_NAME, maliciousName, CWD)
+
+    expect(execFileSync).toHaveBeenCalledWith('rm', ['-rf', expect.stringContaining(maliciousName)], expect.any(Object))
+  })
+
+  it('throws error when workspace does not exist', async () => {
+    vi.mocked(stat).mockResolvedValue(null as any)
+
+    await expect(deleteWorkspace(PROJECT_NAME, 'nonexistent', CWD)).rejects.toThrow(
+      'Workspace "nonexistent" does not exist',
+    )
   })
 })

--- a/src/server/git/workspace.ts
+++ b/src/server/git/workspace.ts
@@ -1,4 +1,4 @@
-import { spawn, execSync } from 'node:child_process'
+import { spawn, execSync, execFileSync } from 'node:child_process'
 import { mkdir } from 'node:fs/promises'
 import { resolve, join, isAbsolute } from 'node:path'
 import { homedir, platform } from 'node:os'
@@ -320,10 +320,10 @@ export async function deleteWorkspace(projectName: string, name: string, project
   if (!st?.isDirectory()) {
     throw new Error(`Workspace "${name}" does not exist`)
   }
-  const { rm } = await import('node:fs/promises')
   try {
-    execSync(`rm -rf "${wsPath}"`, { stdio: 'ignore', timeout: 10_000 })
+    execFileSync('rm', ['-rf', wsPath], { stdio: 'ignore' })
   } catch {
+    const { rm } = await import('node:fs/promises')
     await rm(wsPath, { recursive: true, force: true })
   }
   logger.info('Deleted workspace', { projectName, name, path: wsPath })


### PR DESCRIPTION
### Summary

execSync interpolates user input directly into shell commands, making it vulnerable to shell injection attacks. For example, a workspace named 'test; touch ~/.pwned' would execute 'touch ~/.pwned' via the shell.

execFileSync passes arguments directly to the process without shell interpretation, preventing any command injection regardless of workspace name content. The fallback to fs.rm() in the catch block ensures robust deletion even if rm fails for unexpected reasons.

The dynamic import of 'rm' was moved into the catch block because it's only needed as a fallback. This keeps the happy path (execFileSync succeeds) free from unnecessary module loading overhead.


### AI-Enhanced Development

- **AI Models:** qwen3.6-27b, ornith-1.0-35b

### Cache Impact

Does this PR affect anything cached — system prompts, tool definitions, skills, or other context?

- **No**
