### PR TITLE
fix: load project skills from session.workdir instead of server workdir

### DIFF
--- a/e2e/context-check-dynamic.test.ts
+++ b/e2e/context-check-dynamic.test.ts
@@ -35,7 +35,9 @@ describe('context.checkDynamic', () => {
     // Clean up any skill files created during the test
     for (const skillId of createdSkillIds) {
       try {
-        await fetch(`${server.url}/api/skills/${skillId}`, { method: 'DELETE' })
+        await fetch(`${server.url}/api/skills/${skillId}?workdir=${encodeURIComponent(project.path)}`, {
+          method: 'DELETE',
+        })
       } catch {
         // Ignore cleanup errors
       }
@@ -78,7 +80,7 @@ describe('context.checkDynamic', () => {
 
     // Add a skill via the skills API (same payload as the UI: SkillFull + destination)
     const skillId = `test-skill-${Date.now()}`
-    const skillRes = await fetch(`${server.url}/api/skills`, {
+    const skillRes = await fetch(`${server.url}/api/skills?workdir=${encodeURIComponent(project.path)}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({

--- a/src/server/chat/agent-loop.test.ts
+++ b/src/server/chat/agent-loop.test.ts
@@ -704,4 +704,51 @@ describe('maxTokens clamping', () => {
     expect(callArgs.skipClientReasoningEffort).toBeUndefined()
     expect(streamLLMPure).not.toHaveBeenCalled()
   })
+
+  it('passes session.workdir to getEnabledSkillMetadata instead of global workdir', async () => {
+    const sessionWorkdir = '/actual/project/dir'
+
+    mockSessionManager = {
+      requireSession: vi.fn().mockReturnValue({
+        workdir: sessionWorkdir,
+        projectId: 'test-project',
+        executionState: null,
+        criteria: [],
+        isRunning: false,
+      }),
+      getContextState: vi.fn().mockReturnValue({
+        currentTokens: 0,
+        maxTokens: 200000,
+        compactionCount: 0,
+        dangerZone: false,
+        canCompact: false,
+        dynamicContextChanged: false,
+      }),
+      getCurrentModelContext: vi.fn().mockReturnValue(200000),
+      getCurrentModelSettings: vi.fn().mockReturnValue({ maxTokens: 16384 }),
+      setCurrentContextSize: vi.fn(),
+      getDynamicContextChanged: vi.fn().mockReturnValue(false),
+      setDynamicContextChanged: vi.fn(),
+      getCachedPrompt: vi.fn().mockReturnValue(undefined),
+      setCachedPrompt: vi.fn(),
+      getLspManager: vi.fn(),
+      drainAsapMessages: vi.fn().mockReturnValue([]),
+      getCurrentWindowMessages: vi.fn().mockReturnValue([]),
+      updateMessage: vi.fn(),
+    } as any
+
+    const completeMock = vi.fn().mockResolvedValue({
+      id: 'warmup',
+      content: '',
+      finishReason: 'stop',
+      usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+    })
+    mockLLMClient.complete = completeMock
+
+    vi.mocked(getEnabledSkillMetadata).mockClear()
+
+    await runTopLevelAgentLoop(makeConfig({ warmup: true }), mockTurnMetrics)
+
+    expect(getEnabledSkillMetadata).toHaveBeenCalledWith('/test/config', sessionWorkdir)
+  })
 })

--- a/src/server/chat/agent-loop.ts
+++ b/src/server/chat/agent-loop.ts
@@ -188,7 +188,7 @@ export async function runTopLevelAgentLoop(
       const session = sessionManager.requireSession(sessionId)
       const runtimeConfig = getRuntimeConfig()
       const configDir = getGlobalConfigDir(runtimeConfig.mode ?? 'production')
-      const skills = await getEnabledSkillMetadata(configDir, runtimeConfig.workdir)
+      const skills = await getEnabledSkillMetadata(configDir, session.workdir)
       const { content: instructionContent } = await getAllInstructions(session.workdir, session.projectId)
       const toolRegistry = config.getToolRegistry()
 
@@ -254,7 +254,7 @@ export async function runTopLevelAgentLoop(
 
     const runtimeConfig = getRuntimeConfig()
     const configDir = getGlobalConfigDir(runtimeConfig.mode ?? 'production')
-    const skills = await getEnabledSkillMetadata(configDir, runtimeConfig.workdir)
+    const skills = await getEnabledSkillMetadata(configDir, session.workdir)
     if (signal?.aborted) throw new Error('Aborted')
 
     const assembledRequest = await config.assembleRequest({

--- a/src/server/chat/dynamic-context.ts
+++ b/src/server/chat/dynamic-context.ts
@@ -120,7 +120,7 @@ async function loadSessionContext(
   const { content: instructionContent } = await getAllInstructions(session.workdir, session.projectId)
   const runtimeConfig = getRuntimeConfig()
   const configDir = getGlobalConfigDir(runtimeConfig.mode ?? 'production')
-  const skills = await getEnabledSkillMetadata(configDir, runtimeConfig.workdir)
+  const skills = await getEnabledSkillMetadata(configDir, session.workdir)
   return { instructionContent: instructionContent ?? '', skills }
 }
 

--- a/src/server/chat/orchestrator.ts
+++ b/src/server/chat/orchestrator.ts
@@ -346,13 +346,12 @@ export async function runAgentTurn(
     injectAgentReminder(options.sessionId, agentDef)
   }
 
-  const { content: instructionContent } = await getAllInstructions(
-    options.sessionManager.requireSession(options.sessionId).workdir,
-    options.sessionManager.requireSession(options.sessionId).projectId,
-  )
+  const session = options.sessionManager.requireSession(options.sessionId)
+
+  const { content: instructionContent } = await getAllInstructions(session.workdir, session.projectId)
   const runtimeConfig = getRuntimeConfig()
   const configDir = getGlobalConfigDir(runtimeConfig.mode ?? 'production')
-  const skills = await getEnabledSkillMetadata(configDir, runtimeConfig.workdir)
+  const skills = await getEnabledSkillMetadata(configDir, session.workdir)
 
   return runTopLevelAgentLoop(
     {

--- a/src/server/routes/crud-helpers.ts
+++ b/src/server/routes/crud-helpers.ts
@@ -6,6 +6,11 @@ export function computeOverrideIds<T extends { metadata: { id: string } }>(defau
   return userItems.filter((u) => defaults.some((d) => d.metadata.id === u.metadata.id)).map((u) => u.metadata.id)
 }
 
+export function resolveProjectDir(req: { query: Record<string, unknown> }, fallback?: string): string | undefined {
+  const workdir = req.query['workdir']
+  return typeof workdir === 'string' && workdir.trim() ? workdir : fallback
+}
+
 export interface LoadFunctions<T> {
   loadDefaults: () => Promise<T[]>
   loadUser: (configDir: string) => Promise<T[]>
@@ -64,7 +69,7 @@ export interface CrudRouteConfig<T> {
   getDefaultIds?: () => Promise<string[]>
   validateCreate?: (body: Record<string, unknown>) => string | null
   mapToResponse: (item: T) => { [key: string]: unknown }
-  extraGetData?: () => Promise<{ [key: string]: unknown }>
+  extraGetData?: (effectiveProjectDir?: string) => Promise<{ [key: string]: unknown }>
   extraRoutes?: (router: Router) => void
 }
 
@@ -75,15 +80,16 @@ export function createCrudRoutes<T extends { metadata: { id: string; name: strin
 ): Router {
   const router = Router()
 
-  router.get('/', async (_req, res) => {
+  router.get('/', async (req, res) => {
+    const effectiveProjectDir = resolveProjectDir(req, projectDir)
     const [defaults, userItems, projectItems] = await Promise.all([
       config.loadDefaults(),
       config.loadUser(configDir),
-      projectDir ? config.loadProject(projectDir) : [],
+      effectiveProjectDir ? config.loadProject(effectiveProjectDir) : [],
     ])
     const userOverrideIds = computeOverrideIds(defaults, userItems)
     const projectOverrideIds = computeOverrideIds(defaults, projectItems)
-    const extra = config.extraGetData ? await config.extraGetData() : {}
+    const extra = config.extraGetData ? await config.extraGetData(effectiveProjectDir) : {}
     res.json({
       defaults: defaults.map(config.mapToResponse),
       userItems: userItems.map(config.mapToResponse),
@@ -110,7 +116,8 @@ export function createCrudRoutes<T extends { metadata: { id: string; name: strin
 
   router.get('/:id', async (req, res) => {
     const { id } = req.params
-    const items = await config.loadAll(configDir, projectDir)
+    const effectiveProjectDir = resolveProjectDir(req, projectDir)
+    const items = await config.loadAll(configDir, effectiveProjectDir)
     const item = config.findById(id, items)
     if (!item) {
       return res.status(404).json({ error: 'Not found' })
@@ -127,15 +134,16 @@ export function createCrudRoutes<T extends { metadata: { id: string; name: strin
     }
     const id = String(meta['id'])
     const destination = (body['destination'] as 'project' | 'user') ?? 'user'
-    if (destination === 'project' && !projectDir) {
+    const effectiveProjectDir = resolveProjectDir(req, projectDir)
+    if (destination === 'project' && !effectiveProjectDir) {
       return res.status(400).json({ error: 'No project directory configured' })
     }
-    const exists = await config.exists(configDir, id, projectDir)
+    const exists = await config.exists(configDir, id, effectiveProjectDir)
     if (exists) {
       return res.status(409).json({ error: 'An item with this ID already exists' })
     }
     if (destination === 'project') {
-      await config.saveToProject(projectDir!, body as unknown as T)
+      await config.saveToProject(effectiveProjectDir!, body as unknown as T)
     } else {
       await config.save(configDir, body as unknown as T)
     }
@@ -144,7 +152,8 @@ export function createCrudRoutes<T extends { metadata: { id: string; name: strin
 
   router.put('/:id', async (req, res) => {
     const { id } = req.params
-    const items = await config.loadAll(configDir, projectDir)
+    const effectiveProjectDir = resolveProjectDir(req, projectDir)
+    const items = await config.loadAll(configDir, effectiveProjectDir)
     const existing = config.findById(id, items)
     if (!existing) {
       return res.status(404).json({ error: 'Not found' })
@@ -156,9 +165,9 @@ export function createCrudRoutes<T extends { metadata: { id: string; name: strin
       ...body,
       metadata: { ...existing.metadata, ...meta, id },
     } as unknown as T
-    const isProject = await isProjectItem(projectDir, config.dirName, id, config.ext)
+    const isProject = await isProjectItem(effectiveProjectDir, config.dirName, id, config.ext)
     if (isProject) {
-      await config.saveToProject(projectDir!, updated)
+      await config.saveToProject(effectiveProjectDir!, updated)
     } else {
       await config.save(configDir, updated)
     }
@@ -167,9 +176,10 @@ export function createCrudRoutes<T extends { metadata: { id: string; name: strin
 
   router.delete('/:id', async (req, res) => {
     const { id } = req.params
-    const isProject = await isProjectItem(projectDir, config.dirName, id, config.ext)
+    const effectiveProjectDir = resolveProjectDir(req, projectDir)
+    const isProject = await isProjectItem(effectiveProjectDir, config.dirName, id, config.ext)
     if (isProject) {
-      const result = await config.deleteProject(projectDir!, id)
+      const result = await config.deleteProject(effectiveProjectDir!, id)
       if (!result.success) {
         return res.status(500).json({ error: 'Failed to delete project item' })
       }
@@ -188,7 +198,8 @@ export function createCrudRoutes<T extends { metadata: { id: string; name: strin
 
   router.post('/:id/duplicate', async (req, res) => {
     const { id } = req.params
-    const items = await config.loadAll(configDir, projectDir)
+    const effectiveProjectDir = resolveProjectDir(req, projectDir)
+    const items = await config.loadAll(configDir, effectiveProjectDir)
     const source = config.findById(id, items)
     if (!source) {
       return res.status(404).json({ error: 'Not found' })
@@ -200,8 +211,8 @@ export function createCrudRoutes<T extends { metadata: { id: string; name: strin
     } as unknown as T
     const destination = (req.body as { destination?: 'project' | 'user' }).destination ?? 'user'
     if (destination === 'project') {
-      if (!projectDir) return res.status(400).json({ error: 'No project directory configured' })
-      await config.saveToProject(projectDir, duplicated)
+      if (!effectiveProjectDir) return res.status(400).json({ error: 'No project directory configured' })
+      await config.saveToProject(effectiveProjectDir, duplicated)
     } else {
       await config.save(configDir, duplicated)
     }

--- a/src/server/routes/skills.ts
+++ b/src/server/routes/skills.ts
@@ -26,7 +26,7 @@ import {
 import { installSkillPackage, SkillInstallError } from '../skills/installer.js'
 import { deleteSetting, getSetting, setSetting } from '../db/settings.js'
 import type { SkillDefinition } from '../skills/types.js'
-import { createCrudRoutes, validateNameIdPrompt, type CrudRouteConfig } from './crud-helpers.js'
+import { createCrudRoutes, validateNameIdPrompt, resolveProjectDir, type CrudRouteConfig } from './crud-helpers.js'
 
 const SKILL_DIRECTORIES_SETTING = 'skills.directories'
 const upload = multer({
@@ -108,8 +108,9 @@ function createConfig(configDir: string, projectDir?: string): CrudRouteConfig<S
     getDefaultIds: getDefaultSkillIds,
     validateCreate: validateSkillCreate,
     mapToResponse,
-    extraGetData: async () => {
-      const discovery = await loadAllSkillsWithDiagnostics(configDir, projectDir)
+    extraGetData: async (effectiveProjectDir?: string) => {
+      const projectDirParam = effectiveProjectDir ?? projectDir
+      const discovery = await loadAllSkillsWithDiagnostics(configDir, projectDirParam)
       const items = discovery.skills
       const configured = configuredDirectory()
       let selectedDirectory: {
@@ -186,7 +187,8 @@ export function createSkillRoutes(configDir: string, projectDir?: string): Route
   })
 
   router.post('/:id/toggle', async (req, res) => {
-    const skills = await loadAllSkills(configDir, projectDir)
+    const effectiveProjectDir = resolveProjectDir(req, projectDir)
+    const skills = await loadAllSkills(configDir, effectiveProjectDir)
     const existing = findSkillById(req.params['id']!, skills)
     if (!existing) return res.status(404).json({ error: 'Not found' })
     const enabled = !isSkillEnabled(existing.metadata.id)
@@ -195,7 +197,8 @@ export function createSkillRoutes(configDir: string, projectDir?: string): Route
   })
 
   router.put('/:id', async (req, res) => {
-    const skills = await loadAllSkills(configDir, projectDir)
+    const effectiveProjectDir = resolveProjectDir(req, projectDir)
+    const skills = await loadAllSkills(configDir, effectiveProjectDir)
     const existing = findSkillById(req.params['id']!, skills)
     if (!existing) return res.status(404).json({ error: 'Not found' })
     const updated = await updateOwnedSkill(existing, req.body as Partial<SkillDefinition>)
@@ -204,7 +207,8 @@ export function createSkillRoutes(configDir: string, projectDir?: string): Route
   })
 
   router.delete('/:id', async (req, res) => {
-    const skills = await loadAllSkills(configDir, projectDir)
+    const effectiveProjectDir = resolveProjectDir(req, projectDir)
+    const skills = await loadAllSkills(configDir, effectiveProjectDir)
     const existing = findSkillById(req.params['id']!, skills)
     if (!existing) return res.status(404).json({ error: 'Not found' })
     const result = await deleteOwnedSkill(existing)

--- a/src/server/skills/registry.test.ts
+++ b/src/server/skills/registry.test.ts
@@ -375,6 +375,21 @@ Custom prompt.
     expect(result.skills.filter((skill) => skill.metadata.id === 'linked-skill')).toHaveLength(1)
     expect(result.diagnostics).toContain('Skill "linked-skill" reached through multiple paths')
   })
+
+  it('loads project-specific skills when projectDir differs from configDir', async () => {
+    const projectA = join(tempDir, 'project-a')
+    const projectB = join(tempDir, 'project-b')
+    await createProjectSkillFile(projectA, 'skill-a', 'Skill A', 'Only in project A.')
+    await createProjectSkillFile(projectB, 'skill-b', 'Skill B', 'Only in project B.')
+
+    const skillsA = await loadAllSkills(tempDir, projectA)
+    const skillsB = await loadAllSkills(tempDir, projectB)
+
+    expect(skillsA.some((s) => s.metadata.id === 'skill-a')).toBe(true)
+    expect(skillsA.some((s) => s.metadata.id === 'skill-b')).toBe(false)
+    expect(skillsB.some((s) => s.metadata.id === 'skill-b')).toBe(true)
+    expect(skillsB.some((s) => s.metadata.id === 'skill-a')).toBe(false)
+  })
 })
 
 describe('isSkillEnabled / setSkillEnabled', () => {

--- a/src/server/sub-agents/manager.ts
+++ b/src/server/sub-agents/manager.ts
@@ -266,7 +266,7 @@ export async function executeSubAgent(options: SubAgentExecutionOptions): Promis
   const { content: instructionContent } = await getAllInstructions(effectiveWorkdir, session.projectId)
   const config = getRuntimeConfig()
   const configDir = getGlobalConfigDir(config.mode ?? 'production')
-  const skills = await getEnabledSkillMetadata(configDir, config.workdir)
+  const skills = await getEnabledSkillMetadata(configDir, effectiveWorkdir)
 
   const hasRunCommand = agentDef.metadata.allowedTools?.includes('run_command') ?? false
   const gitignoreSection = hasRunCommand ? await loadGitIgnoreRules(effectiveWorkdir) : ''

--- a/src/server/tools/load-skill.test.ts
+++ b/src/server/tools/load-skill.test.ts
@@ -1,8 +1,37 @@
-import { describe, expect, it } from 'vitest'
-import { formatSkillPrompt } from './load-skill.js'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { formatSkillPrompt, loadSkillTool } from './load-skill.js'
 import type { SkillDefinition } from '../skills/types.js'
 
+vi.mock('../skills/registry.js', () => ({
+  loadAllSkills: vi.fn(),
+  findSkillById: vi.fn(),
+  isSkillEnabled: vi.fn(),
+}))
+
+vi.mock('../runtime-config.js', () => ({
+  getRuntimeConfig: vi.fn().mockReturnValue({
+    mode: 'test',
+    workdir: '/global-server-workdir',
+  }),
+}))
+
+vi.mock('../../cli/paths.js', () => ({
+  getGlobalConfigDir: vi.fn().mockReturnValue('/test/config'),
+}))
+
+import { loadAllSkills, findSkillById, isSkillEnabled } from '../skills/registry.js'
+import type { ToolContext } from './types.js'
+
 const metadata = { id: 'test', name: 'Test', description: 'Test', version: '' }
+
+function makeContext(overrides?: Partial<ToolContext>): ToolContext {
+  return {
+    workdir: '/session/project',
+    sessionId: 'test-session',
+    sessionManager: { requireSession: vi.fn() } as any,
+    ...overrides,
+  }
+}
 
 describe('formatSkillPrompt', () => {
   it('keeps legacy output byte-for-byte compatible', () => {
@@ -20,5 +49,47 @@ describe('formatSkillPrompt', () => {
     expect(formatSkillPrompt(skill)).toBe(
       'Skill package directory: /shared skills/test\nResolve relative paths in these instructions from that directory.\n\nRun scripts/check.sh.',
     )
+  })
+})
+
+describe('load_skill handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('passes session workdir to loadAllSkills instead of global server workdir', async () => {
+    vi.mocked(isSkillEnabled).mockReturnValueOnce(true)
+    vi.mocked(loadAllSkills).mockResolvedValueOnce([])
+    vi.mocked(findSkillById).mockReturnValueOnce(undefined)
+
+    const ctx = makeContext({ workdir: '/my/project' })
+
+    await loadSkillTool.execute({ skillId: 'nonexistent' }, ctx)
+
+    expect(loadAllSkills).toHaveBeenCalledWith('/test/config', '/my/project')
+    expect(loadAllSkills).not.toHaveBeenCalledWith('/test/config', '/global-server-workdir')
+  })
+
+  it('finds a skill loaded from session workdir', async () => {
+    const skill: SkillDefinition = {
+      metadata: { id: 'proj-skill', name: 'Project Skill', description: 'A project skill', version: '1.0' },
+      prompt: 'Do project things.',
+      legacy: false,
+      directory: '/my/project/.openfox/skills/proj-skill',
+    }
+
+    vi.mocked(isSkillEnabled).mockReturnValueOnce(true)
+    vi.mocked(loadAllSkills).mockResolvedValueOnce([skill])
+    vi.mocked(findSkillById).mockImplementation((id: string, skills: SkillDefinition[]) =>
+      skills.find((s) => s.metadata.id === id),
+    )
+
+    const ctx = makeContext({ workdir: '/my/project' })
+
+    const result = await loadSkillTool.execute({ skillId: 'proj-skill' }, ctx)
+
+    expect(result.success).toBe(true)
+    expect(result.output).toContain('Do project things.')
+    expect(loadAllSkills).toHaveBeenCalledWith('/test/config', '/my/project')
   })
 })

--- a/src/server/tools/load-skill.ts
+++ b/src/server/tools/load-skill.ts
@@ -20,7 +20,7 @@ export function formatSkillPrompt(skill: SkillDefinition): string {
   return `Skill package directory: ${skill.directory}\nResolve relative paths in these instructions from that directory.\n\n${skill.prompt}`
 }
 
-const handler: ToolHandler<LoadSkillArgs> = async (args, _context, helpers): Promise<ToolResult> => {
+const handler: ToolHandler<LoadSkillArgs> = async (args, context, helpers): Promise<ToolResult> => {
   const { skillId } = args
 
   if (!skillId) {
@@ -33,7 +33,7 @@ const handler: ToolHandler<LoadSkillArgs> = async (args, _context, helpers): Pro
 
   const config = getRuntimeConfig()
   const configDir = getGlobalConfigDir(config.mode ?? 'production')
-  const allSkills = await loadAllSkills(configDir, config.workdir)
+  const allSkills = await loadAllSkills(configDir, context.workdir)
   const skill = findSkillById(skillId, allSkills)
 
   if (!skill) {

--- a/web/src/components/settings/SkillsModal.tsx
+++ b/web/src/components/settings/SkillsModal.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { Button } from '../shared/Button'
 import { useSkillsStore, type SkillFull, type SkillInfo } from '../../stores/skills'
+import { useSessionStore } from '../../stores/session/store'
 import { useConfirmDialog, FormField, ErrorBanner, DestinationSelector } from './CRUDModal'
 import { ItemsHeader } from '../shared/ItemsHeader'
 import { CRUDListHeader } from './CRUDListHeader'
@@ -30,6 +31,7 @@ export function SkillsContent({ isOpen }: { isOpen: boolean }) {
   const diagnostics = useSkillsStore((state) => state.diagnostics)
   const loading = useSkillsStore((state) => state.loading)
   const fetchSkills = useSkillsStore((state) => state.fetchSkills)
+  const setWorkdir = useSkillsStore((state) => state.setWorkdir)
   const fetchSkill = useSkillsStore((state) => state.fetchSkill)
   const fetchDefaultContent = useSkillsStore((state) => state.fetchDefaultContent)
   const createSkill = useSkillsStore((state) => state.createSkill)
@@ -39,6 +41,7 @@ export function SkillsContent({ isOpen }: { isOpen: boolean }) {
   const removeDirectory = useSkillsStore((state) => state.removeDirectory)
   const installSkill = useSkillsStore((state) => state.installSkill)
   const toggleSkill = useSkillsStore((state) => state.toggleSkill)
+  const currentSession = useSessionStore((state) => state.currentSession)
   const [pendingDelete, setPendingDelete] = useState<SkillInfo | null>(null)
   const [deleting, setDeleting] = useState(false)
   const [deleteError, setDeleteError] = useState('')
@@ -50,12 +53,14 @@ export function SkillsContent({ isOpen }: { isOpen: boolean }) {
 
   useEffect(() => {
     if (isOpen) {
-      fetchSkills()
+      const sessionWorkdir = currentSession?.workdir ?? currentSession?.workspace ?? null
+      setWorkdir(sessionWorkdir)
+      fetchSkills(sessionWorkdir)
       setView('list')
       setEditingId(null)
       clearConfirm()
     }
-  }, [isOpen, fetchSkills, clearConfirm])
+  }, [isOpen, fetchSkills, setWorkdir, clearConfirm, currentSession?.workdir, currentSession?.workspace])
 
   const setSkillFormData = (skill: SkillFull, readOnly: boolean, newId?: string, newName?: string) => {
     setFormData({

--- a/web/src/stores/skills.ts
+++ b/web/src/stores/skills.ts
@@ -43,7 +43,9 @@ interface SkillsState {
   selectedDirectory: SelectedSkillDirectory | null
   diagnostics: string[]
   loading: boolean
-  fetchSkills: () => Promise<void>
+  workdir: string | null
+  setWorkdir: (workdir: string | null) => void
+  fetchSkills: (workdir?: string | null) => Promise<void>
   toggleSkill: (skillId: string) => Promise<void>
   fetchSkill: (skillId: string) => Promise<SkillFull | null>
   fetchDefaultContent: (skillId: string) => Promise<SkillFull | null>
@@ -74,6 +76,11 @@ async function mutateSkills(
   }
 }
 
+function skillsUrl(path: string, workdir?: string | null): string {
+  if (workdir) return `${path}?workdir=${encodeURIComponent(workdir)}`
+  return path
+}
+
 export const useSkillsStore = create<SkillsState>((set, get) => ({
   defaults: [],
   userItems: [],
@@ -82,11 +89,17 @@ export const useSkillsStore = create<SkillsState>((set, get) => ({
   selectedDirectory: null,
   diagnostics: [],
   loading: false,
+  workdir: null,
 
-  fetchSkills: async () => {
+  setWorkdir: (workdir) => {
+    set({ workdir })
+  },
+
+  fetchSkills: async (workdir?: string | null) => {
+    const wd = workdir ?? get().workdir
     set({ loading: true })
     try {
-      const res = await authFetch('/api/skills')
+      const res = await authFetch(skillsUrl('/api/skills', wd))
       const data = await res.json()
       set({
         defaults: data.defaults ?? [],
@@ -104,7 +117,7 @@ export const useSkillsStore = create<SkillsState>((set, get) => ({
 
   toggleSkill: async (skillId: string) => {
     try {
-      const res = await authFetch(`/api/skills/${skillId}/toggle`, { method: 'POST' })
+      const res = await authFetch(skillsUrl(`/api/skills/${skillId}/toggle`, get().workdir), { method: 'POST' })
       const data = await res.json()
       set((state) => ({
         defaults: state.defaults.map((s) => (s.id === skillId ? { ...s, enabled: data.enabled } : s)),
@@ -119,7 +132,7 @@ export const useSkillsStore = create<SkillsState>((set, get) => ({
 
   fetchSkill: async (skillId: string) => {
     try {
-      const res = await authFetch(`/api/skills/${skillId}`)
+      const res = await authFetch(skillsUrl(`/api/skills/${skillId}`, get().workdir))
       if (!res.ok) return null
       return (await res.json()) as SkillFull
     } catch {
@@ -138,7 +151,7 @@ export const useSkillsStore = create<SkillsState>((set, get) => ({
   },
 
   createSkill: async (skill: SkillFull, destination?: 'project' | 'user') => {
-    const result = await saveEntity('POST', '/api/skills', {
+    const result = await saveEntity('POST', skillsUrl('/api/skills', get().workdir), {
       ...skill,
       destination,
     } as unknown as Record<string, unknown>)
@@ -147,14 +160,18 @@ export const useSkillsStore = create<SkillsState>((set, get) => ({
   },
 
   updateSkill: async (id: string, skill: Partial<SkillFull>) => {
-    const result = await saveEntity('PUT', `/api/skills/${id}`, skill as unknown as Record<string, unknown>)
+    const result = await saveEntity(
+      'PUT',
+      skillsUrl(`/api/skills/${id}`, get().workdir),
+      skill as unknown as Record<string, unknown>,
+    )
     if (result.success) await get().fetchSkills()
     return result
   },
 
   deleteSkill: async (skillId: string) => {
     try {
-      const res = await authFetch(`/api/skills/${skillId}`, { method: 'DELETE' })
+      const res = await authFetch(skillsUrl(`/api/skills/${skillId}`, get().workdir), { method: 'DELETE' })
       const data = await res.json()
       if (res.ok) {
         set((state) => ({
@@ -169,7 +186,11 @@ export const useSkillsStore = create<SkillsState>((set, get) => ({
   },
 
   duplicateSkill: async (skillId: string, destination?: 'project' | 'user') => {
-    return duplicateEntity(`/api/skills/${skillId}/duplicate`, () => get().fetchSkills(), destination)
+    return duplicateEntity(
+      skillsUrl(`/api/skills/${skillId}/duplicate`, get().workdir),
+      () => get().fetchSkills(),
+      destination,
+    )
   },
 
   selectDirectory: async (path) => {


### PR DESCRIPTION
### Summary

Skills defined in project directories (.agents/skills/, .openfox/skills/) were not visible to agents because runtimeConfig.workdir (the global server working directory) was used instead of session.workdir (the actual project).

Changes:
- agent-loop, orchestrator, dynamic-context, sub-agents/manager: use session.workdir/effectiveWorkdir for getEnabledSkillMetadata
- load-skill tool: use context.workdir from ToolContext
- API /api/skills: accept optional ?workdir= query param with fallback to server projectDir; extracted shared resolveProjectDir helper
- Frontend skills store: pass currentSession.workdir via ?workdir=
- Tests: added coverage for all modified paths

### AI-Enhanced Development

- **AI Models:** DeepSeek V4 

### Cache Impact

Yes — the list of skills injected into the system prompt changes: instead of using runtimeConfig.workdir (global server workdir), it now uses session.workdir (the actual project directory). This means:

- The dynamic context hash (computeDynamicContextHash) may differ for existing sessions since skill IDs change (project skills become newly visible)
- The frontend will show a "dynamic context changed" banner for open sessions — this is expected behavior, verified by the context-check-dynamic.test.ts e2e test
- Tool definitions and sub-agents are unaffected

