### PR TITLE
feat(terminal): make terminal font configurable

### DIFF
--- a/src/server/db/settings.ts
+++ b/src/server/db/settings.ts
@@ -19,6 +19,7 @@ export const SETTINGS_KEYS = {
   DISPLAY_SHOW_CHANGELOG_ON_UPDATE: 'display.showChangelogOnUpdate',
   DISPLAY_MAX_VISIBLE_ITEMS: 'display.maxVisibleItems',
   DISPLAY_CUSTOM_CSS: 'display.customCss',
+  DISPLAY_TERMINAL_FONT: 'display.terminalFont',
   LLM_DYNAMIC_SYSTEM_PROMPT: 'llm.dynamicSystemPrompt',
   CACHE_WARMING: 'cache.warming',
   KEYBINDINGS: 'keybindings',
@@ -50,6 +51,8 @@ export const SETTINGS_DEFAULTS: Record<string, string> = {
   [SETTINGS_KEYS.DISPLAY_SHOW_CHANGELOG_ON_UPDATE]: 'true',
   [SETTINGS_KEYS.DISPLAY_MAX_VISIBLE_ITEMS]: '300',
   [SETTINGS_KEYS.DISPLAY_CUSTOM_CSS]: '',
+  [SETTINGS_KEYS.DISPLAY_TERMINAL_FONT]:
+    '"JetBrains Mono", "Cascadia Mono", "Menlo", "Consolas", "DejaVu Sans Mono", "Liberation Mono", monospace',
   [SETTINGS_KEYS.LLM_DYNAMIC_SYSTEM_PROMPT]: 'false',
   [SETTINGS_KEYS.CACHE_WARMING]: 'false',
   [SETTINGS_KEYS.RETRY_PATTERNS]: JSON.stringify({ patterns: [], maxRetriesPerTurn: 10 }),

--- a/web/src/components/settings/tabs/DisplayTab.tsx
+++ b/web/src/components/settings/tabs/DisplayTab.tsx
@@ -1,7 +1,14 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useMemo } from 'react'
 import { SETTINGS_KEYS } from '../../../stores/settings'
 import { useSettingsStoreState } from '../useSettingsStore'
 import { ThemeEditor } from '../ThemeEditor'
+import {
+  detectAvailableFonts,
+  extractPrimaryFamily,
+  toFontFamilyValue,
+  resolveDefaultFamily,
+  DEFAULT_TERMINAL_FONT,
+} from '../../../lib/fonts'
 
 function ThemePicker() {
   return <ThemeEditor />
@@ -152,6 +159,93 @@ export function DisplayTab() {
             className="w-20 px-2 py-1 text-sm text-text-primary bg-bg-tertiary border border-border rounded text-right"
           />
         </label>
+      </div>
+
+      <div className="border-t border-border pt-4">
+        <h3 className="text-sm font-medium text-text-primary mb-2">Terminal</h3>
+        <TerminalFontEditor />
+      </div>
+    </div>
+  )
+}
+
+const FONT_PREVIEW_TEXT = '~/project \ue0b0 git status \u2713 \u2717 \u2192 0123 iIlL1 |\u2500\u2524'
+
+function TerminalFontEditor() {
+  const { settings, getSetting, setSetting } = useSettingsStoreState()
+  const savedValue = settings[SETTINGS_KEYS.DISPLAY_TERMINAL_FONT] ?? DEFAULT_TERMINAL_FONT
+  const [localValue, setLocalValue] = useState(savedValue)
+
+  const availableFonts = useMemo(() => detectAvailableFonts(), [])
+  const resolvedDefault = useMemo(() => resolveDefaultFamily(), [])
+
+  useEffect(() => {
+    getSetting(SETTINGS_KEYS.DISPLAY_TERMINAL_FONT)
+  }, [getSetting])
+
+  useEffect(() => {
+    setLocalValue(savedValue)
+  }, [savedValue])
+
+  // The default is a fallback stack, so its first family may not be installed:
+  // show the one the browser actually resolves to instead of a phantom entry.
+  const isDefaultStack = savedValue === DEFAULT_TERMINAL_FONT
+  const primaryFamily = isDefaultStack ? resolvedDefault : extractPrimaryFamily(savedValue)
+  const isCustom = primaryFamily !== '' && !availableFonts.includes(primaryFamily)
+
+  const handleSelect = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const family = e.target.value
+    if (!family) return
+    setSetting(SETTINGS_KEYS.DISPLAY_TERMINAL_FONT, toFontFamilyValue(family))
+  }
+
+  const saveCustom = () => {
+    setSetting(SETTINGS_KEYS.DISPLAY_TERMINAL_FONT, localValue.trim() || DEFAULT_TERMINAL_FONT)
+  }
+
+  return (
+    <div className="space-y-2">
+      <p className="text-xs text-text-muted">
+        Only monospace fonts detected on this machine are listed. Oh My Zsh themes need a Nerd Font for icons and
+        powerline separators to render correctly.
+      </p>
+
+      <select
+        value={isCustom ? '' : primaryFamily}
+        onChange={handleSelect}
+        className="w-full px-2 py-1.5 text-sm text-text-primary bg-bg-tertiary border border-border rounded focus:outline-none focus:ring-2 focus:ring-accent-primary/50 focus:border-accent-primary"
+      >
+        {isCustom && <option value="">{`Custom: ${primaryFamily}`}</option>}
+        {availableFonts.length === 0 && <option value="">No monospace font detected</option>}
+        {availableFonts.map((font) => (
+          <option key={font} value={font} style={{ fontFamily: `"${font}", monospace` }}>
+            {font}
+          </option>
+        ))}
+      </select>
+
+      <div
+        className="px-3 py-2 text-sm text-text-primary bg-bg-tertiary border border-border rounded overflow-x-auto whitespace-nowrap"
+        style={{ fontFamily: savedValue }}
+      >
+        {FONT_PREVIEW_TEXT}
+      </div>
+
+      <div>
+        <div className="text-xs text-text-muted mb-1">
+          Not listed? Enter a CSS font-family manually (e.g. &quot;My Font&quot;, monospace)
+        </div>
+        <input
+          type="text"
+          value={localValue}
+          onChange={(e) => setLocalValue(e.target.value)}
+          onBlur={saveCustom}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') saveCustom()
+          }}
+          className="w-full px-2 py-1 text-xs font-mono text-text-primary bg-bg-tertiary border border-border rounded focus:outline-none focus:ring-2 focus:ring-accent-primary/50 focus:border-accent-primary"
+          spellCheck={false}
+        />
       </div>
     </div>
   )

