### PR TITLE
Fix/agent menu doesn't show custom sub agent

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -40,6 +40,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v7

--- a/.gitignore
+++ b/.gitignore
@@ -44,10 +44,6 @@ e2e/.openfox/
 e2e-playwright/.openfox/
 e2e/.openfox-test/
 e2e/**/.openfox-test/
-.openfox/agents/
-
-# Scratch / user-local files
-coucou/
 
 # Logs
 *.log

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,10 @@ e2e/.openfox/
 e2e-playwright/.openfox/
 e2e/.openfox-test/
 e2e/**/.openfox-test/
+.openfox/agents/
+
+# Scratch / user-local files
+coucou/
 
 # Logs
 *.log

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -17,7 +17,7 @@ import { buildModelsUrl } from './llm/url-utils.js'
 
 import { createMockLLMClient } from './llm/mock.js'
 import { createProviderManager, parseDefaultModelSelection } from './provider-manager.js'
-import { createToolRegistry, setMcpTools } from './tools/index.js'
+import { createToolRegistry, setMcpTools, getBuiltInToolNames } from './tools/index.js'
 import { ALWAYS_ALLOWED, ALWAYS_ALLOWED_FOR_SUBAGENTS, TOP_LEVEL_ONLY_TOOLS } from './tools/tool-policy.js'
 import { McpManager, createMcpTools } from './mcp/index.js'
 import {
@@ -167,7 +167,7 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
     logger.error('LLM initialization failed', { error: err instanceof Error ? err.message : String(err) }),
   )
 
