### PR TITLE
feat: allow selecting vision fallback model from configured providers

### DIFF
--- a/src/cli/config.test.ts
+++ b/src/cli/config.test.ts
@@ -614,4 +614,97 @@ describe('resolveVisionFallback', () => {
     expect(result!.baseUrl).toBe('http://fallback:11434')
     expect(getVisionFallback(config).providerModelRef).toBe('deleted-provider/some-model')
   })
+
+  it('falls back to default url when provider has no url and fallback.url is undefined', () => {
+    const providerNoUrl = {
+      ...visionProvider,
+      url: '',
+      apiKey: undefined,
+    }
+    const config = makeConfig({
+      providers: [providerNoUrl],
+      visionFallback: {
+        enabled: true,
+        providerModelRef: 'vision-provider/gpt-4o-vision',
+        url: '',
+        timeout: 60,
+      },
+    })
+    const result = resolveVisionFallback(config)
+    expect(result).toBeDefined()
+    expect(result!.baseUrl).toBe('http://localhost:11434')
+    expect(result!.model).toBe('gpt-4o-vision')
+    expect(result!.timeout).toBe(60 * 1000)
+  })
+
+  it('returns legacy fallback when providerModelRef is empty string', () => {
+    const config = makeConfig({
+      visionFallback: {
+        enabled: true,
+        providerModelRef: '',
+        url: 'http://manual:11434',
+        model: 'manual-model',
+        timeout: 30,
+        backend: 'ollama' as const,
+      },
+    })
+    const result = resolveVisionFallback(config)
+    expect(result).toBeDefined()
+    expect(result!.baseUrl).toBe('http://manual:11434')
+    expect(result!.model).toBe('manual-model')
+  })
+
+  it('handles ref without slash gracefully', () => {
+    const config = makeConfig({
+      visionFallback: {
+        enabled: true,
+        providerModelRef: 'no-slash-here',
+        url: 'http://fallback:11434',
+        model: 'fallback-model',
+        timeout: 30,
+        backend: 'ollama' as const,
+      },
+    })
+    const result = resolveVisionFallback(config)
+    expect(result).toBeDefined()
+    expect(result!.baseUrl).toBe('http://fallback:11434')
+    expect(result!.model).toBe('fallback-model')
+  })
+
+  it('handles empty provider models array', () => {
+    const providerEmptyModels = {
+      ...visionProvider,
+      id: 'empty-models',
+      models: [],
+    }
+    const config = makeConfig({
+      providers: [providerEmptyModels],
+      visionFallback: {
+        enabled: true,
+        providerModelRef: 'empty-models/gpt-4o-vision',
+        url: 'http://fallback:11434',
+        model: 'fallback-model',
+        timeout: 30,
+        backend: 'ollama' as const,
+      },
+    })
+    const result = resolveVisionFallback(config)
+    expect(result).toBeDefined()
+    expect(result!.baseUrl).toBe('http://fallback:11434')
+    expect(result!.model).toBe('fallback-model')
+  })
+
+  it('returns undefined when fallback.url is undefined in legacy mode', () => {
+    const config = makeConfig({
+      visionFallback: {
+        enabled: true,
+        url: '',
+        model: 'some-model',
+        timeout: 30,
+        backend: 'ollama' as const,
+      },
+    })
+    const result = resolveVisionFallback(config)
+    expect(result).toBeUndefined()
+  })
 })

--- a/src/cli/config.test.ts
+++ b/src/cli/config.test.ts
@@ -418,3 +418,200 @@ describe('config', () => {
     ])
   })
 })
