### PR TITLE
fix: MCP override changes no longer bump session updated_at

### DIFF
--- a/src/server/db/sessions.test.ts
+++ b/src/server/db/sessions.test.ts
@@ -18,12 +18,14 @@ import {
   getSession,
   listSessions,
   listSessionsByProject,
+  updateSessionMcpDisabledServers,
   updateSessionMetadata,
   updateSessionMode,
   updateSessionPhase,
   updateSessionRunning,
   updateSessionMessageCount,
 } from './sessions.js'
+import { getDatabase } from './index.js'
 
 describe('db sessions', () => {
   let rootA: string
@@ -257,5 +259,48 @@ describe('db sessions', () => {
 
     expect(sessionSummary).toBeDefined()
     expect(sessionSummary?.messageCount).toBe(2) // Only user and assistant messages
+  })
+
+  it('updateSessionMcpDisabledServers does not modify updated_at', async () => {
+    const session = createSession(projectAId, rootA, 'MCP Test')
+
+    // Delay to ensure the timestamp would differ if updated_at were touched
+    await new Promise((r) => setTimeout(r, 5))
+
+    const beforeUpdate = getSession(session.id)!
+    const originalUpdatedAt = beforeUpdate.updatedAt
+
+    updateSessionMcpDisabledServers(session.id, ['server-1', 'server-2'])
+
+    const afterUpdate = getSession(session.id)!
+    expect(afterUpdate.updatedAt).toBe(originalUpdatedAt)
+  })
+
+  it('updateSessionMcpDisabledServers sets mcp_disabled_servers to JSON array when servers are provided', () => {
+    const session = createSession(projectAId, rootA, 'MCP JSON Test')
+
+    updateSessionMcpDisabledServers(session.id, ['mcp-a', 'mcp-b'])
+
+    const db = getDatabase()
+    const row = db.prepare('SELECT mcp_disabled_servers FROM sessions WHERE id = ?').get(session.id) as {
+      mcp_disabled_servers: string | null
+    }
+    expect(row).not.toBeNull()
+    expect(row.mcp_disabled_servers).toBe(JSON.stringify(['mcp-a', 'mcp-b']))
+  })
+
+  it('updateSessionMcpDisabledServers sets mcp_disabled_servers to null when list is empty', () => {
+    const session = createSession(projectAId, rootA, 'MCP Empty Test')
+
+    // First set some servers
+    updateSessionMcpDisabledServers(session.id, ['server-1'])
+    // Then clear with empty array
+    updateSessionMcpDisabledServers(session.id, [])
+
+    const db = getDatabase()
+    const row = db.prepare('SELECT mcp_disabled_servers FROM sessions WHERE id = ?').get(session.id) as {
+      mcp_disabled_servers: string | null
+    }
+    expect(row.mcp_disabled_servers).toBeNull()
   })
 })