--- a/web/src/components/terminal/TerminalPane.tsx
+++ b/web/src/components/terminal/TerminalPane.tsx
@@ -2,6 +2,8 @@ import { useEffect, useRef } from 'react'
 import { Terminal } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
 import { useTerminalStore } from '../../stores/terminal'
+import { useSettingsStore, SETTINGS_KEYS } from '../../stores/settings'
+import { DEFAULT_TERMINAL_FONT } from '../../lib/fonts'
 import { wsClient } from '../../lib/ws'
 import type { ServerMessage } from '@shared/protocol.js'
 import { XCloseSmallIcon } from '../shared/icons'
@@ -21,10 +23,15 @@ export function TerminalPane({ sessionId, onClose, onEscape, autoFocus }: Termin
 
   const writeSession = useTerminalStore((state) => state.writeSession)
   const resizeSession = useTerminalStore((state) => state.resizeSession)
+  const terminalFont = useSettingsStore((s) => s.settings[SETTINGS_KEYS.DISPLAY_TERMINAL_FONT] ?? DEFAULT_TERMINAL_FONT)
 
   useEffect(() => {
     sessionIdRef.current = sessionId
   }, [sessionId])
+
+  useEffect(() => {
+    useSettingsStore.getState().getSetting(SETTINGS_KEYS.DISPLAY_TERMINAL_FONT)
+  }, [])
 
   useEffect(() => {
     if (!onEscape) return
@@ -44,7 +51,7 @@ export function TerminalPane({ sessionId, onClose, onEscape, autoFocus }: Termin
     if (!terminalRef.current) return
 
     const term = new Terminal({
-      fontFamily: '"JetBrains Mono", monospace',
+      fontFamily: terminalFont,
       fontSize: 13,
       theme: {
         background: '#1a1a1a',
@@ -135,6 +142,18 @@ export function TerminalPane({ sessionId, onClose, onEscape, autoFocus }: Termin
       termRef.current = null
     }
   }, [sessionId, writeSession, resizeSession])
+
+  useEffect(() => {
+    const instance = termRef.current
+    if (!instance) return
+
+    instance.term.options.fontFamily = terminalFont
+    instance.fitAddon.fit()
+    const { cols, rows } = instance.term
+    if (cols > 0 && rows > 0) {
+      resizeSession(sessionIdRef.current, cols, rows)
+    }
+  }, [terminalFont, resizeSession])
 
   return (
     <div className="flex flex-col h-full bg-[#1a1a1a]">

--- a/web/src/lib/fonts.test.ts
+++ b/web/src/lib/fonts.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from 'vitest'
+import {
+  MONOSPACE_FONT_CANDIDATES,
+  GENERIC_FONT_FAMILIES,
+  DEFAULT_TERMINAL_FONT,
+  DEFAULT_TERMINAL_FONT_STACK,
+  isFontAvailable,
+  detectAvailableFonts,
+  resolveDefaultFamily,
+  toFontFamilyValue,
+  extractPrimaryFamily,
+} from './fonts'
+
+function fakeMeasure(installed: string[]) {
+  return (family: string) => {
+    const primary = family.split(',')[0]?.trim().replace(/^"|"$/g, '') ?? ''
+    if (GENERIC_FONT_FAMILIES.includes(primary as (typeof GENERIC_FONT_FAMILIES)[number])) {
+      return 100
+    }
+    return installed.includes(primary) ? 137 : 100
+  }
+}
+
+describe('isFontAvailable', () => {
+  it('returns true when the measured width differs from the generic fallback', () => {
+    expect(isFontAvailable('Hack', fakeMeasure(['Hack']))).toBe(true)
+  })
+
+  it('returns false when the width matches the generic fallback (font substituted)', () => {
+    expect(isFontAvailable('Nonexistent Font', fakeMeasure(['Hack']))).toBe(false)
+  })
+
+  it('returns false for an empty family name', () => {
+    expect(isFontAvailable('', fakeMeasure(['Hack']))).toBe(false)
+  })
+
+  it('returns false when the measure function throws', () => {
+    const throwing = () => {
+      throw new Error('no canvas')
+    }
+    expect(isFontAvailable('Hack', throwing)).toBe(false)
+  })
+})
+
+describe('detectAvailableFonts', () => {
+  it('keeps only the installed candidates', () => {
+    const result = detectAvailableFonts(['Hack', 'Fira Code', 'Ghost Font'], fakeMeasure(['Hack', 'Fira Code']))
+    expect(result).toEqual(['Fira Code', 'Hack'])
+  })
+
+  it('deduplicates repeated candidates', () => {
+    const result = detectAvailableFonts(['Hack', 'Hack'], fakeMeasure(['Hack']))
+    expect(result).toEqual(['Hack'])
+  })
+
+  it('returns results sorted alphabetically', () => {
+    const result = detectAvailableFonts(['Zed Mono', 'Alpha Mono'], fakeMeasure(['Zed Mono', 'Alpha Mono']))
+    expect(result).toEqual(['Alpha Mono', 'Zed Mono'])
+  })
+
+  it('returns an empty array when nothing is installed', () => {
+    expect(detectAvailableFonts(['Ghost Font'], fakeMeasure([]))).toEqual([])
+  })
+
+  it('returns an empty array instead of throwing when measuring is unavailable', () => {
+    const throwing = () => {
+      throw new Error('no canvas')
+    }
+    expect(detectAvailableFonts(['Hack'], throwing)).toEqual([])
+  })
+
+  it('defaults to the curated candidate list', () => {
+    const result = detectAvailableFonts(undefined, fakeMeasure(['Menlo']))
+    expect(result).toEqual(['Menlo'])
+  })
+})
+
+describe('MONOSPACE_FONT_CANDIDATES', () => {
+  it('contains no duplicates', () => {
+    expect(new Set(MONOSPACE_FONT_CANDIDATES).size).toBe(MONOSPACE_FONT_CANDIDATES.length)
+  })
+
+  it('includes common Nerd Font variants', () => {
+    expect(MONOSPACE_FONT_CANDIDATES).toContain('MesloLGS NF')
+    expect(MONOSPACE_FONT_CANDIDATES).toContain('JetBrainsMono Nerd Font')
+  })
+})
+
+describe('toFontFamilyValue', () => {
+  it('quotes the family and appends the monospace fallback', () => {
+    expect(toFontFamilyValue('Fira Code')).toBe('"Fira Code", monospace')
+  })
+
+  it('trims surrounding whitespace', () => {
+    expect(toFontFamilyValue('  Hack  ')).toBe('"Hack", monospace')
+  })
+
+  it('returns an empty string for a blank family', () => {
+    expect(toFontFamilyValue('   ')).toBe('')
+  })
+})
+
+describe('DEFAULT_TERMINAL_FONT', () => {
+  it('ends with the generic monospace fallback so it always resolves to something', () => {
+    expect(DEFAULT_TERMINAL_FONT.endsWith('monospace')).toBe(true)
+  })
+
+  it('lists several families to cover macOS, Windows and Linux', () => {
+    expect(DEFAULT_TERMINAL_FONT_STACK.length).toBeGreaterThan(1)
+  })
+
+  it('covers each major platform with at least one preinstalled font', () => {
+    const macOS = ['Menlo', 'Monaco', 'SF Mono']
+    const windows = ['Consolas', 'Cascadia Mono', 'Cascadia Code']
+    const linux = ['DejaVu Sans Mono', 'Liberation Mono', 'Ubuntu Mono', 'Noto Sans Mono']
+
+    for (const platform of [macOS, windows, linux]) {
+      expect(platform.some((font) => DEFAULT_TERMINAL_FONT_STACK.includes(font))).toBe(true)
+    }
+  })
+
+  it('only references families present in the candidate list', () => {
+    for (const family of DEFAULT_TERMINAL_FONT_STACK) {
+      expect(MONOSPACE_FONT_CANDIDATES).toContain(family)
+    }
+  })
+})
+
+describe('resolveDefaultFamily', () => {
+  it('returns the first installed family of the default stack', () => {
+    const measure = fakeMeasure(['Consolas', 'DejaVu Sans Mono'])
+    const resolved = resolveDefaultFamily(['Menlo', 'Consolas', 'DejaVu Sans Mono'], measure)
+    expect(resolved).toBe('Consolas')
+  })
+
+  it('respects the declared order of preference', () => {
+    const measure = fakeMeasure(['Menlo', 'Consolas'])
+    expect(resolveDefaultFamily(['Menlo', 'Consolas'], measure)).toBe('Menlo')
+  })
+
+  it('returns an empty string when no family of the stack is installed', () => {
+    expect(resolveDefaultFamily(['Menlo', 'Consolas'], fakeMeasure([]))).toBe('')
+  })
+
+  it('returns an empty string when measuring is unavailable', () => {
+    const throwing = () => {
+      throw new Error('no canvas')
+    }
+    expect(resolveDefaultFamily(['Menlo'], throwing)).toBe('')
+  })
+})
+
+describe('extractPrimaryFamily', () => {
+  it('extracts the first family from a CSS font stack', () => {
+    expect(extractPrimaryFamily('"JetBrains Mono", monospace')).toBe('JetBrains Mono')
+  })
+
+  it('handles unquoted families', () => {
+    expect(extractPrimaryFamily('Menlo, monospace')).toBe('Menlo')
+  })
+
+  it('handles single quotes', () => {
+    expect(extractPrimaryFamily("'Fira Code', monospace")).toBe('Fira Code')
+  })
+
+  it('returns an empty string for empty input', () => {
+    expect(extractPrimaryFamily('')).toBe('')
+  })
+})

--- a/web/src/lib/fonts.ts
+++ b/web/src/lib/fonts.ts
@@ -1,0 +1,133 @@
+export const GENERIC_FONT_FAMILIES = ['monospace', 'serif', 'sans-serif'] as const
+
+/**
+ * Ordered fallback stack used as the terminal default.
+ *
+ * No font is bundled with OpenFox, so the default must only reference families
+ * that ship with an OS: Menlo/Monaco (macOS), Consolas/Cascadia Mono (Windows),
+ * DejaVu/Liberation/Ubuntu Mono (Linux). Nicer fonts come first and are used
+ * when the user happens to have them installed.
+ */
+export const DEFAULT_TERMINAL_FONT_STACK: string[] = [
+  'JetBrains Mono',
+  'Cascadia Mono',
+  'Menlo',
+  'Consolas',
+  'DejaVu Sans Mono',
+  'Liberation Mono',
+]
+
+export const DEFAULT_TERMINAL_FONT = `${DEFAULT_TERMINAL_FONT_STACK.map((f) => `"${f}"`).join(', ')}, monospace`
+
+export const MONOSPACE_FONT_CANDIDATES: string[] = [
+  'Andale Mono',
+  'Anonymous Pro',
+  'Cascadia Code',
+  'Cascadia Mono',
+  'Consolas',
+  'Courier New',
+  'DejaVu Sans Mono',
+  'Fira Code',
+  'Fira Mono',
+  'Geist Mono',
+  'Hack',
+  'IBM Plex Mono',
+  'Inconsolata',
+  'Iosevka',
+  'JetBrains Mono',
+  'Liberation Mono',
+  'Menlo',
+  'Monaco',
+  'Noto Sans Mono',
+  'Roboto Mono',
+  'SF Mono',
+  'Source Code Pro',
+  'Space Mono',
+  'Ubuntu Mono',
+  'Victor Mono',
+  'CaskaydiaCove Nerd Font',
+  'CaskaydiaCove Nerd Font Mono',
+  'DejaVuSansMono Nerd Font',
+  'FiraCode Nerd Font',
+  'FiraCode Nerd Font Mono',
+  'Hack Nerd Font',
+  'Hack Nerd Font Mono',
+  'Iosevka Nerd Font',
+  'JetBrainsMono Nerd Font',
+  'JetBrainsMono Nerd Font Mono',
+  'MesloLGS NF',
+  'MesloLGS Nerd Font',
+  'SauceCodePro Nerd Font',
+  'SauceCodePro Nerd Font Mono',
+  'UbuntuMono Nerd Font',
+]
+
+const TEST_STRING = 'mmmmmmmmmmlliWWWW@0Oo'
+const TEST_SIZE = '72px'
+
+export type MeasureFont = (fontFamily: string) => number
+
+let cachedContext: CanvasRenderingContext2D | null | undefined
+
+function getContext(): CanvasRenderingContext2D | null {
+  if (cachedContext !== undefined) return cachedContext
+  try {
+    cachedContext = document.createElement('canvas').getContext('2d')
+  } catch {
+    cachedContext = null
+  }
+  return cachedContext
+}
+
+export function measureWithCanvas(fontFamily: string): number {
+  const ctx = getContext()
+  if (!ctx) throw new Error('Canvas 2D context unavailable')
+  ctx.font = `${TEST_SIZE} ${fontFamily}`
+  return ctx.measureText(TEST_STRING).width
+}
+
+export function isFontAvailable(family: string, measure: MeasureFont = measureWithCanvas): boolean {
+  const trimmed = family.trim()
+  if (!trimmed) return false
+
+  try {
+    return GENERIC_FONT_FAMILIES.some((generic) => {
+      const baseline = measure(generic)
+      const candidate = measure(`"${trimmed}", ${generic}`)
+      return candidate !== baseline
+    })
+  } catch {
+    return false
+  }
+}
+
+export function detectAvailableFonts(
+  candidates: string[] = MONOSPACE_FONT_CANDIDATES,
+  measure: MeasureFont = measureWithCanvas,
+): string[] {
+  const found = new Set<string>()
+  for (const candidate of candidates) {
+    if (isFontAvailable(candidate, measure)) {
+      found.add(candidate)
+    }
+  }
+  return [...found].sort((a, b) => a.localeCompare(b))
+}
+
+export function resolveDefaultFamily(
+  stack: string[] = DEFAULT_TERMINAL_FONT_STACK,
+  measure: MeasureFont = measureWithCanvas,
+): string {
+  return stack.find((family) => isFontAvailable(family, measure)) ?? ''
+}
+
+export function toFontFamilyValue(family: string): string {
+  const trimmed = family.trim()
+  if (!trimmed) return ''
+  return `"${trimmed}", monospace`
+}
+
+export function extractPrimaryFamily(fontFamilyValue: string): string {
+  const first = fontFamilyValue.split(',')[0]?.trim() ?? ''
+  return first.replace(/^['"]|['"]$/g, '')
+}

--- a/web/src/stores/settings.ts
+++ b/web/src/stores/settings.ts
@@ -19,6 +19,7 @@ export const SETTINGS_KEYS = {
   DISPLAY_SHOW_CHANGELOG_ON_UPDATE: 'display.showChangelogOnUpdate',
   DISPLAY_MAX_VISIBLE_ITEMS: 'display.maxVisibleItems',
   DISPLAY_CUSTOM_CSS: 'display.customCss',
+  DISPLAY_TERMINAL_FONT: 'display.terminalFont',
   LLM_DYNAMIC_SYSTEM_PROMPT: 'llm.dynamicSystemPrompt',
   CACHE_WARMING: 'cache.warming',
   KEYBINDINGS: 'keybindings',
@@ -69,6 +70,7 @@ export const DISPLAY_SETTINGS_KEYS = [
   SETTINGS_KEYS.DISPLAY_SHOW_OPEN_IN_EDITOR,
   SETTINGS_KEYS.DISPLAY_SHOW_CHANGELOG_ON_UPDATE,
   SETTINGS_KEYS.DISPLAY_MAX_VISIBLE_ITEMS,
+  SETTINGS_KEYS.DISPLAY_TERMINAL_FONT,
 ] as const
 
 export function useDisplaySettings() {


### PR DESCRIPTION
### Summary

The terminal font family is hardcoded in `TerminalPane.tsx`, so users running Oh My Zsh (or any Powerlevel10k-style prompt) cannot get a Nerd Font and see tofu boxes instead of icons and powerline separators.

This PR adds a `display.terminalFont` setting, surfaced in **Settings → Display → Terminal**, applied to xterm.js only. The picker lists just the monospace fonts actually installed on the machine, detected via canvas text measurement, with a free-text field as an escape hatch and a live preview showing powerline glyphs.

### AI-Enhanced Development

Tell what models helped shape this PR:

- **AI Models:** Claude Opus 5

### Cache Impact

Does this PR affect anything cached — system prompts, tool definitions, skills, or other context?

- **No**

`display.terminalFont` is a client-render-only setting. The prompt cache key is `computeDynamicContextHash(instructionContent, skills, toolFingerprint)` (`src/server/chat/dynamic-context.ts`), which hashes only instruction text, skill IDs and the tool fingerprint — settings rows are not inputs. Unlike keys such as `global_instructions`, `skills.directories` or `tools.shell`, no `display.*` key is ever read on the server side: they are pushed to the web client and consumed by React. `src/server/chat/prompts.ts` does not import from `db/settings`, and five of the six changed files live under `web/`. No system prompt, tool schema, skill or agent definition is touched.

---

### Design decisions

#### Font detection: canvas measurement, not `queryLocalFonts()`

The Local Font Access API returns an exact font list, but it is **Chromium-only** and requires an explicit user permission grant. Instead, a font is probed by measuring a test string rendered as `"Candidate", monospace` against the generic families — if the width differs, the browser did not fall back, so the font is installed.

This works in every browser with no permission prompt. The tradeoff is that the **candidate list is finite** (~40 curated monospace and Nerd Font families), which is why a free-text field is kept below the picker for anything not detected. A saved value outside the detected list is preserved and shown as `Custom: …` rather than silently dropped.

The measuring function is injected as a parameter, which keeps detection unit-testable without a real canvas and lets it degrade to an empty list instead of throwing when no 2D context is available.

#### Default: a fallback stack, not a single family

No font is bundled with OpenFox — there is no `@font-face` anywhere in the project. A default of `"JetBrains Mono", monospace` therefore silently resolves to the generic `monospace` on any machine without that font, and the picker would display a phantom entry for a font that is not there.

The default is now an ordered stack that only references families shipping with an OS:

```
"JetBrains Mono", "Cascadia Mono", "Menlo", "Consolas",
"DejaVu Sans Mono", "Liberation Mono", monospace
```

macOS is covered by Menlo, Windows by Consolas/Cascadia Mono, Linux by DejaVu/Liberation, with `monospace` as the final guarantee. Nicer fonts come first and win when present. `resolveDefaultFamily()` makes the picker show the family the browser actually resolves to.

#### Live updates require a refit

Changing `fontFamily` changes cell metrics, so `cols`/`rows` become stale and text wraps incorrectly until the next resize. The effect calls `fitAddon.fit()` and propagates the new dimensions via `resizeSession()`.

### Changes

| File | Change |
| --- | --- |
| `web/src/lib/fonts.ts` | **New** — curated candidate list, canvas-based detection, default stack resolution |
| `web/src/lib/fonts.test.ts` | **New** — 27 unit tests |
| `web/src/components/settings/tabs/DisplayTab.tsx` | `TerminalFontEditor`: picker, preview, free-text fallback |
| `web/src/components/terminal/TerminalPane.tsx` | Reads the setting, applies and refits reactively |
| `src/server/db/settings.ts` | Setting key and default |
| `web/src/stores/settings.ts` | Mirror key, added to `DISPLAY_SETTINGS_KEYS` for batch load |

No new API endpoints or store methods — the existing generic `getSetting`/`setSetting` are reused.

### Backward compatibility

Existing installs are unaffected: the default resolves to JetBrains Mono when installed, exactly as before, and to a sensible platform font otherwise (previously a silent fallback to generic `monospace`).

### Testing

- `npm run typecheck` ✅
- `npm run lint` ✅
- `npx prettier --check` ✅ on all touched files
- `npm run test:unit` — 2980 passing, including 27 new

Manual verification: picker lists installed fonts only, selection updates open terminals live without wrapping artifacts, value persists across reload, and an unlisted font entered manually is preserved.

> [!NOTE]
> `src/server/routes/workspace-config.test.ts` fails on this branch, but it **already fails on a clean tree** (verified via `git stash`) and is unrelated to this change. It currently blocks the pre-commit hook for any commit on the repository and likely deserves a separate fix.