-  const toolRegistry = createToolRegistry()
+  let toolRegistry = createToolRegistry()
 
   // Initialize MCP manager and connect to configured servers
   const mcpManager = new McpManager({
@@ -202,6 +202,7 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
     const mcpTools = createMcpTools(mcpManager)
     if (mcpTools.length > 0) {
       setMcpTools(mcpTools)
+      toolRegistry = createToolRegistry()
       logger.info('MCP tools registered', { count: mcpTools.length })
     }
     const { signalMcpReady } = await import('./ws/server.js')
@@ -291,11 +292,14 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
 
   // Available tools with action metadata for granular permissions
   app.get('/api/tools', (_req, res) => {
+    const builtInNames = getBuiltInToolNames()
     const tools = toolRegistry.tools.map((t) => ({
       name: t.name,
       actions: t.permittedActions || [],
       alwaysAllowed: ALWAYS_ALLOWED.has(t.name) || ALWAYS_ALLOWED_FOR_SUBAGENTS.has(t.name),
       topLevelOnly: TOP_LEVEL_ONLY_TOOLS.has(t.name),
+      isMcp: !builtInNames.has(t.name),
+      mcpServer: t.mcpServer,
     }))
     res.json({ tools })
   })
@@ -2377,6 +2381,7 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
     const { setMcpTools } = await import('./tools/index.js')
     const mcpTools = createMcpTools(mcpManager)
     setMcpTools(mcpTools)
+    toolRegistry = createToolRegistry()
   }
 
   app.get('/api/mcp/servers', (_req, res) => {

--- a/src/server/mcp/tool-adapter.ts
+++ b/src/server/mcp/tool-adapter.ts
@@ -24,6 +24,7 @@ export function createMcpTools(mcpManager: McpManager): Tool[] {
       tools.push({
         name: prefixedName,
         definition,
+        mcpServer: server.name,
         execute: async (args: Record<string, unknown>, _context: ToolContext): Promise<ToolResult> => {
           const start = Date.now()
           const result = await mcpManager.callTool(server.name, mcpTool.name, args)

--- a/src/server/tools/index.ts
+++ b/src/server/tools/index.ts
@@ -61,7 +61,7 @@ function getBuiltInTools(): Tool[] {
   return _builtInTools
 }
 
-function getBuiltInToolNames(): Set<string> {
+export function getBuiltInToolNames(): Set<string> {
   if (BUILT_IN_TOOL_NAMES_CACHE.size === 0) {
     for (const t of getBuiltInTools()) {
       BUILT_IN_TOOL_NAMES_CACHE.add(t.name)

--- a/src/server/tools/pdf-utils.ts
+++ b/src/server/tools/pdf-utils.ts
@@ -1,5 +1,6 @@
 import { OUTPUT_LIMITS } from './types.js'
-import { getDocument, OPS } from 'pdfjs-dist/legacy/build/pdf.mjs'
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const { getDocument, OPS } = (await import('pdfjs-dist/legacy/build/pdf.mjs')) as any
 import { PNG } from 'pngjs'
 
 const PDF_HEADER = Buffer.from('%PDF')
@@ -184,7 +185,8 @@ export function encodeImageToDataUrl(imgData: RawImageData, maxDimension = 1024)
 }
 
 async function extractPageBlocks(
-  page: Awaited<ReturnType<Awaited<ReturnType<typeof getDocument>['promise']>['getPage']>>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  page: any,
   pageIndex: number,
   pageCount: number,
   imageCounter: { count: number; limitReached: boolean },
@@ -193,11 +195,13 @@ async function extractPageBlocks(
   const [textContent, opList] = await Promise.all([page.getTextContent(), page.getOperatorList()])
 
   const textItems = textContent.items.filter(
-    (item): item is Extract<(typeof textContent.items)[number], { str: string }> => 'str' in item,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (item: any): item is { str: string } => 'str' in item,
   )
 
   const textStr = textItems
-    .map((t) => t.str)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .map((t: any) => t.str)
     .join(' ')
     .trim()
 

--- a/src/server/tools/types.ts
+++ b/src/server/tools/types.ts
@@ -29,7 +29,8 @@ export interface Tool {
   name: string
   definition: LLMToolDefinition
   execute: (args: Record<string, unknown>, context: ToolContext) => Promise<ToolResult>
-  permittedActions?: string[] // Actions this tool supports for granular permissions
+  permittedActions?: string[]
+  mcpServer?: string
 }
 
 export interface ToolRegistry {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -168,6 +168,7 @@ function App() {
             SETTINGS_KEYS.DISPLAY_USER_PRESETS,
             SETTINGS_KEYS.DISPLAY_CUSTOM_CSS,
             SETTINGS_KEYS.KEYBINDINGS,
+            SETTINGS_KEYS.FEATURES_PER_SESSION_MCP,
           ])
         // Eagerly load MCP servers for the chat MCP indicator
         useMcpStore.getState().fetchServers()

--- a/web/src/components/plan/AgentSelector.tsx
+++ b/web/src/components/plan/AgentSelector.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useMemo } from 'react'
+import { useState, useRef, useEffect } from 'react'
 import { useSessionStore } from '../../stores/session'
 import { ChevronDownIcon, CheckIcon } from '../shared/icons'
 import { useAgentsStore, getAgentColor } from '../../stores/agents'
@@ -11,8 +11,9 @@ export function AgentSelector() {
   const switchMode = useSessionStore((state) => state.switchMode)
   const defaults = useAgentsStore((state) => state.defaults)
   const userItems = useAgentsStore((state) => state.userItems)
+  const projectItems = useAgentsStore((state) => state.projectItems)
   const fetchAgents = useAgentsStore((state) => state.fetchAgents)
-  const agents = useMemo(() => [...defaults, ...userItems], [defaults, userItems])
+  const agents = [...defaults, ...userItems, ...projectItems]
   const [isOpen, setIsOpen] = useState(false)
   const [showManager, setShowManager] = useState(false)
   const [editId, setEditId] = useState<string | null>(null)

--- a/web/src/components/settings/AgentsModal.tsx
+++ b/web/src/components/settings/AgentsModal.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { Modal } from '../shared/SelfContainedModal'
 import { useAgentsStore, type AgentFull } from '../../stores/agents'
+import { useConfigStore } from '../../stores/config'
 import { authFetch } from '../../lib/api'
 import { CRUDListHeader, useConfirmDialog, DestinationSelector } from './CRUDModal'
 import { AgentGroup } from './agents/AgentListItem'
@@ -31,6 +32,7 @@ export function AgentsModal({ isOpen, onClose, initialEditId }: AgentsModalProps
   const createAgent = useAgentsStore((state) => state.createAgent)
   const updateAgent = useAgentsStore((state) => state.updateAgent)
   const deleteAgentAction = useAgentsStore((state) => state.deleteAgent)
+  const providers = useConfigStore((state) => state.providers)
 
   const [view, setView] = useState<'list' | 'edit'>('list')
   const [editingId, setEditingId] = useState<string | null>(null)
@@ -43,6 +45,7 @@ export function AgentsModal({ isOpen, onClose, initialEditId }: AgentsModalProps
   const [formTools, setFormTools] = useState<string[]>([])
   const [formColor, setFormColor] = useState('#6b7280')
   const [formPrompt, setFormPrompt] = useState('')
+  const [formModel, setFormModel] = useState<string | undefined>(undefined)
   const [formDestination, setFormDestination] = useState<'project' | 'user'>('user')
   const [formError, setFormError] = useState('')
   const [saving, setSaving] = useState(false)
@@ -262,6 +265,9 @@ export function AgentsModal({ isOpen, onClose, initialEditId }: AgentsModalProps
           saving={saving}
           isReadOnly={isReadOnly}
           availableTools={availableTools}
+          formModel={formModel}
+          providers={providers}
+          onModelChange={setFormModel}
           onNameChange={handleNameChange}
           onIdChange={setFormId}
           onDescriptionChange={setFormDescription}

--- a/web/src/components/settings/AgentsModal.tsx
+++ b/web/src/components/settings/AgentsModal.tsx
@@ -1,12 +1,10 @@
 import { useEffect, useState } from 'react'
 import { Modal } from '../shared/SelfContainedModal'
 import { useAgentsStore, type AgentFull } from '../../stores/agents'
-import { useConfigStore } from '../../stores/config'
 import { authFetch } from '../../lib/api'
 import { CRUDListHeader, useConfirmDialog, DestinationSelector } from './CRUDModal'
 import { AgentGroup } from './agents/AgentListItem'
 import { AgentForm } from './agents/AgentForm'
-import { ModelPicker } from '../shared/ModelPicker'
 
 interface AgentsModalProps {
   isOpen: boolean
@@ -44,14 +42,10 @@ export function AgentsModal({ isOpen, onClose, initialEditId }: AgentsModalProps
   const [formSubagent, setFormSubagent] = useState(true)
   const [formTools, setFormTools] = useState<string[]>([])
   const [formColor, setFormColor] = useState('#6b7280')
-  const [formModel, setFormModel] = useState<string | undefined>(undefined)
   const [formPrompt, setFormPrompt] = useState('')
   const [formDestination, setFormDestination] = useState<'project' | 'user'>('user')
   const [formError, setFormError] = useState('')
   const [saving, setSaving] = useState(false)
-  const [loadingModel, setLoadingModel] = useState(false)
-
-  const [modelModalAgentId, setModelModalAgentId] = useState<string | null>(null)
 
   const [availableTools, setAvailableTools] = useState<{ name: string; actions: string[]; topLevelOnly?: boolean }[]>(
     [],
@@ -68,19 +62,6 @@ export function AgentsModal({ isOpen, onClose, initialEditId }: AgentsModalProps
     setFormColor(agent.metadata.color ?? '#6b7280')
     setFormPrompt(agent.prompt)
     setFormError('')
-    setLoadingModel(true)
-    // Fetch model override
-    authFetch(`/api/agents/${agent.metadata.id}/model`)
-      .then((r) => r.json())
-      .then((data) => {
-        if (data.providerId && data.model) {
-          setFormModel(`${data.providerId}/${data.model}`)
-        } else {
-          setFormModel(undefined)
-        }
-      })
-      .catch(() => setFormModel(undefined))
-      .finally(() => setLoadingModel(false))
   }
 
   const applyDuplicateFromContent = (content: AgentFull, id: string, setAsNew: boolean) => {
@@ -112,7 +93,7 @@ export function AgentsModal({ isOpen, onClose, initialEditId }: AgentsModalProps
       authFetch('/api/tools')
         .then((r) => r.json())
         .then((d) => {
-          const tools: { name: string; actions: string[]; alwaysAllowed?: boolean; topLevelOnly?: boolean }[] =
+          const tools: { name: string; actions: string[]; alwaysAllowed?: boolean; topLevelOnly?: boolean; isMcp?: boolean; mcpServer?: string }[] =
             d.tools || []
           setAlwaysAllowedNames(new Set(tools.filter((t) => t.alwaysAllowed).map((t) => t.name)))
           setAvailableTools(tools.filter((t) => !t.alwaysAllowed))
@@ -192,10 +173,6 @@ export function AgentsModal({ isOpen, onClose, initialEditId }: AgentsModalProps
     setView('edit')
   }
 
-  const handleEditBuiltInModel = (agentId: string) => {
-    setModelModalAgentId(agentId)
-  }
-
   const handleDelete = async (agentId: string) => {
     await deleteAgentAction(agentId)
   }
@@ -224,16 +201,12 @@ export function AgentsModal({ isOpen, onClose, initialEditId }: AgentsModalProps
 
     const result = editingId ? await updateAgent(editingId, agent) : await createAgent(agent, formDestination)
 
+    setSaving(false)
+
     if (!result.success) {
-      setSaving(false)
       setFormError(result.error ?? 'Failed to save agent.')
       return
     }
-
-    // Save model override separately
-    await saveAgentModelOverride(editingId ?? formId, formModel)
-
-    setSaving(false)
 
     if (initialEditId) onClose()
     else setView('list')
@@ -255,7 +228,6 @@ export function AgentsModal({ isOpen, onClose, initialEditId }: AgentsModalProps
     }
   }
 
-  const modelOverrides = useAgentsStore((state) => state.modelOverrides)
   const defaultSubAgents = defaults.filter((a) => a.subagent)
   const defaultTopLevelAgents = defaults.filter((a) => !a.subagent)
   const userSubAgents = userItems.filter((a) => a.subagent)
@@ -265,222 +237,106 @@ export function AgentsModal({ isOpen, onClose, initialEditId }: AgentsModalProps
 
   if (view === 'edit') {
     return (
-      <>
-        <Modal
-          isOpen={isOpen}
-          onClose={handleCancel}
-          title={isReadOnly ? `${formName}` : editingId ? 'Edit Agent' : 'New Agent'}
-          size="xl"
-        >
-          {!editingId && !isReadOnly && <DestinationSelector value={formDestination} onChange={setFormDestination} />}
-          <AgentForm
-            formName={formName}
-            formId={formId}
-            formDescription={formDescription}
-            formSubagent={formSubagent}
-            formTools={formTools}
-            formColor={formColor}
-            formModel={formModel}
-            formPrompt={formPrompt}
-            formError={formError}
-            saving={saving}
-            loadingModel={loadingModel}
-            isReadOnly={isReadOnly}
-            availableTools={availableTools}
-            providers={useConfigStore.getState().providers}
-            onNameChange={handleNameChange}
-            onIdChange={setFormId}
-            onDescriptionChange={setFormDescription}
-            onSubagentChange={(subagent) => {
-              setFormSubagent(subagent)
-              if (subagent) {
-                setFormTools((prev) => prev.filter((t) => !availableTools.find((at) => at.name === t)?.topLevelOnly))
-              }
-            }}
-            onToolsChange={setFormTools}
-            onColorChange={setFormColor}
-            onModelChange={setFormModel}
-            onPromptChange={setFormPrompt}
-            onSave={handleSave}
-            onCancel={handleCancel}
-            onDuplicate={() => {
-              setFormName(formName + ' (copy)')
-              setFormId(`${editingId}-copy-${Date.now()}`)
-              setEditingId(null)
-              setIsReadOnly(false)
-            }}
-          />
-        </Modal>
-        <BuiltInModelModal
-          agentId={modelModalAgentId}
-          onClose={() => setModelModalAgentId(null)}
-          onSaved={() => fetchAgents()}
+      <Modal
+        isOpen={isOpen}
+        onClose={handleCancel}
+        title={isReadOnly ? `${formName}` : editingId ? 'Edit Agent' : 'New Agent'}
+        size="xl"
+      >
+        {!editingId && !isReadOnly && <DestinationSelector value={formDestination} onChange={setFormDestination} />}
+        <AgentForm
+          formName={formName}
+          formId={formId}
+          formDescription={formDescription}
+          formSubagent={formSubagent}
+          formTools={formTools}
+          formColor={formColor}
+          formPrompt={formPrompt}
+          formError={formError}
+          saving={saving}
+          isReadOnly={isReadOnly}
+          availableTools={availableTools}
+          onNameChange={handleNameChange}
+          onIdChange={setFormId}
+          onDescriptionChange={setFormDescription}
+          onSubagentChange={(subagent) => {
+            setFormSubagent(subagent)
+            if (subagent) {
+              setFormTools((prev) => prev.filter((t) => !availableTools.find((at) => at.name === t)?.topLevelOnly))
+            }
+          }}
+          onToolsChange={setFormTools}
+          onColorChange={setFormColor}
+          onPromptChange={setFormPrompt}
+          onSave={handleSave}
+          onCancel={handleCancel}
+          onDuplicate={() => {
+            setFormName(formName + ' (copy)')
+            setFormId(`${editingId}-copy-${Date.now()}`)
+            setEditingId(null)
+            setIsReadOnly(false)
+          }}
         />
-      </>
+      </Modal>
     )
   }
 
   return (
-    <>
-      <Modal isOpen={isOpen} onClose={onClose} title="Agents" size="lg">
-        <CRUDListHeader
-          description="Agents define behavior, tools, and prompts for top-level modes and sub-agents."
-          onNew={handleNew}
-          loading={loading}
-          hasItems={defaults.length > 0 || userItems.length > 0 || projectItems.length > 0}
-        >
-          <div className="space-y-4">
-            {defaults.length > 0 && (
-              <AgentGroup
-                title="Built-in"
-                agents={defaultTopLevelAgents}
-                subagents={defaultSubAgents}
-                isBuiltIn={true}
-                alwaysAllowedNames={alwaysAllowedNames}
-                modelOverrides={modelOverrides}
-                onView={handleView}
-                onEdit={handleEditBuiltInModel}
-                onDuplicate={handleDuplicate}
-              />
-            )}
+    <Modal isOpen={isOpen} onClose={onClose} title="Agents" size="lg">
+      <CRUDListHeader
+        description="Agents define behavior, tools, and prompts for top-level modes and sub-agents."
+        onNew={handleNew}
+        loading={loading}
+        hasItems={defaults.length > 0 || userItems.length > 0 || projectItems.length > 0}
+      >
+        <div className="space-y-4">
+          {defaults.length > 0 && (
+            <AgentGroup
+              title="Built-in"
+              agents={defaultTopLevelAgents}
+              subagents={defaultSubAgents}
+              isBuiltIn={true}
+              alwaysAllowedNames={alwaysAllowedNames}
+              onView={handleView}
+              onDuplicate={handleDuplicate}
+            />
+          )}
 
-            {[
-              { title: 'Custom', agents: userTopLevelAgents, subagents: userSubAgents },
-              { title: 'Project', agents: projectTopLevelAgents, subagents: projectSubAgents },
-            ].map(
-              (section) =>
-                section.agents.length > 0 && (
-                  <AgentGroup
-                    key={section.title}
-                    title={section.title}
-                    agents={section.agents}
-                    subagents={section.subagents}
-                    isBuiltIn={false}
-                    alwaysAllowedNames={alwaysAllowedNames}
-                    modelOverrides={modelOverrides}
-                    isConfirmingDelete={(id) => isConfirming(id, 'delete')}
-                    onView={handleView}
-                    onDuplicate={handleDuplicate}
-                    onEdit={handleEdit}
-                    onDelete={(id) => {
-                      if (isConfirming(id, 'delete')) {
-                        handleDelete(id)
-                        clearConfirm()
-                      } else {
-                        requestDelete(id)
-                      }
-                    }}
-                    onCancelDelete={clearConfirm}
-                  />
-                ),
-            )}
-          </div>
-        </CRUDListHeader>
-      </Modal>
-      <BuiltInModelModal
-        agentId={modelModalAgentId}
-        onClose={() => setModelModalAgentId(null)}
-        onSaved={() => fetchAgents()}
-      />
-    </>
-  )
-}
-
-function parseModelOverride(value: string): { providerId: string; model: string } {
-  const slashIndex = value.indexOf('/')
-  return slashIndex > 0
-    ? { providerId: value.substring(0, slashIndex), model: value.substring(slashIndex + 1) }
-    : { providerId: value, model: value }
-}
-
-async function saveAgentModelOverride(agentId: string, modelOverride: string | undefined): Promise<void> {
-  if (modelOverride) {
-    const { providerId, model } = parseModelOverride(modelOverride)
-    await authFetch(`/api/agents/${agentId}/model`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ providerId, model }),
-    })
-  } else {
-    await authFetch(`/api/agents/${agentId}/model`, { method: 'DELETE' })
-  }
-}
-
-// Model-only modal for built-in agents — rendered outside the main component tree
-function BuiltInModelModal({
-  agentId,
-  onClose,
-  onSaved,
-}: {
-  agentId: string | null
-  onClose: () => void
-  onSaved: () => void
-}) {
-  const [value, setValue] = useState<string | undefined>(undefined)
-  const [loading, setLoading] = useState(false)
-  const [saving, setSaving] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-  const defaults = useAgentsStore((s) => s.defaults)
-  const userItems = useAgentsStore((s) => s.userItems)
-  const projectItems = useAgentsStore((s) => s.projectItems)
-  const agents = [...defaults, ...userItems, ...projectItems]
-  const agent = agentId ? agents.find((a) => a.id === agentId) : undefined
-  const providers = useConfigStore((s) => s.providers)
-
-  useEffect(() => {
-    if (!agentId) return
-    setLoading(true)
-    authFetch(`/api/agents/${agentId}/model`)
-      .then((r) => r.json())
-      .then((data) => {
-        setValue(data.providerId && data.model ? `${data.providerId}/${data.model}` : undefined)
-      })
-      .catch(() => setValue(undefined))
-      .finally(() => setLoading(false))
-  }, [agentId])
-
-  const handleSave = async () => {
-    if (!agentId) return
-    setSaving(true)
-    setError(null)
-    try {
-      await saveAgentModelOverride(agentId, value)
-      onSaved()
-      onClose()
-    } catch {
-      setError('Failed to save. Please try again.')
-    }
-    setSaving(false)
-  }
-
-  return (
-    <Modal isOpen={!!agentId} onClose={onClose} title={`Model — ${agent?.name ?? agentId ?? ''}`} size="md">
-      <div className="space-y-4 p-2">
-        <p className="text-xs text-text-muted">
-          Choose which model to use when this agent is active. This overrides the session/global model.
-        </p>
-        {loading ? (
-          <div className="text-sm text-text-muted py-2">Loading...</div>
-        ) : (
-          <ModelPicker providers={providers} value={value} onChange={setValue} defaultLabel="Default (global model)" />
-        )}
-        {error && <p className="text-xs text-red-500">{error}</p>}
-        <div className="flex justify-end gap-2 pt-2">
-          <button
-            onClick={onClose}
-            className="px-4 py-1.5 text-sm text-text-muted hover:text-text-secondary transition-colors"
-          >
-            Cancel
-          </button>
-          <button
-            onClick={handleSave}
-            disabled={saving}
-            className="px-4 py-1.5 rounded bg-accent-primary/20 text-sm text-accent-primary font-medium hover:bg-accent-primary/30 disabled:opacity-50 transition-colors"
-          >
-            {saving ? 'Saving...' : 'Save'}
-          </button>
+          {[
+            {
+              title: 'Custom',
+              agents: userTopLevelAgents,
+              subagents: userSubAgents,
+            },
+            { title: 'Project', agents: projectTopLevelAgents, subagents: projectSubAgents },
+          ].map(
+            (section) =>
+              (section.agents.length > 0 || section.subagents.length > 0) && (
+                <AgentGroup
+                  key={section.title}
+                  title={section.title}
+                  agents={section.agents}
+                  subagents={section.subagents}
+                  isBuiltIn={false}
+                  alwaysAllowedNames={alwaysAllowedNames}
+                  isConfirmingDelete={(id) => isConfirming(id, 'delete')}
+                  onView={handleView}
+                  onDuplicate={handleDuplicate}
+                  onEdit={handleEdit}
+                  onDelete={(id) => {
+                    if (isConfirming(id, 'delete')) {
+                      handleDelete(id)
+                      clearConfirm()
+                    } else {
+                      requestDelete(id)
+                    }
+                  }}
+                  onCancelDelete={clearConfirm}
+                />
+              ),
+          )}
         </div>
-      </div>
+      </CRUDListHeader>
     </Modal>
   )
 }

--- a/web/src/components/settings/AgentsModal.tsx
+++ b/web/src/components/settings/AgentsModal.tsx
@@ -93,8 +93,14 @@ export function AgentsModal({ isOpen, onClose, initialEditId }: AgentsModalProps
       authFetch('/api/tools')
         .then((r) => r.json())
         .then((d) => {
-          const tools: { name: string; actions: string[]; alwaysAllowed?: boolean; topLevelOnly?: boolean; isMcp?: boolean; mcpServer?: string }[] =
-            d.tools || []
+          const tools: {
+            name: string
+            actions: string[]
+            alwaysAllowed?: boolean
+            topLevelOnly?: boolean
+            isMcp?: boolean
+            mcpServer?: string
+          }[] = d.tools || []
           setAlwaysAllowedNames(new Set(tools.filter((t) => t.alwaysAllowed).map((t) => t.name)))
           setAvailableTools(tools.filter((t) => !t.alwaysAllowed))
         })

--- a/web/src/components/settings/agents/AgentForm.tsx
+++ b/web/src/components/settings/agents/AgentForm.tsx
@@ -1,6 +1,8 @@
+import { useState } from 'react'
 import { FormField, ModalActions, ErrorBanner } from '../CRUDModal'
 import { DropdownMenu } from '../../shared/DropdownMenu'
 import { ModelPicker } from '../../shared/ModelPicker'
+import { Toggle } from '../../shared/Toggle'
 import { parseAllowedTools, serializeTools } from './tools'
 import type { Provider } from '../../../stores/config'
 
@@ -17,7 +19,7 @@ interface AgentFormProps {
   saving: boolean
   loadingModel?: boolean
   isReadOnly: boolean
-  availableTools: { name: string; actions: string[]; topLevelOnly?: boolean }[]
+  availableTools: { name: string; actions: string[]; topLevelOnly?: boolean; isMcp?: boolean; mcpServer?: string }[]
   providers: Provider[]
   onNameChange: (name: string) => void
   onIdChange: (id: string) => void
@@ -60,7 +62,27 @@ export function AgentForm({
   onDuplicate,
 }: AgentFormProps) {
   const granularTools = parseAllowedTools(formTools)
-  const filteredTools = availableTools.filter((t) => !(formSubagent && t.topLevelOnly))
+  const filteredTools = availableTools.filter((t) => !(formSubagent && t.topLevelOnly) && !t.isMcp)
+  const mcpTools = availableTools.filter((t) => t.isMcp && !(formSubagent && t.topLevelOnly))
+
+  const mcpGroups: Map<string, typeof mcpTools> = new Map()
+  for (const tool of mcpTools) {
+    const server = tool.mcpServer ?? tool.name
+    const group = mcpGroups.get(server) ?? []
+    group.push(tool)
+    mcpGroups.set(server, group)
+  }
+
+  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set())
+
+  const toggleGroup = (server: string) => {
+    setExpandedGroups((prev) => {
+      const next = new Set(prev)
+      if (next.has(server)) next.delete(server)
+      else next.add(server)
+      return next
+    })
+  }
 
   const toggleToolAction = (toolName: string, action: string) => {
     const newGranular = new Map(granularTools)
@@ -215,17 +237,13 @@ export function AgentForm({
                   trigger={
                     <button
                       className={`px-1.5 py-0.5 rounded text-xs font-mono transition-colors flex items-center gap-1 ${
-                        isSelected ? 'bg-accent-primary/25 text-accent-primary' : 'bg-bg-primary text-text-muted'
-                      }`}
+                        isSelected
+                          ? 'bg-accent-primary/25 text-accent-primary'
+                          : 'bg-bg-primary text-text-muted hover:text-text-secondary'
+                      } cursor-pointer`}
                     >
                       <span>{tool.name}</span>
-                      {hasActions && (
-                        <span
-                          className={`text-[10px] ${isSelected && selectedActions.size > 0 ? 'text-accent-primary' : 'text-text-muted'}`}
-                        >
-                          *
-                        </span>
-                      )}
+                      {selectedActions.size > 0 && <span className="text-[10px]">*</span>}
                     </button>
                   }
                   minWidth="160px"
@@ -265,6 +283,64 @@ export function AgentForm({
             })}
           </div>
         </div>
+
+        {mcpGroups.size > 0 && (
+          <div>
+            <label className="block text-xs text-text-secondary mb-1">
+              MCP Tools <span className="text-text-muted font-normal">— from connected MCP servers</span>
+            </label>
+            <div className="bg-bg-tertiary border border-border rounded overflow-hidden">
+              {Array.from(mcpGroups.entries()).map(([server, tools]) => {
+                const isExpanded = expandedGroups.has(server)
+                const selectedCount = tools.filter((t) => granularTools.has(t.name)).length
+                return (
+                  <div key={server} className="border-b border-border last:border-b-0">
+                    <button
+                      onClick={() => toggleGroup(server)}
+                      className="w-full flex items-center justify-between px-3 py-2 hover:bg-bg-primary/50 transition-colors"
+                    >
+                      <div className="flex items-center gap-2">
+                        <span className="text-xs font-mono text-text-primary">{server}</span>
+                        <span className="text-xs text-text-muted">
+                          ({selectedCount}/{tools.length})
+                        </span>
+                      </div>
+                      <span className="text-xs text-text-muted">{isExpanded ? '▲' : '▼'}</span>
+                    </button>
+                    {isExpanded && (
+                      <div className="border-t border-border px-2 py-1 space-y-0.5">
+                        {tools.map((tool) => {
+                          const isSelected = granularTools.has(tool.name)
+                          const shortName = tool.mcpServer
+                            ? tool.name.slice(tool.mcpServer.length + 1) || tool.name
+                            : tool.name
+                          return (
+                            <div
+                              key={tool.name}
+                              className="flex items-center justify-between py-1 px-1 rounded hover:bg-bg-primary/50 transition-colors"
+                            >
+                              <span
+                                className={`text-xs font-mono ${isSelected ? 'text-text-primary' : 'text-text-muted'}`}
+                              >
+                                {shortName}
+                              </span>
+                              <Toggle
+                                enabled={isSelected}
+                                onClick={() => !isReadOnly && toggleTool(tool.name)}
+                                disabled={isReadOnly}
+                                label={tool.name}
+                              />
+                            </div>
+                          )
+                        })}
+                      </div>
+                    )}
+                  </div>
+                )
+              })}
+            </div>
+          </div>
+        )}
       </div>
 
       <div className="flex-1 min-h-[150px] border-t border-border pt-3 flex flex-col">

--- a/web/src/components/settings/agents/AgentListItem.tsx
+++ b/web/src/components/settings/agents/AgentListItem.tsx
@@ -69,6 +69,8 @@ export function AgentListItem({
 
 export function AgentGroup({
   title,
+  agentTitle = 'Agents',
+  subagentTitle = 'Sub-agents',
   agents,
   subagents,
   isBuiltIn,
@@ -82,6 +84,8 @@ export function AgentGroup({
   isConfirmingDelete,
 }: {
   title: string
+  agentTitle?: string
+  subagentTitle?: string
   agents: AgentInfo[]
   subagents: AgentInfo[]
   isBuiltIn: boolean
@@ -113,11 +117,14 @@ export function AgentGroup({
   return (
     <div>
       <h3 className="text-xs font-medium text-text-secondary mb-2 uppercase tracking-wide">{title}</h3>
+      {agents.length > 0 && (
+        <div className="text-xs text-text-muted uppercase tracking-wider mb-1.5">{agentTitle}</div>
+      )}
       <div className="space-y-2">
         {agents.map(renderAgentItem)}
         {subagents.length > 0 && (
           <div className="mt-3">
-            <div className="text-xs text-text-muted uppercase tracking-wider mb-1.5">Sub-agents</div>
+            <div className="text-xs text-text-muted uppercase tracking-wider mb-1.5">{subagentTitle}</div>
             <div className="space-y-2">{subagents.map(renderAgentItem)}</div>
           </div>
         )}


### PR DESCRIPTION
### Summary

- Fixed a bug where sub-agents weren't displayed if you hadn't created at least one custom agent
- Fix button mcp per session stats not save
- add timeout for the test run in the CI
- fix missing project Agent in the AgentSelector
- Add an option to add mcp tool to agent and subagent

### AI-Enhanced Development

Tell what models helped shape this PR:

- **AI Models:** DeepSeek V4 Flash

### Cache Impact

Does this PR affect anything cached — system prompts, tool definitions, skills, or other context?

- **No**
