### PR TITLE
Fix systemd service target

### DIFF
--- a/src/cli/service.ts
+++ b/src/cli/service.ts
@@ -115,8 +115,7 @@ async function createSystemdService(): Promise<void> {
   const servicePath = expandPath(SERVICE_PATH)
   const serviceContent = `[Unit]
 Description=OpenFox Agentic Coding Assistant
-After=graphical-session.target
-Wants=graphical-session.target
+After=default.target
 
 [Service]
 Type=simple
@@ -127,7 +126,7 @@ KillMode=control-group
 Environment=OPENFOX_SERVICE=true
 
 [Install]
-WantedBy=graphical-session.target
+WantedBy=default.target
 `
   await writeFile(servicePath, serviceContent, 'utf-8')
   console.log(`Created: ${servicePath}`)

--- a/src/cli/service.ts
+++ b/src/cli/service.ts
@@ -54,34 +54,6 @@ async function createWrapperScript(): Promise<void> {
 source ~/.profile 2>/dev/null || true
 source ~/.bashrc 2>/dev/null || true
 
-if [ -z "$DISPLAY" ] || [ -z "$WAYLAND_DISPLAY" ]; then
-  for _ in 0 1 2 3 4; do
-    if [ -z "$DISPLAY" ]; then
-      xdisplay=$(
-        ps aux --no-headers 2>/dev/null \\
-          | grep -v grep \\
-          | grep "Xwayland" \\
-          | awk '{ for (i = 1; i <= NF; i++) if ($i ~ /^:[0-9]+$/) print $i }'
-      )
-      if [ -n "$xdisplay" ]; then
-        export DISPLAY="$xdisplay"
-        for f in "$HOME/.Xauthority" "\${XDG_RUNTIME_DIR}"/xauth_*; do
-          [ -f "$f" ] && export XAUTHORITY="$f" && break
-        done 2>/dev/null
-      fi
-    fi
-
-    if [ -z "$WAYLAND_DISPLAY" ]; then
-      socket="\${XDG_RUNTIME_DIR}/wayland-0"
-      [ -e "$socket" ] || socket="\${XDG_RUNTIME_DIR}/wayland-1"
-      [ -e "$socket" ] && export WAYLAND_DISPLAY="\${socket##*/}"
-    fi
-
-    [ -n "$DISPLAY" ] && [ -n "$WAYLAND_DISPLAY" ] && break
-    sleep 2
-  done
-fi
-
 # Find openfox - respect user's PATH, fallback to nvm search for non-interactive cases
 if ! openfox_bin=$(which openfox 2>/dev/null); then
   openfox_bindir=""


### PR DESCRIPTION
### Summary

The actual service does not starts on headless system because of its dependancy with graphical interface.
Change `graphical-session.target` to `default.target`.
`graphical-session.target` never hit on headless / console only systems.

While openfox as service is a pure cli application I removed the X11/XWayland pulling in generated start.sh script.

I split changes in two commits :
- **first** : only change target. **Compulsary for starting on headless.**
- **second** : **Optional.** Cleanup of start.sh, remove useless code with new service settings.
  Should have no impacts unless I missed some details.

---

- Unit test pass, no need to change test.
- Manual test tests are OK on headless system, no impact on system with X11/Wayland PC.

**Full details in commit messages.**

### AI-Enhanced Development

Helps to quickly find service management code and makes implémentations faster.

- **AI Models:** Qwen-35B-A3B

### Cache Impact

- **No**