+
+describe('resolveVisionFallback', () => {
+  let resolveVisionFallback: typeof import('./config.js').resolveVisionFallback
+  let getVisionFallback: typeof import('./config.js').getVisionFallback
+
+  beforeEach(async () => {
+    vi.resetModules()
+    const configModule = await import('./config.js')
+    resolveVisionFallback = configModule.resolveVisionFallback
+    getVisionFallback = configModule.getVisionFallback
+  })
+
+  const visionProvider = {
+    id: 'vision-provider',
+    name: 'Vision Provider',
+    url: 'http://vision-server:8000/v1',
+    backend: 'openai' as const,
+    apiKey: 'sk-test-key-123',
+    models: [
+      { id: 'gpt-4o-vision', contextWindow: 128000, source: 'backend' as const, supportsVision: true },
+      { id: 'gpt-4o-mini', contextWindow: 64000, source: 'backend' as const, supportsVision: true },
+      { id: 'text-only-model', contextWindow: 32000, source: 'backend' as const },
+    ],
+    isActive: true,
+    createdAt: new Date().toISOString(),
+  }
+
+  function makeConfig(overrides?: Record<string, unknown>): any {
+    return {
+      providers: [visionProvider],
+      server: { port: 10369, host: '127.0.0.1', openBrowser: true },
+      logging: { level: 'error' as const },
+      database: { path: '' },
+      workspace: { workdir: process.cwd() },
+      visionFallback: {
+        enabled: false,
+        url: 'http://localhost:11434',
+        model: 'qwen3.5:0.8b',
+        timeout: 120,
+        backend: 'ollama' as const,
+      },
+      ...overrides,
+    }
+  }
+
+  it('resolves a valid providerModelRef to the correct provider/model', () => {
+    const config = makeConfig({
+      visionFallback: {
+        enabled: true,
+        providerModelRef: 'vision-provider/gpt-4o-vision',
+        timeout: 120,
+      },
+    })
+    const result = resolveVisionFallback(config)
+    expect(result).toBeDefined()
+    expect(result!.baseUrl).toBe('http://vision-server:8000/v1')
+    expect(result!.model).toBe('gpt-4o-vision')
+    expect(result!.timeout).toBe(120 * 1000)
+    expect(result!.backend).toBe('openai')
+    expect(result!.apiKey).toBe('sk-test-key-123')
+  })
+
+  it('falls back to legacy fields when providerModelRef is absent', () => {
+    const config = makeConfig({
+      visionFallback: {
+        enabled: true,
+        url: 'http://legacy-server:11434',
+        model: 'llava',
+        timeout: 60,
+        backend: 'ollama' as const,
+      },
+    })
+    const result = resolveVisionFallback(config)
+    expect(result).toBeDefined()
+    expect(result!.baseUrl).toBe('http://legacy-server:11434')
+    expect(result!.model).toBe('llava')
+    expect(result!.timeout).toBe(60 * 1000)
+    expect(result!.backend).toBe('ollama')
+    expect(result!.apiKey).toBeUndefined()
+  })
+
+  it('handles provider-not-found gracefully by falling back to legacy', () => {
+    const config = makeConfig({
+      visionFallback: {
+        enabled: true,
+        providerModelRef: 'nonexistent-provider/gpt-4o-vision',
+        url: 'http://fallback:11434',
+        model: 'fallback-model',
+        timeout: 30,
+        backend: 'ollama' as const,
+      },
+    })
+    const result = resolveVisionFallback(config)
+    expect(result).toBeDefined()
+    expect(result!.baseUrl).toBe('http://fallback:11434')
+    expect(result!.model).toBe('fallback-model')
+  })
+
+  it('handles model-not-found gracefully by falling back to first vision-capable model', () => {
+    const config = makeConfig({
+      visionFallback: {
+        enabled: true,
+        providerModelRef: 'vision-provider/nonexistent-model',
+        timeout: 120,
+      },
+    })
+    const result = resolveVisionFallback(config)
+    expect(result).toBeDefined()
+    expect(result!.model).toBe('gpt-4o-vision')
+    expect(result!.baseUrl).toBe('http://vision-server:8000/v1')
+    expect(result!.backend).toBe('openai')
+  })
+
+  it('disables vision fallback when provider ref has no vision-capable models', () => {
+    const noVisionProvider = {
+      ...visionProvider,
+      id: 'no-vision-provider',
+      models: [{ id: 'text-model', contextWindow: 32000, source: 'backend' as const }],
+    }
+    const config = makeConfig({
+      providers: [noVisionProvider],
+      visionFallback: {
+        enabled: true,
+        providerModelRef: 'no-vision-provider/text-model',
+        url: 'http://fallback:11434',
+        model: 'fallback-model',
+        timeout: 30,
+        backend: 'ollama' as const,
+      },
+    })
+    const result = resolveVisionFallback(config)
+    expect(result).toBeDefined()
+    expect(result!.baseUrl).toBe('http://fallback:11434')
+    expect(result!.model).toBe('fallback-model')
+  })
+
+  it('returns undefined when vision fallback is disabled', () => {
+    const config = makeConfig({
+      visionFallback: {
+        enabled: false,
+        providerModelRef: 'vision-provider/gpt-4o-vision',
+      },
+    })
+    const result = resolveVisionFallback(config)
+    expect(result).toBeUndefined()
+  })
+
+  it('includes apiKey when the provider has one', () => {
+    const config = makeConfig({
+      visionFallback: {
+        enabled: true,
+        providerModelRef: 'vision-provider/gpt-4o-mini',
+        timeout: 120,
+      },
+    })
+    const result = resolveVisionFallback(config)
+    expect(result).toBeDefined()
+    expect(result!.apiKey).toBe('sk-test-key-123')
+    expect(result!.model).toBe('gpt-4o-mini')
+  })
+
+  it('omits apiKey when the provider has none', () => {
+    const providerNoKey = {
+      ...visionProvider,
+      apiKey: undefined,
+    }
+    const config = makeConfig({
+      providers: [providerNoKey],
+      visionFallback: {
+        enabled: true,
+        providerModelRef: 'vision-provider/gpt-4o-vision',
+        timeout: 120,
+      },
+    })
+    const result = resolveVisionFallback(config)
+    expect(result).toBeDefined()
+    expect(result!.apiKey).toBeUndefined()
+  })
+
+  it('retains providerModelRef in config even when provider is missing (graceful degradation)', () => {
+    const config = makeConfig({
+      providers: [],
+      visionFallback: {
+        enabled: true,
+        providerModelRef: 'deleted-provider/some-model',
+        url: 'http://fallback:11434',
+        model: 'fallback-model',
+        timeout: 30,
+        backend: 'ollama' as const,
+      },
+    })
+    const result = resolveVisionFallback(config)
+    expect(result).toBeDefined()
+    expect(result!.baseUrl).toBe('http://fallback:11434')
+    expect(getVisionFallback(config).providerModelRef).toBe('deleted-provider/some-model')
+  })
+})

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -224,18 +224,15 @@ export function resolveVisionFallback(
       const provider = config.providers?.find((p) => p.id === providerId)
 
       if (provider) {
-        let model = provider.models?.find((m) => m.id === modelId)
-        if (model && !model.supportsVision) {
-          model = provider.models?.find((m) => m.supportsVision)
-        }
-        if (!model || !model.supportsVision) {
-          model = provider.models?.find((m) => m.supportsVision)
-        }
+        const exactModel = provider.models?.find((m) => m.id === modelId)
+        const model = exactModel?.supportsVision
+          ? exactModel
+          : provider.models?.find((m) => m.supportsVision)
 
-        if (model) {
+        if (model?.supportsVision) {
           const backend: 'ollama' | 'openai' = provider.backend === 'ollama' ? 'ollama' : 'openai'
           return {
-            baseUrl: provider.url || fallback.url,
+            baseUrl: provider.url || fallback.url || 'http://localhost:11434',
             model: model.id,
             timeout: (fallback.timeout ?? 120) * 1000,
             backend,

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -105,6 +105,7 @@ const visionFallbackSchema = z.object({
   model: z.string().default('qwen3.5:0.8b'),
   timeout: z.number().default(120),
   backend: z.enum(['ollama', 'openai']).default('ollama'),
+  providerModelRef: z.string().optional(),
 })
 
 const cachedToolSchema = z.object({
@@ -132,12 +133,12 @@ const llmConfigSchema = z.object({
   idleTimeout: z.number().optional(),
 })
 
-const defaultVisionFallback = {
+const defaultVisionFallback: z.output<typeof visionFallbackSchema> = {
   enabled: false,
   url: 'http://localhost:11434',
   model: 'qwen3.5:0.8b',
   timeout: 120,
-  backend: 'ollama' as const,
+  backend: 'ollama',
 }
 
 // New config schema with providers array
@@ -200,7 +201,61 @@ export async function loadGlobalConfig(mode: Mode, configPathOverride?: string):
 }
 
 export function getDefaultVisionFallback() {
-  return { enabled: false, url: 'http://localhost:11434', model: 'qwen3.5:0.8b', timeout: 120 }
+  return {
+    enabled: false,
+    url: 'http://localhost:11434',
+    model: 'qwen3.5:0.8b',
+    timeout: 120,
+    backend: 'ollama' as const,
+  }
+}
+
+export function resolveVisionFallback(
+  config: GlobalConfig,
+): { baseUrl: string; model: string; timeout: number; backend: 'ollama' | 'openai'; apiKey?: string } | undefined {
+  const fallback = config.visionFallback
+  if (!fallback?.enabled) return undefined
+
+  if (fallback.providerModelRef) {
+    const slashIndex = fallback.providerModelRef.indexOf('/')
+    if (slashIndex !== -1) {
+      const providerId = fallback.providerModelRef.substring(0, slashIndex)
+      const modelId = fallback.providerModelRef.substring(slashIndex + 1)
+      const provider = config.providers?.find((p) => p.id === providerId)
+
+      if (provider) {
+        let model = provider.models?.find((m) => m.id === modelId)
+        if (model && !model.supportsVision) {
+          model = provider.models?.find((m) => m.supportsVision)
+        }
+        if (!model || !model.supportsVision) {
+          model = provider.models?.find((m) => m.supportsVision)
+        }
+
+        if (model) {
+          const backend: 'ollama' | 'openai' = provider.backend === 'ollama' ? 'ollama' : 'openai'
+          return {
+            baseUrl: provider.url || fallback.url,
+            model: model.id,
+            timeout: (fallback.timeout ?? 120) * 1000,
+            backend,
+            ...(provider.apiKey ? { apiKey: provider.apiKey } : {}),
+          }
+        }
+      }
+    }
+  }
+
+  if (fallback.url && fallback.model) {
+    return {
+      baseUrl: fallback.url,
+      model: fallback.model,
+      timeout: (fallback.timeout ?? 120) * 1000,
+      backend: fallback.backend ?? 'ollama',
+    }
+  }
+
+  return undefined
 }
 
 export async function saveGlobalConfig(

--- a/src/server/context/image-processor.test.ts
+++ b/src/server/context/image-processor.test.ts
@@ -1230,3 +1230,40 @@ describe('processContextImages', () => {
     expect(persistEvent).not.toHaveBeenCalled()
   })
 })
+
+describe('loadVisionModelFromGlobalConfig', () => {
+  it('returns resolved config from providerModelRef', async () => {
+    const configModule = await import('../../cli/config.js')
+    const visionProvider = {
+      id: 'vision-provider',
+      name: 'Vision Provider',
+      url: 'http://vision-server:8000/v1',
+      backend: 'openai' as const,
+      apiKey: 'sk-test-key-123',
+      models: [{ id: 'gpt-4o-vision', contextWindow: 128000, source: 'backend' as const, supportsVision: true }],
+      isActive: true,
+      createdAt: new Date().toISOString(),
+    }
+
+    const config = {
+      providers: [visionProvider],
+      server: { port: 10369, host: '127.0.0.1', openBrowser: true },
+      logging: { level: 'error' as const },
+      database: { path: '' },
+      workspace: { workdir: process.cwd() },
+      visionFallback: {
+        enabled: true,
+        providerModelRef: 'vision-provider/gpt-4o-vision',
+        timeout: 120,
+      },
+    }
+
+    const fallbackRef = configModule.resolveVisionFallback(config as any)
+    expect(fallbackRef).toBeDefined()
+    expect(fallbackRef!.baseUrl).toBe('http://vision-server:8000/v1')
+    expect(fallbackRef!.model).toBe('gpt-4o-vision')
+    expect(fallbackRef!.timeout).toBe(120 * 1000)
+    expect(fallbackRef!.backend).toBe('openai')
+    expect(fallbackRef!.apiKey).toBe('sk-test-key-123')
+  })
+})

--- a/src/server/context/image-processor.ts
+++ b/src/server/context/image-processor.ts
@@ -9,22 +9,14 @@ import { contentHash, cacheSet } from '../utils/cache.js'
 import { decodeDataUrl } from '../utils/data-url.js'
 
 export async function loadVisionModelFromGlobalConfig(): Promise<
-  { baseUrl: string; model: string; timeout: number; backend: VisionBackend } | undefined
+  { baseUrl: string; model: string; timeout: number; backend: VisionBackend; apiKey?: string } | undefined
 > {
   try {
-    const { loadGlobalConfig, getVisionFallback } = await import('../../cli/config.js')
+    const { loadGlobalConfig, resolveVisionFallback } = await import('../../cli/config.js')
     const runtimeConfig = getRuntimeConfig()
     const mode = runtimeConfig.mode ?? 'production'
     const globalConfig = await loadGlobalConfig(mode)
-    const fallback = getVisionFallback(globalConfig)
-    if (fallback?.enabled && fallback.model) {
-      return {
-        baseUrl: fallback.url,
-        model: fallback.model,
-        timeout: fallback.timeout * 1000,
-        backend: fallback.backend ?? 'ollama',
-      }
-    }
+    return resolveVisionFallback(globalConfig)
   } catch {
     // Global config not available
   }
@@ -38,6 +30,7 @@ export interface ImageProcessorOptions {
     model: string
     timeout: number
     backend: VisionBackend
+    apiKey?: string
   }
   signal?: AbortSignal
   onEvent?: (event: TurnEvent) => void

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1535,7 +1535,14 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
     const activeProvider = providerManager.getActiveProvider()
 
     let visionFallback:
-      | { enabled: boolean; url: string; model: string; timeout: number; backend: VisionBackend }
+      | {
+          enabled: boolean
+          url: string
+          model: string
+          timeout: number
+          backend: VisionBackend
+          providerModelRef?: string
+        }
       | undefined
     let globalWorkdir: string | undefined
     try {
@@ -1549,6 +1556,7 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
           model: fallback.model ?? 'qwen3.5:0.8b',
           timeout: fallback.timeout ?? 120,
           backend: fallback.backend ?? 'ollama',
+          ...(fallback.providerModelRef ? { providerModelRef: fallback.providerModelRef } : {}),
         }
       }
       globalWorkdir = globalConfig.workspace?.workdir
@@ -2007,17 +2015,28 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
   app.post('/api/init/config', async (req, res) => {
     const { workdir, visionFallback } = req.body as {
       workdir?: string
-      visionFallback?: { enabled: boolean; url: string; model: string; timeout: number; backend: VisionBackend }
+      visionFallback?: {
+        enabled: boolean
+        url?: string
+        model?: string
+        timeout?: number
+        backend?: VisionBackend
+        providerModelRef?: string
+      }
     }
 
     try {
       const { loadGlobalConfig, saveGlobalConfig } = await import('../cli/config.js')
       const globalConfig = await loadGlobalConfig(config.mode ?? 'production', config.globalConfigPath)
 
+      const updatedVf = visionFallback
+        ? { ...globalConfig.visionFallback, ...visionFallback }
+        : globalConfig.visionFallback
+
       const updatedConfig = {
         ...globalConfig,
         workspace: workdir ? { workdir } : globalConfig.workspace,
-        visionFallback: visionFallback ?? globalConfig.visionFallback,
+        visionFallback: updatedVf,
       }
 
       await saveGlobalConfig(config.mode ?? 'production', updatedConfig, config.globalConfigPath)
@@ -2028,6 +2047,89 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
         success: false,
         error: error instanceof Error ? error.message : 'Failed to save config',
       })
+    }
+  })
+
+  // Update vision fallback config only
+  app.put('/api/config/vision-fallback', async (req, res) => {
+    const updates = req.body as {
+      enabled?: boolean
+      url?: string
+      model?: string
+      timeout?: number
+      backend?: VisionBackend
+      providerModelRef?: string
+    }
+
+    try {
+      const { loadGlobalConfig, saveGlobalConfig } = await import('../cli/config.js')
+      const globalConfig = await loadGlobalConfig(config.mode ?? 'production', config.globalConfigPath)
+
+      const updatedConfig = {
+        ...globalConfig,
+        visionFallback: {
+          ...(globalConfig.visionFallback ?? {
+            enabled: false,
+            url: 'http://localhost:11434',
+            model: 'qwen3.5:0.8b',
+            timeout: 120,
+            backend: 'ollama',
+          }),
+          ...updates,
+        },
+      }
+
+      await saveGlobalConfig(config.mode ?? 'production', updatedConfig, config.globalConfigPath)
+
+      res.json({ success: true })
+    } catch (error) {
+      res.status(500).json({
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to save vision fallback config',
+      })
+    }
+  })
+
+  // Test vision fallback configuration
+  app.post('/api/config/vision-fallback/test', async (req, res) => {
+    const testConfig = req.body as {
+      url?: string
+      model?: string
+      backend?: VisionBackend
+      providerModelRef?: string
+      timeout?: number
+    }
+
+    try {
+      const { resolveVisionFallback } = await import('../cli/config.js')
+      const { loadGlobalConfig } = await import('../cli/config.js')
+      const globalConfig = await loadGlobalConfig(config.mode ?? 'production', config.globalConfigPath)
+
+      // Merge test config over the existing one for testing
+      const testVisionFallback = {
+        ...(globalConfig.visionFallback ?? {
+          enabled: true,
+          url: 'http://localhost:11434',
+          model: 'qwen3.5:0.8b',
+          timeout: 120,
+          backend: 'ollama' as const,
+        }),
+        ...testConfig,
+        enabled: true,
+      }
+      const testGlobalConfig = { ...globalConfig, visionFallback: testVisionFallback }
+      const resolved = resolveVisionFallback(testGlobalConfig)
+
+      if (resolved) {
+        res.json({
+          success: true,
+          description: `Config valid: ${resolved.model} @ ${resolved.baseUrl} (${resolved.backend})`,
+        })
+      } else {
+        res.json({ success: false, error: 'Could not resolve vision model config. Check your settings.' })
+      }
+    } catch (error) {
+      res.json({ success: false, error: error instanceof Error ? error.message : 'Test failed' })
     }
   })
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -2052,18 +2052,30 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
 
   // Update vision fallback config only
   app.put('/api/config/vision-fallback', async (req, res) => {
-    const updates = req.body as {
-      enabled?: boolean
-      url?: string
-      model?: string
-      timeout?: number
-      backend?: VisionBackend
-      providerModelRef?: string
+    const { z } = await import('zod')
+
+    const visionFallbackUpdateSchema = z.object({
+      enabled: z.boolean().optional(),
+      url: z.string().optional(),
+      model: z.string().optional(),
+      timeout: z.number().positive().optional(),
+      backend: z.enum(['ollama', 'openai']).optional(),
+      providerModelRef: z.string().optional(),
+    })
+
+    const parsed = visionFallbackUpdateSchema.safeParse(req.body)
+    if (!parsed.success) {
+      res.status(400).json({ success: false, error: parsed.error.issues.map((i) => i.message).join(', ') })
+      return
     }
+
+    const updates = parsed.data
 
     try {
       const { loadGlobalConfig, saveGlobalConfig } = await import('../cli/config.js')
       const globalConfig = await loadGlobalConfig(config.mode ?? 'production', config.globalConfigPath)
+
+      const filteredUpdates = Object.fromEntries(Object.entries(updates).filter(([, v]) => v !== undefined))
 
       const updatedConfig = {
         ...globalConfig,
@@ -2073,9 +2085,9 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
             url: 'http://localhost:11434',
             model: 'qwen3.5:0.8b',
             timeout: 120,
-            backend: 'ollama',
+            backend: 'ollama' as const,
           }),
-          ...updates,
+          ...filteredUpdates,
         },
       }
 
@@ -2092,13 +2104,23 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
 
   // Test vision fallback configuration
   app.post('/api/config/vision-fallback/test', async (req, res) => {
-    const testConfig = req.body as {
-      url?: string
-      model?: string
-      backend?: VisionBackend
-      providerModelRef?: string
-      timeout?: number
+    const { z } = await import('zod')
+
+    const testSchema = z.object({
+      url: z.string().optional(),
+      model: z.string().optional(),
+      backend: z.enum(['ollama', 'openai']).optional(),
+      providerModelRef: z.string().optional(),
+      timeout: z.number().positive().optional(),
+    })
+
+    const parsed = testSchema.safeParse(req.body)
+    if (!parsed.success) {
+      res.status(400).json({ success: false, error: parsed.error.issues.map((i) => i.message).join(', ') })
+      return
     }
+
+    const testConfig = parsed.data
 
     try {
       const { resolveVisionFallback } = await import('../cli/config.js')
@@ -2106,6 +2128,7 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
       const globalConfig = await loadGlobalConfig(config.mode ?? 'production', config.globalConfigPath)
 
       // Merge test config over the existing one for testing
+      const filteredTestConfig = Object.fromEntries(Object.entries(testConfig).filter(([, v]) => v !== undefined))
       const testVisionFallback = {
         ...(globalConfig.visionFallback ?? {
           enabled: true,
@@ -2114,7 +2137,7 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
           timeout: 120,
           backend: 'ollama' as const,
         }),
-        ...testConfig,
+        ...filteredTestConfig,
         enabled: true,
       }
       const testGlobalConfig = { ...globalConfig, visionFallback: testVisionFallback }

--- a/src/server/llm/vision-fallback.test.ts
+++ b/src/server/llm/vision-fallback.test.ts
@@ -226,6 +226,70 @@ describe('vision-fallback', () => {
     })
   })
 
+  describe('HTTP auth headers', () => {
+    it('sends Authorization: Bearer header when apiKey is provided with openai backend', async () => {
+      const modelWithKey: VisionModelConfig = {
+        baseUrl: 'http://localhost:8000/v1',
+        model: 'gpt-4o-vision',
+        timeout: 120000,
+        backend: 'openai',
+        apiKey: 'sk-test-key-456',
+      }
+      const mockResponse = {
+        ok: true,
+        json: async () => ({ choices: [{ message: { content: 'desc' } }] }),
+      }
+      vi.mocked(fetch).mockResolvedValue(mockResponse as unknown as Response)
+
+      await describeImage('dGVzdA==', modelWithKey)
+
+      const headers = vi.mocked(fetch).mock.calls[0]?.[1]?.headers as Record<string, string>
+      expect(headers['Authorization']).toBe('Bearer sk-test-key-456')
+      expect(headers['Content-Type']).toBe('application/json')
+    })
+
+    it('does not send Authorization header when apiKey is not provided with openai backend', async () => {
+      const modelWithoutKey: VisionModelConfig = {
+        baseUrl: 'http://localhost:8000/v1',
+        model: 'gpt-4o-vision',
+        timeout: 120000,
+        backend: 'openai',
+      }
+      const mockResponse = {
+        ok: true,
+        json: async () => ({ choices: [{ message: { content: 'desc' } }] }),
+      }
+      vi.mocked(fetch).mockResolvedValue(mockResponse as unknown as Response)
+
+      await describeImage('dGVzdA==', modelWithoutKey)
+
+      const headers = vi.mocked(fetch).mock.calls[0]?.[1]?.headers as Record<string, string>
+      expect(headers['Authorization']).toBeUndefined()
+      expect(headers['Content-Type']).toBe('application/json')
+    })
+
+    it('does not send Authorization header for ollama backend even when apiKey is provided', async () => {
+      const ollamaModelWithKey: VisionModelConfig = {
+        baseUrl: 'http://localhost:11434',
+        model: 'llava',
+        timeout: 120000,
+        backend: 'ollama',
+        apiKey: 'should-not-be-used',
+      }
+      const mockResponse = {
+        ok: true,
+        json: async () => ({ message: { content: 'desc' } }),
+      }
+      vi.mocked(fetch).mockResolvedValue(mockResponse as unknown as Response)
+
+      await describeImage('dGVzdA==', ollamaModelWithKey)
+
+      const headers = vi.mocked(fetch).mock.calls[0]?.[1]?.headers as Record<string, string>
+      expect(headers['Authorization']).toBeUndefined()
+      expect(headers['Content-Type']).toBe('application/json')
+    })
+  })
+
   describe('describeImageFromDataUrl', () => {
     it('extracts base64 from data URL (ollama)', async () => {
       const mockResponse = {

--- a/src/server/llm/vision-fallback.ts
+++ b/src/server/llm/vision-fallback.ts
@@ -7,6 +7,7 @@ export interface VisionModelConfig {
   model: string
   timeout: number
   backend: VisionBackend
+  apiKey?: string
 }
 
 interface OllamaChatMessage {
@@ -125,11 +126,16 @@ export async function describeImage(
       ? AbortSignal.any([timeoutController.signal, options.signal])
       : timeoutController.signal
 
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    }
+    if (isOpenAI && visionModel.apiKey) {
+      headers['Authorization'] = `Bearer ${visionModel.apiKey}`
+    }
+
     const response = await fetch(url, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
+      headers,
       body: JSON.stringify(requestBody),
       signal,
     })

--- a/web/src/components/onboarding/OnboardingWizard.tsx
+++ b/web/src/components/onboarding/OnboardingWizard.tsx
@@ -11,7 +11,14 @@ import type { ProviderInfo } from './types'
 interface OnboardingData {
   providers: ProviderInfo[]
   workdir: string
-  visionFallback?: { enabled: boolean; url: string; model: string; timeout: number; backend: 'ollama' | 'openai' }
+  visionFallback?: {
+    enabled: boolean
+    url?: string
+    model?: string
+    timeout: number
+    backend?: 'ollama' | 'openai'
+    providerModelRef?: string
+  }
 }
 
 interface OnboardingWizardProps {
@@ -34,7 +41,14 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
   }
 
   async function handleVisionComplete(visionData: {
-    visionFallback?: { enabled: boolean; url: string; model: string; timeout: number; backend: 'ollama' | 'openai' }
+    visionFallback?: {
+      enabled: boolean
+      url?: string
+      model?: string
+      timeout: number
+      backend?: 'ollama' | 'openai'
+      providerModelRef?: string
+    }
   }) {
     setSaving(true)
 

--- a/web/src/components/onboarding/steps/VisionStep.tsx
+++ b/web/src/components/onboarding/steps/VisionStep.tsx
@@ -2,10 +2,24 @@ import { useState, useEffect } from 'react'
 import { authFetch } from '../../../lib/api'
 import { useCopyToClipboard } from '../../../hooks/useCopyToClipboard'
 import { CheckIcon, ClipboardIcon } from '../../shared/icons'
+import type { Provider } from '../../../stores/config'
+import {
+  useVisionModelOptions,
+  VisionModelConfigSection,
+  useBackendChangeHandler,
+  useProviderModelSelectHandler,
+} from '../../shared/VisionModelSelector'
 
 interface VisionStepProps {
   onNext: (data: {
-    visionFallback?: { enabled: boolean; url: string; model: string; timeout: number; backend: 'ollama' | 'openai' }
+    visionFallback?: {
+      enabled: boolean
+      url?: string
+      model?: string
+      timeout: number
+      backend?: 'ollama' | 'openai'
+      providerModelRef?: string
+    }
   }) => void
 }
 
@@ -14,6 +28,8 @@ export function VisionStep({ onNext }: VisionStepProps) {
   const [url, setUrl] = useState('http://localhost:11434')
   const [model, setModel] = useState('qwen3.5:0.8b')
   const [backend, setBackend] = useState<'ollama' | 'openai'>('ollama')
+  const [providers, setProviders] = useState<Provider[]>([])
+  const [selectedRef, setSelectedRef] = useState<string>('')
   const { copied, copy } = useCopyToClipboard()
 
   useEffect(() => {
@@ -22,15 +38,28 @@ export function VisionStep({ onNext }: VisionStepProps) {
       .then((data) => {
         if (data.visionFallback) {
           setEnabled(data.visionFallback.enabled)
-          setUrl(data.visionFallback.url)
-          setModel(data.visionFallback.model)
-          if (data.visionFallback.backend) {
-            setBackend(data.visionFallback.backend)
+          if (data.visionFallback.providerModelRef) {
+            setSelectedRef(data.visionFallback.providerModelRef)
+          } else {
+            setUrl(data.visionFallback.url ?? 'http://localhost:11434')
+            setModel(data.visionFallback.model ?? 'qwen3.5:0.8b')
+            if (data.visionFallback.backend) {
+              setBackend(data.visionFallback.backend)
+            }
           }
+        }
+        if (data.providers) {
+          setProviders(data.providers)
         }
       })
       .catch(() => {})
   }, [])
+
+  const visionModelOptions = useVisionModelOptions(providers)
+
+  const handleProviderModelSelect = useProviderModelSelectHandler(setSelectedRef, setUrl, setModel)
+
+  const handleBackendChange = useBackendChangeHandler(setBackend, setSelectedRef, setUrl, setModel)
 
   function handleFinish(skip: boolean) {
     if (skip) {
@@ -38,16 +67,30 @@ export function VisionStep({ onNext }: VisionStepProps) {
       return
     }
 
-    onNext({
-      visionFallback: {
-        enabled,
-        url,
-        model,
-        timeout: 120,
-        backend,
-      },
-    })
+    if (enabled && selectedRef) {
+      onNext({
+        visionFallback: {
+          enabled,
+          providerModelRef: selectedRef,
+          timeout: 120,
+        },
+      })
+    } else {
+      onNext({
+        visionFallback: {
+          enabled,
+          url,
+          model,
+          timeout: 120,
+          backend,
+          providerModelRef: '',
+        },
+      })
+    }
   }
+
+  const hasOptions = visionModelOptions.length > 0
+  const noVisionMsg = 'No vision-capable models found in your providers. You can manually enter a model below.'
 
   return (
     <div className="max-w-xl mx-auto">
@@ -93,43 +136,15 @@ export function VisionStep({ onNext }: VisionStepProps) {
           <span className="text-text-primary">Enable vision fallback for non-vision models</span>
         </label>
 
-        {enabled && (
-          <div className="space-y-4 pl-8">
-            <div>
-              <label className="block text-sm text-text-secondary mb-1">Backend type</label>
-              <select
-                value={backend}
-                onChange={(e) => setBackend(e.target.value as 'ollama' | 'openai')}
-                className="w-full px-4 py-2 bg-bg-secondary border border-border rounded-lg text-text-primary focus:outline-none focus:border-accent-primary"
-              >
-                <option value="ollama">Ollama</option>
-                <option value="openai">OpenAI-compatible (vLLM, sglang, llama.cpp)</option>
-              </select>
-            </div>
-
-            <div>
-              <label className="block text-sm text-text-secondary mb-1">Vision server URL</label>
-              <input
-                type="text"
-                value={url}
-                onChange={(e) => setUrl(e.target.value)}
-                placeholder={backend === 'ollama' ? 'http://localhost:11434' : 'http://localhost:8000/v1'}
-                className="w-full px-4 py-2 bg-bg-secondary border border-border rounded-lg text-text-primary placeholder-text-muted focus:outline-none focus:border-accent-primary"
-              />
-            </div>
-
-            <div>
-              <label className="block text-sm text-text-secondary mb-1">Vision model name</label>
-              <input
-                type="text"
-                value={model}
-                onChange={(e) => setModel(e.target.value)}
-                placeholder={backend === 'ollama' ? 'qwen3.5:0.8b' : 'qwen3.5-27b'}
-                className="w-full px-4 py-2 bg-bg-secondary border border-border rounded-lg text-text-primary placeholder-text-muted focus:outline-none focus:border-accent-primary"
-              />
-            </div>
-          </div>
-        )}
+        <VisionModelConfigSection
+          {...{ enabled, hasOptions, selectedRef, visionModelOptions }}
+          onProviderModelSelect={handleProviderModelSelect}
+          {...{ backend, url, model }}
+          onBackendChange={handleBackendChange}
+          onUrlChange={setUrl}
+          onModelChange={setModel}
+          noOptionsMessage={noVisionMsg}
+        />
 
         <div className="flex items-center justify-between pt-4">
           <button

--- a/web/src/components/shared/VisionModelSelector.tsx
+++ b/web/src/components/shared/VisionModelSelector.tsx
@@ -1,0 +1,206 @@
+import { type ReactNode, useMemo } from 'react'
+import type { Provider } from '../../stores/config'
+
+export interface VisionModelOption {
+  providerId: string
+  providerName: string
+  modelId: string
+  modelName: string
+}
+
+export function getModelDisplayName(modelId: string): string {
+  return modelId.split('/').pop()?.replace(/-/g, ' ') ?? modelId
+}
+
+export function useVisionModelOptions(providers: Provider[]): VisionModelOption[] {
+  return useMemo(() => {
+    const options: VisionModelOption[] = []
+    for (const provider of providers) {
+      for (const m of provider.models) {
+        if (m.supportsVision) {
+          options.push({
+            providerId: provider.id,
+            providerName: provider.name,
+            modelId: m.id,
+            modelName: m.name ?? getModelDisplayName(m.id),
+          })
+        }
+      }
+    }
+    return options
+  }, [providers])
+}
+
+export interface ProviderModelSelectProps {
+  value: string
+  options: VisionModelOption[]
+  onChange: (ref: string) => void
+  className?: string
+}
+
+export function ProviderModelSelect({ value, options, onChange, className }: ProviderModelSelectProps) {
+  return (
+    <select
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      className={
+        className ??
+        'w-full px-4 py-2 bg-bg-secondary border border-border rounded-lg text-text-primary focus:outline-none focus:border-accent-primary'
+      }
+    >
+      <option value="">Manual configuration...</option>
+      {options.map((opt) => (
+        <option key={`${opt.providerId}/${opt.modelId}`} value={`${opt.providerId}/${opt.modelId}`}>
+          {opt.providerName} • {opt.modelName}
+        </option>
+      ))}
+    </select>
+  )
+}
+
+export interface ManualVisionConfigProps {
+  backend: 'ollama' | 'openai'
+  url: string
+  model: string
+  onBackendChange: (backend: 'ollama' | 'openai') => void
+  onUrlChange: (url: string) => void
+  onModelChange: (model: string) => void
+}
+
+export function ManualVisionConfig({
+  backend,
+  url,
+  model,
+  onBackendChange,
+  onUrlChange,
+  onModelChange,
+}: ManualVisionConfigProps) {
+  return (
+    <div className="space-y-4">
+      <div>
+        <label className="block text-sm text-text-secondary mb-1">Backend type</label>
+        <select
+          value={backend}
+          onChange={(e) => onBackendChange(e.target.value as 'ollama' | 'openai')}
+          className="w-full px-4 py-2 bg-bg-secondary border border-border rounded-lg text-text-primary focus:outline-none focus:border-accent-primary"
+        >
+          <option value="ollama">Ollama</option>
+          <option value="openai">OpenAI-compatible (vLLM, sglang, llama.cpp)</option>
+        </select>
+      </div>
+
+      <div>
+        <label className="block text-sm text-text-secondary mb-1">Vision server URL</label>
+        <input
+          type="text"
+          value={url}
+          onChange={(e) => onUrlChange(e.target.value)}
+          placeholder={backend === 'ollama' ? 'http://localhost:11434' : 'http://localhost:8000/v1'}
+          className="w-full px-4 py-2 bg-bg-secondary border border-border rounded-lg text-text-primary placeholder-text-muted focus:outline-none focus:border-accent-primary"
+        />
+      </div>
+
+      <div>
+        <label className="block text-sm text-text-secondary mb-1">Vision model name</label>
+        <input
+          type="text"
+          value={model}
+          onChange={(e) => onModelChange(e.target.value)}
+          placeholder={backend === 'ollama' ? 'qwen3.5:0.8b' : 'qwen3.5-27b'}
+          className="w-full px-4 py-2 bg-bg-secondary border border-border rounded-lg text-text-primary placeholder-text-muted focus:outline-none focus:border-accent-primary"
+        />
+      </div>
+    </div>
+  )
+}
+
+export function useBackendChangeHandler(
+  setBackend: (b: 'ollama' | 'openai') => void,
+  setSelectedRef: (ref: string) => void,
+  setUrl: (url: string) => void,
+  setModel: (model: string) => void,
+): (newBackend: 'ollama' | 'openai') => void {
+  return (newBackend: 'ollama' | 'openai') => {
+    setBackend(newBackend)
+    setSelectedRef('')
+    if (newBackend === 'ollama') {
+      setUrl('http://localhost:11434')
+      setModel('qwen3.5:0.8b')
+    } else {
+      setUrl('http://localhost:8000/v1')
+      setModel('qwen3.5-27b')
+    }
+  }
+}
+
+export function useProviderModelSelectHandler(
+  setSelectedRef: (ref: string) => void,
+  setUrl: (url: string) => void,
+  setModel: (model: string) => void,
+): (ref: string) => void {
+  return (ref: string) => {
+    setSelectedRef(ref)
+    if (ref) {
+      setUrl('')
+      setModel('')
+    }
+  }
+}
+
+export interface VisionModelConfigSectionProps {
+  enabled: boolean
+  hasOptions: boolean
+  selectedRef: string
+  visionModelOptions: VisionModelOption[]
+  onProviderModelSelect: (ref: string) => void
+  backend: 'ollama' | 'openai'
+  url: string
+  model: string
+  onBackendChange: (backend: 'ollama' | 'openai') => void
+  onUrlChange: (url: string) => void
+  onModelChange: (model: string) => void
+  noOptionsMessage: string
+  children?: ReactNode
+}
+
+export function VisionModelConfigSection({
+  enabled,
+  hasOptions,
+  selectedRef,
+  visionModelOptions,
+  onProviderModelSelect,
+  backend,
+  url,
+  model,
+  onBackendChange,
+  onUrlChange,
+  onModelChange,
+  noOptionsMessage,
+  children,
+}: VisionModelConfigSectionProps) {
+  if (!enabled) return null
+
+  return (
+    <div className="space-y-4 pl-8">
+      {hasOptions ? (
+        <div>
+          <label className="block text-sm text-text-secondary mb-1">Vision model from your providers</label>
+          <ProviderModelSelect value={selectedRef} options={visionModelOptions} onChange={onProviderModelSelect} />
+        </div>
+      ) : (
+        <p className="text-sm text-text-muted italic">{noOptionsMessage}</p>
+      )}
+
+      <ManualVisionConfig
+        backend={backend}
+        url={url}
+        model={model}
+        onBackendChange={onBackendChange}
+        onUrlChange={onUrlChange}
+        onModelChange={onModelChange}
+      />
+
+      {children}
+    </div>
+  )
+}


### PR DESCRIPTION
### Summary

Actuellement, pour configurer le modèle de vision fallback, l'utilisateur doit saisir manuellement une URL, un nom de modèle et un backend — sans pouvoir référencer un provider déjà configuré, ni bénéficier de sa clé API.

Cette PR permet de sélectionner le modèle de vision fallback **parmi les modèles vision-capables** des providers déjà paramétrés par l'utilisateur. La configuration hérite automatiquement de l'URL, du backend et de la clé API du provider choisi.

### Résolution

- **`providerModelRef`** (`"providerId/modelId"`) : nouveau champ optionnel dans le schéma `visionFallback` de la config, qui référence un modèle existant
- **`resolveVisionFallback()`** : nouvelle fonction dans `config.ts` qui résout une référence `providerModelRef` vers un `VisionModelConfig` complet (URL, model, backend, apiKey), avec fallback sur les champs legacy (`url`/`model`/`backend`)
- **`VisionModelConfig.apiKey`** : ajout du support de clé API dans le client HTTP pour les backends OpenAI-compatibles
- **UI (onboarding)** : nouveau sélecteur dans `VisionStep` listant uniquement les modèles avec `supportsVision === true` — permet de choisir entre un provider configuré ou une saisie manuelle
- **API** : `PUT /api/config/vision-fallback` et `POST /api/config/vision-fallback/test`
- **Composants partagés** : `VisionModelSelector.tsx` avec hooks (`useVisionModelOptions`, `useBackendChangeHandler`, `useProviderModelSelectHandler`) et composants (`ProviderModelSelect`, `ManualVisionConfig`, `VisionModelConfigSection`)

### Notes de revue

- Rétrocompatibilité totale : les anciennes configs avec `url`/`model`/`backend` continuent de fonctionner sans `providerModelRef`
- Edge cases couverts : provider supprimé → fallback legacy / model introuvable → premier modèle vision du même provider / `providerModelRef` vide envoyé explicitement pour éviter les références périmées
- Pas d'impact cache (les modèles de vision fallback ne sont pas mis en cache dans le système de prompts)

### AI-Enhanced Development

- **AI Models:** DeepSeek v4 Flash

### Cache Impact

- **No**