--- a/src/server/db/sessions.ts
+++ b/src/server/db/sessions.ts
@@ -215,9 +215,8 @@ export function updateSessionMetadata(id: string, metadata: Partial<Session['met
 
 export function updateSessionMcpDisabledServers(id: string, disabledServers: string[]): void {
   const db = getDatabase()
-  const now = new Date().toISOString()
   const value = disabledServers.length > 0 ? JSON.stringify(disabledServers) : null
-  db.prepare(`UPDATE sessions SET mcp_disabled_servers = ?, updated_at = ? WHERE id = ?`).run(value, now, id)
+  db.prepare(`UPDATE sessions SET mcp_disabled_servers = ? WHERE id = ?`).run(value, id)
 }
 
 export function updateSessionCachedPrompt(

--- a/src/server/routes/workspace-config.test.ts
+++ b/src/server/routes/workspace-config.test.ts
@@ -4,6 +4,7 @@ import { mkdir, rm, writeFile } from 'node:fs/promises'
 import { join, resolve } from 'node:path'
 import { tmpdir } from 'node:os'
 import { createWorkspaceConfigRoutes } from './workspace-config.js'
+import Database from 'better-sqlite3'
 
 /**
  * Simulates project DB records for route tests.
@@ -13,6 +14,19 @@ import { createWorkspaceConfigRoutes } from './workspace-config.js'
 const mockProjectById = new Map<string, string>() // projectId → workdir
 const mockProjectRecords = new Map<string, { workspaceRootDir?: string }>() // workdir → data
 
+/**
+ * In-memory SQLite database for MCP overrides integration test.
+ * Allows verifying that updateSessionMcpDisabledServers does not touch updated_at.
+ */
+let mockDb: Database.Database | undefined
+
+vi.mock('../db/index.js', () => ({
+  getDatabase: () => {
+    if (!mockDb) throw new Error('mockDb not initialized for test')
+    return mockDb
+  },
+}))
+
 vi.mock('../db/projects.js', () => ({
   getProjectByWorkdir: vi.fn((workdir: string) => {
     let record = mockProjectRecords.get(workdir)
@@ -20,8 +34,8 @@ vi.mock('../db/projects.js', () => ({
       record = {}
       mockProjectRecords.set(workdir, record)
     }
-    mockProjectById.set('test-id', workdir)
-    return { id: 'test-id', workspaceRootDir: record.workspaceRootDir }
+    mockProjectById.set('test-project', workdir)
+    return { id: 'test-project', workspaceRootDir: record.workspaceRootDir }
   }),
   updateProject: vi.fn((id: string, updates: { workspaceRootDir?: string | null }) => {
     const workdir = mockProjectById.get(id)
@@ -458,5 +472,156 @@ describe('POST /api/workspace/config (existing endpoint)', () => {
     const body = (await res.json()) as ConfigResponse
     expect(body.config.rootDir).toBeUndefined()
     expect(body.config.setup).toEqual(['npm install'])
+  })
+})
+
+describe('POST /api/workspace/config with MCP overrides', () => {
+  let app: express.Express
+  let server: ReturnType<typeof app.listen>
+  let baseUrl: string
+  let testDir: string
+
+  const SESSION_1_ID = 'mcp-session-1'
+  const SESSION_2_ID = 'mcp-session-2'
+  const FROZEN_TIME = '2024-01-01T00:00:00.000Z'
+
+  beforeEach(async () => {
+    testDir = join(tmpdir(), `openfox-ws-config-mcp-test-${Date.now()}`)
+    await mkdir(testDir, { recursive: true })
+
+    mockDb = new Database(':memory:')
+    mockDb.exec(`
+      CREATE TABLE sessions (
+        id TEXT PRIMARY KEY,
+        project_id TEXT NOT NULL,
+        workdir TEXT NOT NULL,
+        mode TEXT NOT NULL DEFAULT 'planner',
+        phase TEXT NOT NULL DEFAULT 'idle',
+        workflow_phase TEXT NOT NULL DEFAULT 'plan',
+        is_running INTEGER NOT NULL DEFAULT 0,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        title TEXT,
+        total_tokens_used INTEGER DEFAULT 0,
+        total_tool_calls INTEGER DEFAULT 0,
+        iteration_count INTEGER DEFAULT 0,
+        provider_id TEXT,
+        provider_model TEXT,
+        message_count INTEGER NOT NULL DEFAULT 0,
+        mcp_disabled_servers TEXT,
+        danger_level TEXT NOT NULL DEFAULT 'normal',
+        workspace TEXT,
+        branch TEXT
+      )
+    `)
+    mockDb
+      .prepare(
+        `
+      INSERT INTO sessions (id, project_id, workdir, mode, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?)
+    `,
+      )
+      .run(SESSION_1_ID, 'test-project', testDir, 'builder', FROZEN_TIME, FROZEN_TIME)
+    mockDb
+      .prepare(
+        `
+      INSERT INTO sessions (id, project_id, workdir, mode, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?)
+    `,
+      )
+      .run(SESSION_2_ID, 'test-project', testDir, 'planner', FROZEN_TIME, FROZEN_TIME)
+
+    app = express()
+    app.use(express.json())
+    app.use(
+      '/api/workspace',
+      createWorkspaceConfigRoutes({
+        listSessions: () => [
+          {
+            id: SESSION_1_ID,
+            projectId: 'test-project',
+            workdir: testDir,
+            mode: 'builder',
+            phase: 'build',
+            isRunning: false,
+            createdAt: FROZEN_TIME,
+            updatedAt: FROZEN_TIME,
+            criteriaCount: 0,
+            criteriaCompleted: 0,
+            messageCount: 0,
+          },
+          {
+            id: SESSION_2_ID,
+            projectId: 'test-project',
+            workdir: testDir,
+            mode: 'planner',
+            phase: 'plan',
+            isRunning: false,
+            createdAt: FROZEN_TIME,
+            updatedAt: FROZEN_TIME,
+            criteriaCount: 0,
+            criteriaCompleted: 0,
+            messageCount: 0,
+          },
+        ],
+        setDynamicContextChanged: () => {},
+      } as any),
+    )
+
+    return new Promise<void>((resolve) => {
+      server = app.listen(0, () => {
+        baseUrl = `http://localhost:${(server.address() as any).port}`
+        resolve()
+      })
+    })
+  })
+
+  afterEach(async () => {
+    server?.close()
+    mockDb?.close()
+    mockDb = undefined
+    await rm(testDir, { recursive: true, force: true })
+  })
+
+  it('does not change session updated_at when saving MCP overrides', async () => {
+    const res = await fetch(`${baseUrl}/api/workspace/config?workdir=${encodeURIComponent(testDir)}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        mcpOverrides: { 'server-1': { disabled: true }, 'server-2': { disabled: true } },
+      }),
+    })
+
+    expect(res.status).toBe(200)
+
+    const session1 = mockDb!
+      .prepare('SELECT updated_at, mcp_disabled_servers FROM sessions WHERE id = ?')
+      .get(SESSION_1_ID) as { updated_at: string; mcp_disabled_servers: string | null }
+    const session2 = mockDb!
+      .prepare('SELECT updated_at, mcp_disabled_servers FROM sessions WHERE id = ?')
+      .get(SESSION_2_ID) as { updated_at: string; mcp_disabled_servers: string | null }
+
+    expect(session1.updated_at).toBe(FROZEN_TIME)
+    expect(session2.updated_at).toBe(FROZEN_TIME)
+    expect(session1.mcp_disabled_servers).toBe(JSON.stringify(['server-1', 'server-2']))
+    expect(session2.mcp_disabled_servers).toBe(JSON.stringify(['server-1', 'server-2']))
+  })
+
+  it('does not change session updated_at when clearing MCP overrides', async () => {
+    const res = await fetch(`${baseUrl}/api/workspace/config?workdir=${encodeURIComponent(testDir)}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        mcpOverrides: {},
+      }),
+    })
+
+    expect(res.status).toBe(200)
+
+    const session1 = mockDb!.prepare('SELECT updated_at FROM sessions WHERE id = ?').get(SESSION_1_ID) as {
+      updated_at: string
+    }
+
+    expect(session1.updated_at).toBe(FROZEN_TIME)
   })
 })

--- a/web/src/stores/session/messageHandler.test.ts
+++ b/web/src/stores/session/messageHandler.test.ts
@@ -1,0 +1,168 @@
+// @vitest-environment happy-dom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.stubGlobal('requestAnimationFrame', (cb: () => void) => setTimeout(cb, 0))
+vi.stubGlobal('cancelAnimationFrame', (id: number) => clearTimeout(id))
+
+const fetchMock = vi.fn(() =>
+  Promise.resolve({ ok: true, json: () => Promise.resolve({ success: true }), status: 200 }),
+)
+vi.stubGlobal('fetch', fetchMock)
+vi.stubGlobal('localStorage', {
+  getItem: vi.fn(() => null),
+  setItem: vi.fn(),
+  removeItem: vi.fn(),
+})
+
+const {
+  wsSendMock,
+  wsSubscribeMock,
+  wsConnectMock,
+  wsDisconnectMock,
+  wsStatusMock,
+  playNotificationMock,
+  playAchievementMock,
+  playInterventionMock,
+  playWaitingForUserMock,
+  playNewMessageMock,
+} = vi.hoisted(() => ({
+  wsSendMock: vi.fn(() => 'message-id'),
+  wsSubscribeMock: vi.fn(() => () => undefined),
+  wsConnectMock: vi.fn(async () => undefined),
+  wsDisconnectMock: vi.fn(() => undefined),
+  wsStatusMock: vi.fn(() => undefined),
+  playNotificationMock: vi.fn(),
+  playAchievementMock: vi.fn(),
+  playInterventionMock: vi.fn(),
+  playWaitingForUserMock: vi.fn(),
+  playNewMessageMock: vi.fn(),
+}))
+
+vi.mock('../../lib/ws', () => ({
+  wsClient: {
+    send: wsSendMock,
+    subscribe: wsSubscribeMock,
+    connect: wsConnectMock,
+    disconnect: wsDisconnectMock,
+    onStatusChange: wsStatusMock,
+  },
+}))
+
+vi.mock('../../lib/sound', () => ({
+  playNotification: playNotificationMock,
+  playAchievement: playAchievementMock,
+  playIntervention: playInterventionMock,
+  playWaitingForUser: playWaitingForUserMock,
+  playNewMessage: playNewMessageMock,
+}))
+
+type SessionStoreModule = typeof import('../session')
+
+async function loadSessionStore(): Promise<SessionStoreModule['useSessionStore']> {
+  vi.resetModules()
+  const module = await import('../session')
+  return module.useSessionStore
+}
+
+describe('session.name_generated handler', () => {
+  beforeEach(() => {
+    wsSendMock.mockClear()
+    wsSubscribeMock.mockClear()
+    wsConnectMock.mockClear()
+    wsDisconnectMock.mockClear()
+    wsStatusMock.mockClear()
+    playNotificationMock.mockClear()
+    playAchievementMock.mockClear()
+    playInterventionMock.mockClear()
+    playWaitingForUserMock.mockClear()
+    playNewMessageMock.mockClear()
+    fetchMock.mockClear()
+  })
+
+  it('should NOT modify updatedAt when a session name is generated', async () => {
+    const useSessionStore = await loadSessionStore()
+
+    const originalUpdatedAt = '2024-01-01T00:00:00.000Z'
+
+    useSessionStore.setState((state) => ({
+      ...state,
+      sessions: [
+        {
+          id: 'session-1',
+          projectId: 'project-1',
+          workdir: '/tmp/test',
+          mode: 'builder',
+          phase: 'build',
+          isRunning: false,
+          createdAt: '2024-01-01T00:00:00.000Z',
+          updatedAt: originalUpdatedAt,
+          criteriaCount: 0,
+          criteriaCompleted: 0,
+          messageCount: 0,
+        } as any,
+      ],
+    }))
+
+    useSessionStore.getState().handleServerMessage({
+      type: 'session.name_generated',
+      sessionId: 'session-1',
+      payload: { name: 'My New Session Name' },
+    })
+
+    const state = useSessionStore.getState()
+    expect(state.sessions[0]?.title).toBe('My New Session Name')
+    expect(state.sessions[0]?.updatedAt).toBe(originalUpdatedAt)
+  })
+
+  it('should update the title without changing updatedAt on currentSession', async () => {
+    const useSessionStore = await loadSessionStore()
+
+    const originalUpdatedAt = '2024-06-15T10:30:00.000Z'
+
+    useSessionStore.setState((state) => ({
+      ...state,
+      sessions: [
+        {
+          id: 'session-1',
+          projectId: 'project-1',
+          workdir: '/tmp/test',
+          mode: 'builder',
+          phase: 'build',
+          isRunning: false,
+          createdAt: '2024-01-01T00:00:00.000Z',
+          updatedAt: originalUpdatedAt,
+          criteriaCount: 0,
+          criteriaCompleted: 0,
+          messageCount: 0,
+        } as any,
+      ],
+      currentSession: {
+        id: 'session-1',
+        projectId: 'project-1',
+        workdir: '/tmp/test',
+        mode: 'builder',
+        phase: 'build',
+        isRunning: false,
+        createdAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: originalUpdatedAt,
+        messages: [],
+        criteria: [],
+        contextWindows: [],
+        executionState: null,
+        metadata: { title: '', totalTokensUsed: 0, totalToolCalls: 0, iterationCount: 0 },
+        metadataEntries: {},
+      } as any,
+    }))
+
+    useSessionStore.getState().handleServerMessage({
+      type: 'session.name_generated',
+      sessionId: 'session-1',
+      payload: { name: 'Renamed Session' },
+    })
+
+    const state = useSessionStore.getState()
+    expect(state.currentSession?.metadata?.title).toBe('Renamed Session')
+    expect(state.currentSession?.updatedAt).toBe(originalUpdatedAt)
+    expect(state.sessions[0]?.updatedAt).toBe(originalUpdatedAt)
+  })
+})

--- a/web/src/stores/session/messageHandler.ts
+++ b/web/src/stores/session/messageHandler.ts
@@ -739,14 +739,12 @@ export function handleServerMessage(
       const activeSessionId = get().currentSession?.id
 
       set((state) => {
-        const updatedSessions = state.sessions.map((s) =>
-          s.id === eventSessionId ? { ...s, title: payload.name, updatedAt: new Date().toISOString() } : s,
-        )
+        const updatedSessions = state.sessions.map((s) => (s.id === eventSessionId ? { ...s, title: payload.name } : s))
 
         const updatedCurrentSession =
           activeSessionId === eventSessionId
             ? state.currentSession
-              ? { ...state.currentSession, title: payload.name, updatedAt: new Date().toISOString() }
+              ? { ...state.currentSession, metadata: { ...state.currentSession.metadata, title: payload.name } }
               : null
             : state.currentSession
 


### PR DESCRIPTION
### Résumé

Quand on modifie les serveurs MCP disponibles dans les paramètres d'un projet puis qu'on crée une nouvelle session, toutes les sessions du projet voyaient leur `updated_at` mise à jour à la date actuelle. Comme la sidebar regroupe et trie les sessions par `updated_at`, toutes les sessions apparaissaient brutalement sous "la date actuelle" — rendant le suivi temporel inutilisable.

**Deux bugs ont été corrigés :**

1. **Côté serveur** : `updateSessionMcpDisabledServers()` dans `src/server/db/sessions.ts` mettait `updated_at = now` sur chaque session du projet. Appelée via `POST /api/workspace/config` (qui boucle sur toutes les sessions quand les MCP overrides changent), cela impactait toutes les sessions d'un coup.

2. **Côté frontend** : Le handler `session.name_generated` dans `web/src/stores/session/messageHandler.ts` utilisait `new Date().toISOString()` côté client pour fixer `updatedAt` — ce qui faisait sauter la session à la date courante dans la sidebar lors de l'auto-génération de son titre.

### Reproduction

1. Ouvrir les paramètres d'un projet existant (Project Settings)
2. Basculer un serveur MCP dans la section "MCP Servers" et sauvegarder
3. Créer une nouvelle session dans ce projet
4. Observer la sidebar : **toutes** les sessions du projet sont maintenant sous "date actuelle"

### Correction

- **`updateSessionMcpDisabledServers`** : le `updated_at` a été retiré de la requête SQL. La configuration MCP est une metadata interne, pas une activité utilisateur.
- **Handler `session.name_generated`** : suppression du `new Date().toISOString()` sur `updatedAt`. Le titre est maintenant mis à jour via `metadata.title` (conforme au type `Session`). La valeur correcte de `updatedAt` sera synchronisée depuis le serveur via les messages `session.list` ou `session.state`.

### Tests

- `src/server/db/sessions.test.ts` : 3 tests — `updated_at` inchangé, stockage JSON, nullification à vide
- `src/server/routes/workspace-config.test.ts` : 2 tests d'intégration — sauvegarde et effacement des MCP overrides
- `web/src/stores/session/messageHandler.test.ts` : 2 tests — `updatedAt` préservé sur sessions list et currentSession

### AI-Enhanced Development

- **AI Models:** DeepSeek V4 Flash

### Cache Impact

- **Yes** — Les fonctions `updateSessionMcpDisabledServers` et `session.name_generated` handler sont modifiées. Les sessions existantes conservent leur `updated_at` original. Aucun impact sur les prompts système, les outils, ou les skills.
