### PR TITLE
perf: speed up session loading and rendering (snapshot truncation, server caches, feed virtualization, markdown fast path)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,8 @@
         "multer": "^2.2.0",
         "node-pty": "^1.2.0-beta.12",
         "open": "^11.0.0",
+        "overlayscrollbars": "^2.16.0",
+        "overlayscrollbars-react": "^0.5.6",
         "pdfjs-dist": "^6.1.200",
         "pngjs": "^7.0.0",
         "pyright": "^1.1.408",
@@ -11150,6 +11152,22 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/overlayscrollbars": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/overlayscrollbars/-/overlayscrollbars-2.16.0.tgz",
+      "integrity": "sha512-N03oje/q7j93D0aLZtoCdsDSYLmhheSsv8H7oSLE7HhdV9P/bmCURtLV/KbPye7P/bpfyt/obSfDpGUYoJ0OWg==",
+      "license": "MIT"
+    },
+    "node_modules/overlayscrollbars-react": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/overlayscrollbars-react/-/overlayscrollbars-react-0.5.6.tgz",
+      "integrity": "sha512-E5To04bL5brn9GVCZ36SnfGanxa2I2MDkWoa4Cjo5wol7l+diAgi4DBc983V7l2nOk/OLJ6Feg4kySspQEGDBw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "overlayscrollbars": "^2.0.0",
+        "react": ">=16.8.0"
       }
     },
     "node_modules/own-keys": {

--- a/package.json
+++ b/package.json
@@ -86,6 +86,8 @@
     "multer": "^2.2.0",
     "node-pty": "^1.2.0-beta.12",
     "open": "^11.0.0",
+    "overlayscrollbars": "^2.16.0",
+    "overlayscrollbars-react": "^0.5.6",
     "pdfjs-dist": "^6.1.200",
     "pngjs": "^7.0.0",
     "pyright": "^1.1.408",

--- a/src/server/events/fold-state.ts
+++ b/src/server/events/fold-state.ts
@@ -11,6 +11,7 @@ import type {
   MessageStatsEntry,
   CompactionRecord,
   SnapshotMessage,
+  ToolCallWithResult,
 } from './types.js'
 import type { FormatRetry } from './apply-events.js'
 import type { WorkflowWaitingPayload } from '../../shared/protocol.js'
@@ -406,16 +407,59 @@ export function foldWaitingWorkflow(events: EventLike[]): FoldedSessionState['wa
   return waitingWorkflow
 }
 
+// Maximum retained streaming output per finished tool call in a snapshot.
+// RunCommandView only renders `result` once a command is done — the raw
+// stdout/stderr stream is never displayed afterwards — so persisting it in
+// full just bloats the snapshot (a single long session accumulated 41MB).
+// The threshold is deliberately high (1MB) so ordinary command outputs keep
+// their full stream in the snapshot (the data contract for CLI/mobile
+// clients); only pathological outputs (giant builds, log dumps) are trimmed
+// to the tail, and the raw tool.output events remain the source of truth
+// until cleanupOldEvents prunes them.
+export const SNAPSHOT_STREAMING_TAIL_BYTES = 1024 * 1024
+
+function truncateSnapshotStreamingOutput(messages: SnapshotMessage[]): SnapshotMessage[] {
+  return messages.map((message) => {
+    const toolCalls = message.toolCalls
+    if (!toolCalls) return message
+    let changed = false
+    const newToolCalls = toolCalls.map((tc) => {
+      if (!tc.streamingOutput || tc.streamingOutput.length === 0) return tc
+      // Finished calls (with a result) no longer need the live stream —
+      // keep only the tail. Pending calls keep everything (reload while running).
+      if (tc.result === undefined) return tc
+      let total = 0
+      for (const chunk of tc.streamingOutput) total += chunk.content.length
+      if (total <= SNAPSHOT_STREAMING_TAIL_BYTES) return tc
+      const kept: typeof tc.streamingOutput = []
+      let keptBytes = 0
+      for (let i = tc.streamingOutput.length - 1; i >= 0 && keptBytes < SNAPSHOT_STREAMING_TAIL_BYTES; i--) {
+        const chunk = tc.streamingOutput[i]!
+        kept.unshift(chunk)
+        keptBytes += chunk.content.length
+      }
+      changed = true
+      return { ...tc, streamingOutput: kept, streamingOutputTruncated: true } satisfies ToolCallWithResult
+    })
+    if (!changed) return message
+    return { ...message, toolCalls: newToolCalls }
+  })
+}
+
 export function buildSnapshot(
   foldedState: FoldedSessionState,
   latestSeq: number,
   snapshotAt: number = Date.now(),
 ): SessionSnapshot {
+  // The snapshot is the hot path loaded on every session open — trim the
+  // never-displayed streaming output before persisting it. The function
+  // returns new objects for any modified messages so foldedState is not mutated.
+  const messages = truncateSnapshotStreamingOutput(foldedState.messages)
   return {
     mode: foldedState.mode,
     phase: foldedState.phase,
     isRunning: foldedState.isRunning,
-    messages: foldedState.messages,
+    messages,
     criteria: foldedState.criteria,
     metadataEntries: foldedState.metadataEntries,
     contextState: foldedState.contextState,
@@ -474,12 +518,16 @@ export function buildSnapshotFromSessionState(input: {
         events.slice(latestSnapshotIndex + 1),
       )
     : foldedState.messages
+  // The snapshot is the hot path loaded on every session open — trim the
+  // never-displayed streaming output before persisting it. The function
+  // returns new objects for modified messages so the source arrays are not mutated.
+  const trimmedMessages = truncateSnapshotStreamingOutput(messages)
 
   return {
     mode: session.mode,
     phase: session.phase,
     isRunning: session.isRunning,
-    messages,
+    messages: trimmedMessages,
     criteria: session.criteria,
     metadataEntries: foldedState.metadataEntries,
     contextState: {

--- a/src/server/events/folding.test.ts
+++ b/src/server/events/folding.test.ts
@@ -5,6 +5,7 @@ import {
   buildContextMessagesFromEventHistory,
   buildContextMessagesFromStoredEvents,
   buildMessagesFromStoredEvents,
+  buildSnapshot,
   buildSnapshotFromSessionState,
   foldContextState,
   foldSessionState,
@@ -2697,5 +2698,88 @@ describe('foldSessionState metadataEntries snapshot fallback merge', () => {
 
     // foldMetadata returns {} by default; snapshot has no metadataEntries → result should be {}
     expect(state.metadataEntries).toEqual({})
+  })
+})
+
+describe('buildSnapshot streamingOutput truncation', () => {
+  const baseEvent = { seq: 0, timestamp: 1000, sessionId: 's1' }
+
+  function makeEvents(streamChunks: number, chunkSize: number, withResult: boolean): StoredEvent[] {
+    const events: StoredEvent[] = [
+      { ...baseEvent, type: 'message.start', data: { messageId: 'm1', role: 'assistant' } },
+      {
+        ...baseEvent,
+        type: 'tool.call',
+        data: { messageId: 'm1', toolCall: { id: 'call-1', name: 'run_command', arguments: {} } },
+      },
+    ]
+    for (let i = 0; i < streamChunks; i++) {
+      events.push({
+        ...baseEvent,
+        type: 'tool.output',
+        data: {
+          messageId: 'm1',
+          toolCallId: 'call-1',
+          stream: 'stdout',
+          content: `chunk-${String(i).padStart(5, '0')}:` + 'x'.repeat(Math.max(0, chunkSize - 12)),
+        },
+      })
+    }
+    if (withResult) {
+      events.push({
+        ...baseEvent,
+        type: 'tool.result',
+        data: {
+          messageId: 'm1',
+          toolCallId: 'call-1',
+          result: { success: true, output: 'Done', durationMs: 1, truncated: false },
+        },
+      })
+    }
+    return events
+  }
+
+  it('truncates streamingOutput of finished tool calls to the tail + marker', () => {
+    // 1100 chunks × 1KB ≈ 1.1MB, above the 1MB tail budget
+    const state = foldSessionState(makeEvents(1100, 1024, true), 'window-1', 200000)
+    const snapshot = buildSnapshot(state, 100)
+
+    const tc = snapshot.messages[0]!.toolCalls![0]!
+    const joined = tc.streamingOutput?.map((c) => c.content).join('') ?? ''
+    expect(joined.length).toBeLessThanOrEqual(1024 * 1024 + 1024)
+    expect(joined.endsWith('chunk-01099:' + 'x'.repeat(1024 - 12))).toBe(true) // tail preserved
+    expect(joined.startsWith('chunk-00000:')).toBe(false) // head dropped
+    expect(tc.streamingOutputTruncated).toBe(true)
+  })
+
+  it('keeps streamingOutput integral for pending tool calls (no result yet)', () => {
+    const state = foldSessionState(makeEvents(1100, 1024, false), 'window-1', 200000)
+    const snapshot = buildSnapshot(state, 100)
+
+    const tc = snapshot.messages[0]!.toolCalls![0]!
+    const joined = tc.streamingOutput?.map((c) => c.content).join('') ?? ''
+    expect(joined.length).toBe(1100 * 1024)
+    expect(tc.streamingOutputTruncated).toBeUndefined()
+  })
+
+  it('keeps short streamingOutput untouched for finished tool calls', () => {
+    // 500KB — under the 1MB budget, nothing is truncated
+    const state = foldSessionState(makeEvents(500, 1024, true), 'window-1', 200000)
+    const snapshot = buildSnapshot(state, 100)
+
+    const tc = snapshot.messages[0]!.toolCalls![0]!
+    const joined = tc.streamingOutput?.map((c) => c.content).join('') ?? ''
+    expect(joined.length).toBe(500 * 1024)
+    expect(tc.streamingOutputTruncated).toBeUndefined()
+  })
+
+  it('does not mutate foldedState when building a snapshot', () => {
+    const state = foldSessionState(makeEvents(1100, 1024, true), 'window-1', 200000)
+    const originalLength = state.messages[0]!.toolCalls![0]!.streamingOutput!.length
+
+    buildSnapshot(state, 100)
+
+    expect(state.messages[0]!.toolCalls![0]!.streamingOutput!.length).toBe(originalLength)
+    expect(state.messages[0]!.toolCalls![0]!.streamingOutputTruncated).toBeUndefined()
   })
 })

--- a/src/server/events/session.ts
+++ b/src/server/events/session.ts
@@ -677,13 +677,15 @@ export function truncateSessionMessages(sessionId: string, messageIndex: number)
   const lastKept = messageIndex + 1
   if (lastKept < 0 || lastKept >= messages.length) return
 
-  snapshot.messages = messages.slice(0, lastKept)
+  // Clone before mutating: the snapshot object is shared with the in-memory
+  // snapshot cache, and the cache is only invalidated by the append below.
+  const truncatedSnapshot = { ...snapshot, messages: messages.slice(0, lastKept) }
 
   eventStore.deleteEventsAfterSeq(sessionId, snapshotEvent.seq)
 
   eventStore.append(sessionId, {
     type: 'turn.snapshot',
-    data: snapshot,
+    data: truncatedSnapshot,
   })
 
   const removed = messages.length - lastKept
@@ -708,91 +710,7 @@ export function getRecentUserPromptsForSession(
 ): { id: string; content: string; timestamp: string }[] {
   try {
     const eventStore = getEventStore()
-    const db = (eventStore as unknown as { db?: import('better-sqlite3').Database }).db
-
-    // If no db available (e.g., in tests), return empty array
-    if (!db) {
-      return []
-    }
-
-    const isRealUserMessage = (msg: {
-      role: string
-      isSystemGenerated?: boolean
-      messageKind?: string
-      subAgentType?: string
-    }) => msg.role === 'user' && !msg.isSystemGenerated && !msg.messageKind && !msg.subAgentType
-
-    // Collect user prompts from both snapshots and message.start events.
-    // After a snapshot is created, older message.start events may be deleted,
-    // so we must extract messages from the latest snapshot as well.
-    const promptMap = new Map<string, { id: string; content: string; timestamp: string }>()
-
-    // 1. Extract user messages from the latest snapshot (if any)
-    const snapshotRow = db
-      .prepare(
-        `
-        SELECT payload, timestamp
-        FROM events
-        WHERE session_id = ? AND event_type = 'turn.snapshot'
-        ORDER BY timestamp DESC
-        LIMIT 1
-      `,
-      )
-      .get(sessionId) as { payload: string; timestamp: number } | undefined
-
-    if (snapshotRow) {
-      const snapshot = JSON.parse(snapshotRow.payload) as {
-        messages: Array<{
-          id: string
-          role: string
-          content: string
-          timestamp: number
-          isSystemGenerated?: boolean
-          messageKind?: string
-          subAgentType?: string
-        }>
-      }
-      for (const msg of snapshot.messages) {
-        if (isRealUserMessage(msg)) {
-          promptMap.set(msg.id, {
-            id: msg.id,
-            content: msg.content,
-            timestamp: new Date(msg.timestamp).toISOString(),
-          })
-        }
-      }
-    }
-
-    // 2. Add/override with message.start events (these may be newer than the snapshot)
-    const rows = db
-      .prepare(
-        `
-        SELECT payload, timestamp
-        FROM events
-        WHERE session_id = ? AND event_type = 'message.start'
-          AND json_extract(payload, '$.role') = 'user'
-          AND json_extract(payload, '$.isSystemGenerated') IS NULL
-          AND json_extract(payload, '$.messageKind') IS NULL
-          AND json_extract(payload, '$.subAgentType') IS NULL
-        ORDER BY timestamp DESC
-        LIMIT ?
-      `,
-      )
-      .all(sessionId, limit) as { payload: string; timestamp: number }[]
-
-    for (const row of rows) {
-      const message = JSON.parse(row.payload) as { messageId: string; content: string }
-      promptMap.set(message.messageId, {
-        id: message.messageId,
-        content: message.content,
-        timestamp: new Date(row.timestamp).toISOString(),
-      })
-    }
-
-    // Sort by timestamp descending (newest first) and take top N
-    return [...promptMap.values()]
-      .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime())
-      .slice(0, limit)
+    return eventStore.getRecentUserPrompts(sessionId, limit)
   } catch {
     // If any error occurs (e.g., in tests), return empty array
     return []

--- a/src/server/events/store.test.ts
+++ b/src/server/events/store.test.ts
@@ -1618,4 +1618,65 @@ describe('EventStore - Event Cleanup', () => {
       expect(orphaned).not.toContain(sessionId)
     })
   })
+
+  describe('snapshot cache invalidation', () => {
+    const snapshotData = (mode: string, snapshotSeq: number) => ({
+      mode,
+      phase: 'plan' as const,
+      isRunning: false,
+      messages: [],
+      criteria: [],
+      metadataEntries: {},
+      contextState: {
+        currentTokens: 0,
+        maxTokens: 200000,
+        compactionCount: 0,
+        dangerZone: false,
+        canCompact: false,
+        dynamicContextChanged: false,
+      },
+      currentContextWindowId: 'window-1',
+      todos: [],
+      readFiles: [],
+      snapshotSeq,
+      snapshotAt: Date.now(),
+    })
+
+    it('serves the cached snapshot until an append invalidates it', () => {
+      store.append('session-1', { type: 'turn.snapshot', data: snapshotData('planner', 1) })
+      const first = store.getLatestSnapshot('session-1')
+      expect(first!.data.mode).toBe('planner')
+
+      // Second read comes from cache — same object identity
+      expect(store.getLatestSnapshot('session-1')).toBe(first)
+
+      store.append('session-1', { type: 'turn.snapshot', data: snapshotData('builder', 2) })
+      const second = store.getLatestSnapshot('session-1')
+      expect(second).toBeDefined()
+      expect(second!.data.mode).toBe('builder')
+      expect(second).not.toBe(first)
+    })
+
+    it('refreshes recent user prompts after an append', () => {
+      store.append('session-1', {
+        type: 'turn.snapshot',
+        data: {
+          ...snapshotData('planner', 1),
+          messages: [{ id: 'm1', role: 'user', content: 'First', timestamp: 1000 }],
+        },
+      })
+
+      const prompts = store.getRecentUserPrompts('session-1', 10)
+      expect(prompts.map((p) => p.id)).toEqual(['m1'])
+
+      store.append('session-1', {
+        type: 'message.start',
+        data: { messageId: 'm2', role: 'user', content: 'Second' },
+      })
+
+      const refreshed = store.getRecentUserPrompts('session-1', 10)
+      expect(refreshed.map((p) => p.id)).toContain('m2')
+      expect(refreshed).not.toEqual(prompts)
+    })
+  })
 })

--- a/src/server/events/store.ts
+++ b/src/server/events/store.ts
@@ -134,6 +134,22 @@ export class EventStore {
   private subscribers: Map<string, Set<Subscriber>> = new Map()
   private globalSubscribers: Map<number, GlobalSubscriber> = new Map()
   private globalSubscriberIdCounter = 0
+  // Parsed latest-snapshot cache per session. Snapshots can be tens of MB of
+  // JSON; re-parsing them on every session load (REST, WS, sidebar list) costs
+  // hundreds of ms. Invalidated on every write path (append, delete, cleanup).
+  // This is a pragmatic stopgap: the real fix is shrinking the 47MB snapshots
+  // themselves (compaction refactor, out of scope) — the cache hides the cost
+  // without removing it.
+  private snapshotCache: Map<string, { stored: StoredEvent; bytes: number }> = new Map()
+  private snapshotCacheBytes = 0
+  private static readonly SNAPSHOT_CACHE_MAX_ENTRIES = 16
+  private static readonly SNAPSHOT_CACHE_MAX_BYTES = 128 * 1024 * 1024
+  // Recent user prompts per session (sidebar list). Computed once from the
+  // snapshot + message.start events, then served from memory. Bounded — small
+  // arrays, but a long-lived server must not accumulate one per listed
+  // session; entries are also dropped when their session is written to.
+  private promptsCache: Map<string, Array<{ id: string; content: string; timestamp: string }>> = new Map()
+  private static readonly PROMPTS_CACHE_MAX_ENTRIES = 64
 
   constructor(db: Database.Database) {
     this.db = db
@@ -211,6 +227,8 @@ export class EventStore {
       )
       .run(sessionId, seq, timestamp, event.type, payload)
 
+    this.invalidateSessionCache(sessionId)
+
     const stored: StoredEvent = {
       seq,
       timestamp,
@@ -258,6 +276,8 @@ export class EventStore {
 
     transaction()
 
+    this.invalidateSessionCache(sessionId)
+
     // Notify after transaction commits
     for (const stored of results) {
       this.notifySubscribers(sessionId, stored)
@@ -268,8 +288,7 @@ export class EventStore {
 
   private getNextSeq(sessionId: string): number {
     const row = this.db.prepare(`SELECT MAX(seq) as max_seq FROM events WHERE session_id = ?`).get(sessionId) as
-      | { max_seq: number | null }
-      | undefined
+      { max_seq: number | null } | undefined
 
     return (row?.max_seq ?? 0) + 1
   }
@@ -338,6 +357,7 @@ export class EventStore {
     this.db
       .prepare(`UPDATE events SET payload = ? WHERE session_id = ? AND seq = ?`)
       .run(JSON.stringify(data), sessionId, seq)
+    this.invalidateSessionCache(sessionId)
   }
 
   /**
@@ -345,8 +365,7 @@ export class EventStore {
    */
   getLatestSeq(sessionId: string): number | undefined {
     const row = this.db.prepare(`SELECT MAX(seq) as max_seq FROM events WHERE session_id = ?`).get(sessionId) as
-      | { max_seq: number | null }
-      | undefined
+      { max_seq: number | null } | undefined
 
     return row?.max_seq ?? undefined
   }
@@ -355,6 +374,11 @@ export class EventStore {
    * Get the latest snapshot event for a session
    */
   getLatestSnapshot(sessionId: string): StoredEvent<Extract<TurnEvent, { type: 'turn.snapshot' }>> | undefined {
+    const cached = this.snapshotCache.get(sessionId)
+    if (cached) {
+      return cached.stored as StoredEvent<Extract<TurnEvent, { type: 'turn.snapshot' }>>
+    }
+
     const row = this.db
       .prepare(
         `SELECT * FROM events 
@@ -365,7 +389,127 @@ export class EventStore {
 
     if (!row) return undefined
 
-    return this.rowToStoredEvent(row) as StoredEvent<Extract<TurnEvent, { type: 'turn.snapshot' }>>
+    const stored = this.rowToStoredEvent(row) as StoredEvent<Extract<TurnEvent, { type: 'turn.snapshot' }>>
+    this.cacheSnapshot(sessionId, stored, row.payload.length)
+    return stored
+  }
+
+  private cacheSnapshot(sessionId: string, stored: StoredEvent, bytes: number): void {
+    const existing = this.snapshotCache.get(sessionId)
+    if (existing) {
+      this.snapshotCacheBytes -= existing.bytes
+    }
+    this.snapshotCache.set(sessionId, { stored, bytes })
+    this.snapshotCacheBytes += bytes
+
+    while (
+      this.snapshotCache.size > EventStore.SNAPSHOT_CACHE_MAX_ENTRIES ||
+      this.snapshotCacheBytes > EventStore.SNAPSHOT_CACHE_MAX_BYTES
+    ) {
+      const oldestKey = this.snapshotCache.keys().next().value
+      if (oldestKey === undefined || oldestKey === sessionId) break
+      const oldest = this.snapshotCache.get(oldestKey)
+      if (oldest) {
+        this.snapshotCacheBytes -= oldest.bytes
+      }
+      this.snapshotCache.delete(oldestKey)
+    }
+  }
+
+  private invalidateSessionCache(sessionId: string): void {
+    const entry = this.snapshotCache.get(sessionId)
+    if (entry) {
+      this.snapshotCacheBytes -= entry.bytes
+      this.snapshotCache.delete(sessionId)
+    }
+    this.promptsCache.delete(sessionId)
+  }
+
+  private clearSnapshotCache(): void {
+    this.snapshotCache.clear()
+    this.snapshotCacheBytes = 0
+    this.promptsCache.clear()
+  }
+
+  /**
+   * Get the most recent real user prompts for a session, cached in memory.
+   * Extracts them from the latest snapshot (when present) plus recent
+   * message.start events. Parsing a multi-MB snapshot on every sidebar list
+   * call dominated the list endpoint, so the result is memoized per session.
+   */
+  getRecentUserPrompts(sessionId: string, limit: number): Array<{ id: string; content: string; timestamp: string }> {
+    const cached = this.promptsCache.get(sessionId)
+    if (cached) {
+      return cached.slice(0, limit)
+    }
+
+    const isRealUserMessage = (msg: {
+      role: string
+      isSystemGenerated?: boolean
+      messageKind?: string
+      subAgentType?: string
+    }) => msg.role === 'user' && !msg.isSystemGenerated && !msg.messageKind && !msg.subAgentType
+
+    const promptMap = new Map<string, { id: string; content: string; timestamp: string }>()
+
+    const snapshotEvent = this.getLatestSnapshot(sessionId)
+    if (snapshotEvent) {
+      const snapshot = snapshotEvent.data as {
+        messages: Array<{
+          id: string
+          role: string
+          content: string
+          timestamp: number
+          isSystemGenerated?: boolean
+          messageKind?: string
+          subAgentType?: string
+        }>
+      }
+      for (const msg of snapshot.messages) {
+        if (isRealUserMessage(msg)) {
+          promptMap.set(msg.id, {
+            id: msg.id,
+            content: msg.content,
+            timestamp: new Date(msg.timestamp).toISOString(),
+          })
+        }
+      }
+    }
+
+    const rows = this.db
+      .prepare(
+        `
+        SELECT payload, timestamp
+        FROM events
+        WHERE session_id = ? AND event_type = 'message.start'
+          AND json_extract(payload, '$.role') = 'user'
+          AND json_extract(payload, '$.isSystemGenerated') IS NULL
+          AND json_extract(payload, '$.messageKind') IS NULL
+          AND json_extract(payload, '$.subAgentType') IS NULL
+        ORDER BY timestamp DESC
+        LIMIT ?
+      `,
+      )
+      .all(sessionId, limit) as { payload: string; timestamp: number }[]
+
+    for (const row of rows) {
+      const message = JSON.parse(row.payload) as { messageId: string; content: string }
+      promptMap.set(message.messageId, {
+        id: message.messageId,
+        content: message.content,
+        timestamp: new Date(row.timestamp).toISOString(),
+      })
+    }
+
+    const prompts = [...promptMap.values()]
+      .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime())
+      .slice(0, limit)
+    this.promptsCache.set(sessionId, prompts)
+    if (this.promptsCache.size > EventStore.PROMPTS_CACHE_MAX_ENTRIES) {
+      const oldestKey = this.promptsCache.keys().next().value
+      if (oldestKey !== undefined) this.promptsCache.delete(oldestKey)
+    }
+    return prompts
   }
 
   /**
@@ -550,6 +694,7 @@ export class EventStore {
    */
   deleteSession(sessionId: string): void {
     this.db.prepare(`DELETE FROM events WHERE session_id = ?`).run(sessionId)
+    this.invalidateSessionCache(sessionId)
 
     // Close all subscribers for this session
     const sessionSubs = this.subscribers.get(sessionId)
@@ -572,6 +717,7 @@ export class EventStore {
    */
   deleteEventsUpToSeq(sessionId: string, upToSeq: number): number {
     const result = this.db.prepare(`DELETE FROM events WHERE session_id = ? AND seq <= ?`).run(sessionId, upToSeq)
+    this.invalidateSessionCache(sessionId)
 
     return result.changes as number
   }
@@ -587,6 +733,7 @@ export class EventStore {
    */
   deleteEventsAfterSeq(sessionId: string, fromSeq: number): number {
     const result = this.db.prepare(`DELETE FROM events WHERE session_id = ? AND seq > ?`).run(sessionId, fromSeq)
+    this.invalidateSessionCache(sessionId)
 
     return result.changes as number
   }
@@ -635,6 +782,8 @@ export class EventStore {
       )
       .run(sessionId, latestSnapshotSeq)
 
+    this.invalidateSessionCache(sessionId)
+
     return result.changes as number
   }
 
@@ -660,6 +809,8 @@ export class EventStore {
       `,
       )
       .run()
+
+    this.clearSnapshotCache()
 
     return { deletedSnapshots: deleteResult.changes as number }
   }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -31,6 +31,7 @@ import { createServerMessage } from '../shared/protocol.js'
 import { createContextStateMessage } from './ws/protocol.js'
 import { createWebSocketServer } from './ws/index.js'
 import { SessionManager } from './session/manager.js'
+import { toClientSession } from './session/client-session.js'
 import { setRuntimeConfig } from './runtime-config.js'
 import { createSkillRoutes } from './routes/skills.js'
 import { createCommandRoutes } from './routes/commands.js'
@@ -751,7 +752,7 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
         },
       },
     })
-    res.status(201).json({ session })
+    res.status(201).json({ session: toClientSession(session) })
   })
 
   /** Switch to a workspace — target is "original" or a workspace name */
@@ -771,7 +772,7 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
 
     try {
       const updated = await sessionManager.switchWorkspace(req.params.id, target, branch, sourceBranch)
-      res.json({ session: updated })
+      res.json({ session: toClientSession(updated) })
     } catch (err) {
       res.status(400).json({ error: err instanceof Error ? err.message : 'Failed to switch workspace' })
     }
@@ -794,7 +795,7 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
 
     try {
       const updated = await sessionManager.deleteWorkspace(req.params.id, target, force === true)
-      res.json({ session: updated })
+      res.json({ session: toClientSession(updated) })
     } catch (err) {
       if (err instanceof WorkspaceInUseError) {
         return res.status(409).json({
@@ -843,7 +844,7 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
     const activeWorkflowExecution = sessionManager.getActiveWorkflowExecution(req.params.id)
 
     res.json({
-      session,
+      session: toClientSession(session!),
       messages,
       hiddenCount,
       contextState,
@@ -930,7 +931,7 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
     const { messages, hiddenCount } = buildMessagesFromStoredEvents(events, maxVisibleItems || undefined)
     const updatedSession = sessionManager.getSession(sessionId)
 
-    res.json({ session: updatedSession, messages, hiddenCount, contextState })
+    res.json({ session: toClientSession(updatedSession!), messages, hiddenCount, contextState })
   })
 
   // Set global default model (persisted to config, used for new sessions)
@@ -1099,7 +1100,7 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
     const { messages, hiddenCount } = buildMessagesFromStoredEvents(events, maxVisibleItems || undefined)
     const updatedSession = sessionManager.getSession(sessionId)
 
-    res.json({ session: updatedSession, messages, hiddenCount })
+    res.json({ session: toClientSession(updatedSession!), messages, hiddenCount })
   })
 
   // Danger level (REST)
@@ -1118,7 +1119,7 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
     sessionManager.setDangerLevel(sessionId, dangerLevel)
     const updatedSession = sessionManager.getSession(sessionId)
 
-    res.json({ session: updatedSession })
+    res.json({ session: toClientSession(updatedSession!) })
   })
 
   // Session MCP server overrides (per-session)
@@ -1164,7 +1165,7 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
 
     sessionManager.renameSession(sessionId, title.slice(0, 100))
     const updatedSession = sessionManager.getSession(sessionId)
-    res.json({ session: updatedSession })
+    res.json({ session: toClientSession(updatedSession!) })
   })
 
   // Path confirmation (REST)
@@ -1476,7 +1477,7 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
 
     try {
       const newSession = sessionManager.forkSession(sessionId, messageId, title)
-      return res.status(201).json({ session: newSession })
+      return res.status(201).json({ session: toClientSession(newSession) })
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
       if (message.includes('not found')) {

--- a/src/server/session/client-session.test.ts
+++ b/src/server/session/client-session.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import { toClientSession } from './client-session.js'
+
+describe('toClientSession', () => {
+  it('empties messages and preserves other fields', () => {
+    const session = {
+      id: 's1',
+      projectId: 'p1',
+      workdir: '/tmp/p1',
+      mode: 'builder',
+      phase: 'build',
+      isRunning: true,
+      criteria: [],
+      metadataEntries: {},
+      contextWindows: [],
+      executionState: null,
+      messageCount: 12,
+      messages: [{ id: 'm1' }],
+    } as any
+
+    const result = toClientSession(session)
+
+    expect(result.messages).toEqual([])
+    expect(result.messageCount).toBe(12)
+    expect(result.mode).toBe('builder')
+    expect(result.phase).toBe('build')
+    expect(result.isRunning).toBe(true)
+  })
+
+  it('falls back to messages.length when messageCount is absent', () => {
+    const session = {
+      id: 's1',
+      messages: [{ id: 'm1' }, { id: 'm2' }],
+    } as any
+
+    const result = toClientSession(session)
+
+    expect(result.messages).toEqual([])
+    expect(result.messageCount).toBe(2)
+  })
+
+  it('does not mutate the original session object', () => {
+    const session = {
+      id: 's1',
+      messageCount: 3,
+      messages: [{ id: 'm1' }],
+    } as any
+
+    toClientSession(session)
+
+    expect(session.messages).toHaveLength(1)
+    expect(session.messageCount).toBe(3)
+  })
+})

--- a/src/server/session/client-session.ts
+++ b/src/server/session/client-session.ts
@@ -1,0 +1,16 @@
+import type { Session } from '../../shared/types.js'
+
+/**
+ * Build the Session object sent to clients.
+ * Full messages travel in the dedicated `messages` payload field (already
+ * truncated server-side); embedding them again in `session.messages` would
+ * double the payload for long sessions. `messageCount` is guaranteed so the
+ * client can rely on it instead of `messages.length`.
+ */
+export function toClientSession(session: Session): Session {
+  return {
+    ...session,
+    messageCount: session.messageCount ?? session.messages.length,
+    messages: [],
+  }
+}

--- a/src/server/ws/protocol.test.ts
+++ b/src/server/ws/protocol.test.ts
@@ -112,7 +112,7 @@ describe('ws/protocol', () => {
         id: 'corr-1',
         type: 'session.state',
         payload: {
-          session,
+          session: { ...session, messageCount: 0, messages: [] },
           messages: [
             {
               ...assistantMessage,

--- a/src/server/ws/protocol.ts
+++ b/src/server/ws/protocol.ts
@@ -129,7 +129,7 @@ export function createSessionStateMessage(
   return createServerMessage(
     'session.state',
     {
-      session,
+      session: toClientSession(session),
       messages: enrichedMessages,
       pendingConfirmations,
       ...(pendingQuestions ? { pendingQuestions } : {}),
@@ -407,6 +407,7 @@ export function createQueueStateMessage(messages: QueuedMessage[]): ServerMessag
 // ============================================================================
 
 import type { StoredEvent, TurnEvent } from '../events/types.js'
+import { toClientSession } from '../session/client-session.js'
 
 /**
  * Convert a StoredEvent from EventStore to a ServerMessage for WebSocket.

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -138,9 +138,7 @@ export type MessageRole = 'user' | 'assistant' | 'system' | 'tool'
 
 // Segment types for preserving streaming order
 export type MessageSegment =
-  | { type: 'text'; content: string }
-  | { type: 'thinking'; content: string }
-  | { type: 'tool_call'; toolCallId: string }
+  { type: 'text'; content: string } | { type: 'thinking'; content: string } | { type: 'tool_call'; toolCallId: string }
 
 export interface MessageStats {
   providerId: string
@@ -336,6 +334,10 @@ export interface ToolCall {
   result?: ToolResult // Attached after execution (during streaming or enriched on load)
   startedAt?: number // Timestamp when tool started (for timeout display, transient)
   streamingOutput?: Array<{ stream: 'stdout' | 'stderr'; content: string; timestamp: number }> // Real-time output (transient, run_command only)
+  // Set when streamingOutput was truncated when building a snapshot: the full
+  // live stream lives in the raw tool.output events, the snapshot only keeps
+  // the tail for display.
+  streamingOutputTruncated?: boolean
   parseError?: string // Error message if JSON parsing failed
   rawArguments?: string // The unparsed arguments string for debugging
 }

--- a/web/src/components/plan/AssistantMessage.tsx
+++ b/web/src/components/plan/AssistantMessage.tsx
@@ -197,7 +197,7 @@ export const AssistantMessage = memo(function AssistantMessage({
             case 'text':
               return (
                 <div key={i} className="prose prose-sm prose-invert max-w-none">
-                  <Markdown content={element.content} />
+                  <Markdown content={element.content} isStreaming={message.isStreaming} />
                 </div>
               )
 

--- a/web/src/components/plan/BranchModal.tsx
+++ b/web/src/components/plan/BranchModal.tsx
@@ -72,7 +72,7 @@ export function BranchModal({ isOpen, onClose, sessionId }: BranchModalProps) {
           setBusy(false)
           return
         }
-        await refreshSession(sessionId)
+        await refreshSession(sessionId, true)
         onClose()
       } catch (e) {
         setError(e instanceof Error ? e.message : 'Failed to switch branch')

--- a/web/src/components/plan/ChatFeedItems.test.tsx
+++ b/web/src/components/plan/ChatFeedItems.test.tsx
@@ -1,9 +1,29 @@
 // @vitest-environment happy-dom
-import { describe, it, expect } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createRoot } from 'react-dom/client'
 import { flushSync } from 'react-dom'
+import { act } from 'react'
 import { ChatFeedItems } from './ChatFeedItems'
+import { FEED_REVEAL_EVENT } from './feed-window'
 import type { DisplayItem } from './groupMessages'
+
+class MockIntersectionObserver {
+  static instances: MockIntersectionObserver[] = []
+  callback: IntersectionObserverCallback
+
+  constructor(callback: IntersectionObserverCallback) {
+    this.callback = callback
+    MockIntersectionObserver.instances.push(this)
+  }
+
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+
+  trigger() {
+    this.callback([{ isIntersecting: true } as IntersectionObserverEntry], this as unknown as IntersectionObserver)
+  }
+}
 
 function msg(id: string, role: 'user' | 'assistant' = 'user', content = 'Hello'): DisplayItem {
   return {
@@ -74,5 +94,233 @@ describe('ChatFeedItems stable keys', () => {
     expect(container.querySelector('[data-message-id="a"]')).toBe(nodeA)
     expect(container.querySelector('[data-message-id="b"]')).toBe(nodeB)
     expect(container.textContent).toContain('Third')
+  })
+})
+
+describe('ChatFeedItems progressive rendering', () => {
+  beforeEach(() => {
+    MockIntersectionObserver.instances = []
+    vi.stubGlobal('IntersectionObserver', MockIntersectionObserver)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('mounts only the most recent items first', () => {
+    const items = Array.from({ length: 70 }, (_, i) => msg(`m${i}`, 'user', `Content ${i}`))
+
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+
+    flushSync(() => root.render(<ChatFeedItems displayItems={items} />))
+
+    // Only the 30 most recent are mounted: m40..m69
+    expect(container.querySelector('[data-message-id="m0"]')).toBeNull()
+    expect(container.querySelector('[data-message-id="m39"]')).toBeNull()
+    expect(container.querySelector('[data-message-id="m40"]')).toBeTruthy()
+    expect(container.querySelector('[data-message-id="m69"]')).toBeTruthy()
+    expect(container.querySelectorAll('.feed-item')).toHaveLength(30)
+    // The rest are unmounted placeholders
+    expect(container.querySelectorAll('[data-placeholder]')).toHaveLength(40)
+  })
+
+  it('reveals older items in batches when the sentinel becomes visible', () => {
+    const items = Array.from({ length: 70 }, (_, i) => msg(`m${i}`, 'user', `Content ${i}`))
+
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+
+    flushSync(() => root.render(<ChatFeedItems displayItems={items} />))
+    expect(container.querySelectorAll('.feed-item')).toHaveLength(30)
+    expect(container.querySelector('[data-testid="feed-sentinel"]')).toBeTruthy()
+
+    // Each reveal moves the window up by 20 items
+    act(() => {
+      MockIntersectionObserver.instances.at(-1)!.trigger()
+    })
+    expect(container.querySelectorAll('.feed-item')).toHaveLength(50)
+    expect(container.querySelector('[data-message-id="m20"]')).toBeTruthy()
+
+    act(() => {
+      MockIntersectionObserver.instances.at(-1)!.trigger()
+    })
+    expect(container.querySelectorAll('.feed-item')).toHaveLength(70)
+    expect(container.querySelector('[data-message-id="m0"]')).toBeTruthy()
+    expect(container.querySelector('[data-placeholder]')).toBeNull()
+    expect(container.querySelector('[data-testid="feed-sentinel"]')).toBeNull()
+  })
+
+  it('reveals up to a target index on the feed reveal event', () => {
+    const items = Array.from({ length: 100 }, (_, i) => msg(`m${i}`, 'user', `Content ${i}`))
+
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+
+    flushSync(() => root.render(<ChatFeedItems displayItems={items} />))
+    expect(container.querySelectorAll('.feed-item')).toHaveLength(30)
+
+    // Timeline navigation targets index 10 — everything up to it is revealed
+    act(() => {
+      window.dispatchEvent(new CustomEvent(FEED_REVEAL_EVENT, { detail: { index: 10 } }))
+    })
+    expect(container.querySelector('[data-message-id="m0"]')).toBeTruthy()
+    expect(container.querySelectorAll('.feed-item')).toHaveLength(100)
+  })
+
+  it('keeps the window stable when new items are appended', () => {
+    const items = Array.from({ length: 70 }, (_, i) => msg(`m${i}`, 'user', `Content ${i}`))
+
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+
+    flushSync(() => root.render(<ChatFeedItems displayItems={items} />))
+    const nodeM69 = container.querySelector('[data-message-id="m69"]')
+
+    const items2 = [...items, msg('m70', 'user', 'Newest')]
+    flushSync(() => root.render(<ChatFeedItems displayItems={items2} />))
+
+    // Newest item is mounted, previously mounted items keep their identity
+    expect(container.querySelector('[data-message-id="m70"]')).toBeTruthy()
+    expect(container.querySelector('[data-message-id="m69"]')).toBe(nodeM69)
+    expect(container.querySelectorAll('.feed-item')).toHaveLength(31)
+  })
+
+  it('re-anchors to the latest window when a large batch arrives (initial load)', () => {
+    const items = Array.from({ length: 70 }, (_, i) => msg(`m${i}`, 'user', `Content ${i}`))
+
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+
+    // Session arrives in chunks, like the real WS/REST load flow
+    flushSync(() => root.render(<ChatFeedItems displayItems={items.slice(0, 16)} />))
+    expect(container.querySelectorAll('.feed-item')).toHaveLength(16)
+
+    act(() => {
+      root.render(<ChatFeedItems displayItems={items} />)
+    })
+    // Bulk append re-anchors the window: only the 30 most recent are mounted
+    expect(container.querySelectorAll('.feed-item')).toHaveLength(30)
+    expect(container.querySelector('[data-message-id="m40"]')).toBeTruthy()
+    expect(container.querySelector('[data-message-id="m0"]')).toBeNull()
+    expect(container.querySelectorAll('[data-placeholder]')).toHaveLength(40)
+  })
+
+  it('resets userScrolled state when sessionId changes', () => {
+    const items = Array.from({ length: 70 }, (_, i) => msg(`m${i}`, 'user', `Content ${i}`))
+
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+
+    const scrollListeners: Array<() => void> = []
+    const viewport = {
+      scrollTop: 0,
+      addEventListener: (_: string, cb: () => void) => scrollListeners.push(cb),
+      removeEventListener: () => {},
+    }
+    const scrollContainerRef = {
+      current: {
+        osInstance: () => ({ elements: () => ({ viewport }) }),
+        getElement: () => null,
+      },
+    } as never
+
+    // Load session A and simulate user scrolling into history
+    flushSync(() =>
+      root.render(
+        <ChatFeedItems
+          displayItems={items.slice(0, 16)}
+          sessionId="session-a"
+          scrollContainerRef={scrollContainerRef}
+        />,
+      ),
+    )
+    act(() => {
+      root.render(<ChatFeedItems displayItems={items} sessionId="session-a" scrollContainerRef={scrollContainerRef} />)
+    })
+    act(() => {
+      viewport.scrollTop = 500
+      for (const cb of scrollListeners) cb()
+      MockIntersectionObserver.instances.at(-1)!.trigger()
+      MockIntersectionObserver.instances.at(-1)!.trigger()
+    })
+    expect(container.querySelectorAll('.feed-item')).toHaveLength(70)
+
+    // Switch to session B — userScrolled must be reset; window re-anchors
+    const itemsB = Array.from({ length: 70 }, (_, i) => msg(`b${i}`, 'user', `B ${i}`))
+    act(() => {
+      root.render(<ChatFeedItems displayItems={itemsB} sessionId="session-b" scrollContainerRef={scrollContainerRef} />)
+    })
+    expect(container.querySelectorAll('.feed-item')).toHaveLength(30)
+    expect(container.querySelector('[data-message-id="b69"]')).toBeTruthy()
+    expect(container.querySelector('[data-message-id="b0"]')).toBeNull()
+
+    // A bulk batch on session B also re-anchors (userScrolled was reset)
+    const bigBatch = Array.from({ length: 100 }, (_, i) => msg(`b${i}`, 'user', `B ${i}`))
+    act(() => {
+      root.render(
+        <ChatFeedItems displayItems={bigBatch} sessionId="session-b" scrollContainerRef={scrollContainerRef} />,
+      )
+    })
+    expect(container.querySelectorAll('.feed-item')).toHaveLength(30)
+    expect(container.querySelector('[data-message-id="b99"]')).toBeTruthy()
+    expect(container.querySelector('[data-message-id="b0"]')).toBeNull()
+  })
+
+  it('does not re-anchor when the user has scrolled into history (reconnect replay)', () => {
+    const items = Array.from({ length: 70 }, (_, i) => msg(`m${i}`, 'user', `Content ${i}`))
+
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+
+    // OS viewport mock: scrollTop > 4 means the user scrolled up
+    const scrollListeners: Array<() => void> = []
+    const viewport = {
+      scrollTop: 0,
+      addEventListener: (_: string, cb: () => void) => scrollListeners.push(cb),
+      removeEventListener: () => {},
+    }
+    const scrollContainerRef = {
+      current: {
+        osInstance: () => ({ elements: () => ({ viewport }) }),
+        getElement: () => null,
+      },
+    } as never
+
+    // Initial load re-anchors to the bottom
+    flushSync(() =>
+      root.render(<ChatFeedItems displayItems={items.slice(0, 16)} scrollContainerRef={scrollContainerRef} />),
+    )
+    act(() => {
+      root.render(<ChatFeedItems displayItems={items} scrollContainerRef={scrollContainerRef} />)
+    })
+    expect(container.querySelectorAll('.feed-item')).toHaveLength(30)
+
+    // User scrolls up (fires the scroll listener) and reveals everything
+    act(() => {
+      viewport.scrollTop = 500
+      for (const cb of scrollListeners) cb()
+      MockIntersectionObserver.instances.at(-1)!.trigger()
+      MockIntersectionObserver.instances.at(-1)!.trigger()
+    })
+    expect(container.querySelectorAll('.feed-item')).toHaveLength(70)
+    expect(container.querySelector('[data-message-id="m0"]')).toBeTruthy()
+
+    // Reconnect replay delivers a large batch — the window must NOT jump back down
+    const replayItems = Array.from({ length: 100 }, (_, i) => msg(`r${i}`, 'user', `Replay ${i}`))
+    act(() => {
+      root.render(<ChatFeedItems displayItems={replayItems} scrollContainerRef={scrollContainerRef} />)
+    })
+    // Window stays anchored at the top: all 100 items mounted, no placeholders
+    expect(container.querySelectorAll('.feed-item')).toHaveLength(100)
+    expect(container.querySelector('[data-message-id="r0"]')).toBeTruthy()
+    expect(container.querySelector('[data-placeholder]')).toBeNull()
   })
 })

--- a/web/src/components/plan/ChatFeedItems.tsx
+++ b/web/src/components/plan/ChatFeedItems.tsx
@@ -1,15 +1,26 @@
-import { memo } from 'react'
+import { memo, useEffect, useRef, useState } from 'react'
+import type { OverlayScrollbarsComponentRef } from 'overlayscrollbars-react'
 import type { DisplayItem } from './groupMessages.js'
 import { ChatMessage } from './ChatMessage'
 import { AssistantMessage } from './AssistantMessage'
 import { SubAgentContainer } from './SubAgentContainer'
+import { FEED_REVEAL_EVENT } from './feed-window'
 
 const ITEM_CONTAINMENT_STYLE = { contentVisibility: 'auto', containIntrinsicSize: 'auto 200px' } as const
+const PLACEHOLDER_STYLE = { contentVisibility: 'auto', containIntrinsicSize: '160px', minHeight: '160px' } as const
+
+// Bottom-anchored virtualization: only the most recent items are mounted at
+// load, older items are revealed in batches as the user scrolls up.
+const INITIAL_RENDER_COUNT = 30
+const REVEAL_BATCH_SIZE = 20
+const REVEAL_MARGIN = 10
+const BULK_APPEND_THRESHOLD = 5
 
 interface ChatFeedItemsProps {
   displayItems: DisplayItem[]
   highlightedMessageId?: string | null
   sessionId?: string | null
+  scrollContainerRef?: React.RefObject<OverlayScrollbarsComponentRef<'div'> | null>
   showThinking?: boolean
   showVerboseToolOutput?: boolean
   showStats?: boolean
@@ -27,18 +38,141 @@ export const ChatFeedItems = memo(function ChatFeedItems({
   displayItems,
   highlightedMessageId = null,
   sessionId,
+  scrollContainerRef,
   showThinking = true,
   showVerboseToolOutput = true,
   showStats = true,
   showAgentDefinitions = true,
   showWorkflowBars = true,
 }: ChatFeedItemsProps) {
+  const totalItems = displayItems.length
+  // Absolute index of the first mounted item. New items appended at the end
+  // (streaming) keep the window stable — only the reveal moves it up.
+  const [startIndex, setStartIndex] = useState(() => Math.max(0, totalItems - INITIAL_RENDER_COUNT))
+  const sentinelRef = useRef<HTMLDivElement | null>(null)
+  const prevItemCountRef = useRef(displayItems.length)
+  const userScrolledRef = useRef(false)
+
+  // Reset the virtual window when switching sessions.
+  useEffect(() => {
+    setStartIndex(Math.max(0, displayItems.length - INITIAL_RENDER_COUNT))
+    userScrolledRef.current = false
+  }, [sessionId])
+
+  // Re-anchor the window when a large batch of items arrives at once (initial
+  // history load). Single-item streaming appends keep the window stable, and
+  // so does a bulk replay after WS reconnect when the user has scrolled into
+  // history — jumping back to the bottom would yank the viewport away.
+  useEffect(() => {
+    const prev = prevItemCountRef.current
+    prevItemCountRef.current = displayItems.length
+    if (displayItems.length - prev >= BULK_APPEND_THRESHOLD && !userScrolledRef.current) {
+      setStartIndex(Math.max(0, displayItems.length - INITIAL_RENDER_COUNT))
+    }
+  }, [displayItems.length])
+
+  // Clamp when items are removed (truncation, session switch).
+  useEffect(() => {
+    if (startIndex > 0 && startIndex >= displayItems.length) {
+      setStartIndex(Math.max(0, displayItems.length - INITIAL_RENDER_COUNT))
+    }
+  }, [displayItems.length, startIndex])
+
+  // Reveal older items in batches while the sentinel approaches the viewport.
+  // The bottom-expanded rootMargin triggers before the user reaches the
+  // placeholder region, so scrolling up never exposes gaps.
+  useEffect(() => {
+    if (startIndex <= 0 || typeof IntersectionObserver === 'undefined') return
+    const sentinel = sentinelRef.current
+    if (!sentinel) return
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          setStartIndex((index) => Math.max(0, index - REVEAL_BATCH_SIZE))
+        }
+      },
+      { rootMargin: '0px 0px 300px 0px' },
+    )
+    observer.observe(sentinel)
+    return () => observer.disconnect()
+  }, [startIndex])
+
+  // When the user reaches the very top, keep revealing until everything is
+  // mounted — the sentinel can end up below remaining placeholders, out of the
+  // observer margin, leaving unmounted gaps at the top of the list. Only runs
+  // after the user has scrolled the container (not during the initial
+  // bottom-anchor scroll).
+  const startIndexRef = useRef(startIndex)
+  startIndexRef.current = startIndex
+
+  useEffect(() => {
+    const container = scrollContainerRef?.current
+    if (!container) return
+    const viewport = container.osInstance?.()?.elements().viewport
+    if (!viewport) return
+    const onScroll = () => {
+      if (viewport.scrollTop > 4) {
+        userScrolledRef.current = true
+        return
+      }
+      if (startIndexRef.current > 0) {
+        setStartIndex((index) => Math.max(0, index - REVEAL_BATCH_SIZE))
+      }
+    }
+    viewport.addEventListener('scroll', onScroll, { passive: true })
+    return () => viewport.removeEventListener('scroll', onScroll)
+  }, [scrollContainerRef])
+
+  useEffect(() => {
+    if (startIndex <= 0 || !userScrolledRef.current) return
+    const container = scrollContainerRef?.current
+    const viewport = container?.osInstance?.()?.elements().viewport
+    if (viewport && viewport.scrollTop <= 4) {
+      setStartIndex((index) => Math.max(0, index - REVEAL_BATCH_SIZE))
+    }
+  }, [startIndex, scrollContainerRef])
+
+  // Timeline navigation: reveal up to a target index when asked. This is the
+  // only active reveal path — highlightedMessageId (ChatFeedItems) has no
+  // non-null caller today, so any future highlight must reveal the target via
+  // this event first (see PlanPanel's MessageList usage).
+  useEffect(() => {
+    const onRevealRequest = (event: Event) => {
+      const index = (event as CustomEvent<{ index: number }>).detail?.index
+      if (typeof index !== 'number') return
+      setStartIndex((current) => Math.min(current, Math.max(0, index - REVEAL_MARGIN)))
+    }
+    window.addEventListener(FEED_REVEAL_EVENT, onRevealRequest)
+    return () => window.removeEventListener(FEED_REVEAL_EVENT, onRevealRequest)
+  }, [])
+
+  const visibleItems = displayItems.slice(startIndex)
+
   return (
     <>
-      {displayItems.map((item, index) => {
+      {startIndex > 0 && (
+        <>
+          <div
+            className="flex items-center justify-center gap-2 py-3 text-xs text-text-muted"
+            data-testid="feed-unmounted-hint"
+          >
+            Scroll up to load {startIndex} older item{startIndex !== 1 ? 's' : ''}
+          </div>
+          {Array.from({ length: startIndex }, (_, i) => (
+            <div key={`ph-${i}`} data-item-index={i} data-placeholder style={PLACEHOLDER_STYLE} />
+          ))}
+          <div ref={sentinelRef} data-testid="feed-sentinel" style={{ height: 1 }} />
+        </>
+      )}
+      {visibleItems.map((item, index) => {
+        const displayIndex = startIndex + index
         if (item.type === 'context-divider') {
           return (
-            <div key={itemKey(item)} data-item-index={index} className="flex items-center gap-2 feed-item px-2 md:px-4">
+            <div
+              key={itemKey(item)}
+              data-item-index={displayIndex}
+              className="flex items-center gap-2 feed-item px-2 md:px-4"
+            >
               <div className="flex-1 border-t border-border" />
               <span className="text-[10px] text-text-muted font-medium px-2">Earlier context summarized</span>
               <div className="flex-1 border-t border-border" />
@@ -49,7 +183,12 @@ export const ChatFeedItems = memo(function ChatFeedItems({
         if (item.type === 'subagent') {
           const groupIsStreaming = item.messages.some((m) => m.isStreaming)
           return (
-            <div key={itemKey(item)} data-item-index={index} className="px-2 md:px-4" style={ITEM_CONTAINMENT_STYLE}>
+            <div
+              key={itemKey(item)}
+              data-item-index={displayIndex}
+              className="px-2 md:px-4"
+              style={ITEM_CONTAINMENT_STYLE}
+            >
               <SubAgentContainer
                 messages={item.messages}
                 subAgentType={item.subAgentType}
@@ -63,7 +202,12 @@ export const ChatFeedItems = memo(function ChatFeedItems({
         const message = item.message
         if (message.role === 'assistant') {
           return (
-            <div key={itemKey(item)} data-item-index={index} className="px-2 md:px-4" style={ITEM_CONTAINMENT_STYLE}>
+            <div
+              key={itemKey(item)}
+              data-item-index={displayIndex}
+              className="px-2 md:px-4"
+              style={ITEM_CONTAINMENT_STYLE}
+            >
               <AssistantMessage
                 message={message}
                 showStats={showStats}
@@ -83,7 +227,12 @@ export const ChatFeedItems = memo(function ChatFeedItems({
         }
 
         return (
-          <div key={itemKey(item)} data-item-index={index} className="px-2 md:px-4" style={ITEM_CONTAINMENT_STYLE}>
+          <div
+            key={itemKey(item)}
+            data-item-index={displayIndex}
+            className="px-2 md:px-4"
+            style={ITEM_CONTAINMENT_STYLE}
+          >
             <div
               data-message-id={message.id}
               className={highlightedMessageId === message.id ? 'rounded animate-highlight-fade' : undefined}

--- a/web/src/components/plan/ChatInput.tsx
+++ b/web/src/components/plan/ChatInput.tsx
@@ -477,7 +477,7 @@ export function ChatInput({
       }
 
       // Warmup: on first keystroke in an empty session, prefill the LLM cache
-      if (!warmupSentRef.current && sessionId && value && currentSession && currentSession.messages.length === 0) {
+      if (!warmupSentRef.current && sessionId && value && currentSession && (currentSession.messageCount ?? 0) === 0) {
         warmupSentRef.current = true
         authFetch(`/api/sessions/${sessionId}/warmup`, { method: 'POST' }).catch(() => {})
       }

--- a/web/src/components/plan/ChatInput.warmup.test.tsx
+++ b/web/src/components/plan/ChatInput.warmup.test.tsx
@@ -1,0 +1,118 @@
+// @vitest-environment happy-dom
+import '@testing-library/jest-dom/vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ChatInput } from './ChatInput'
+
+const { authFetchMock, currentSessionMock } = vi.hoisted(() => ({
+  authFetchMock: vi.fn(() => Promise.resolve({ ok: true })),
+  currentSessionMock: { id: 's1', workdir: '/tmp', projectId: 'p1', messageCount: 0 },
+}))
+
+vi.mock('../../lib/api', () => ({
+  authFetch: authFetchMock,
+}))
+
+vi.mock('../../stores/session', () => ({
+  useSessionStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      currentSession: currentSessionMock,
+      stopGeneration: vi.fn(),
+      cancelQueued: vi.fn(),
+      queuedMessages: [],
+      restoredInput: null,
+      clearRestoredInput: vi.fn(),
+    }),
+  useIsRunning: () => false,
+}))
+
+vi.mock('../../stores/workflows', () => ({
+  useWorkflowsStore: Object.assign(
+    (selector: (state: unknown) => unknown) =>
+      selector({ defaults: [], userItems: [], projectItems: [], fetchWorkflows: vi.fn() }),
+    { getState: () => ({ defaults: [], userItems: [], projectItems: [], fetchWorkflows: vi.fn() }) },
+  ),
+}))
+
+vi.mock('../../stores/commands', () => ({
+  useCommandsStore: Object.assign(
+    (selector: (state: unknown) => unknown) =>
+      selector({ defaults: [], userItems: [], projectItems: [], fetchCommands: vi.fn() }),
+    { getState: () => ({ defaults: [], userItems: [], projectItems: [], fetchCommands: vi.fn() }) },
+  ),
+}))
+
+vi.mock('../../hooks/useScrolledSend', () => ({
+  useScrolledSend: () => ({ sendMessage: vi.fn(), launchWorkflow: vi.fn() }),
+}))
+
+vi.mock('../../stores/settings', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>
+  return {
+    ...actual,
+    useSettingsStore: (selector: (state: unknown) => unknown) =>
+      selector({ settings: { 'features.perSessionMcp': 'false' } }),
+  }
+})
+
+function renderChatInput() {
+  return render(
+    <ChatInput
+      input=""
+      setInput={vi.fn()}
+      attachments={[]}
+      setAttachments={vi.fn()}
+      dragOver={false}
+      setDragOver={vi.fn()}
+      errorMessage={null}
+      setErrorMessage={vi.fn()}
+      scrollToBottom={vi.fn()}
+      sessionId="s1"
+      showHistory={false}
+      history={[]}
+      selectedIndex={0}
+      openHistory={vi.fn()}
+      closeHistory={vi.fn()}
+      navigateUp={vi.fn()}
+      navigateDown={vi.fn()}
+      selectCurrent={vi.fn()}
+      isAutoScrollActive={true}
+      setAutoScroll={vi.fn()}
+      onOpenMessageSearch={vi.fn()}
+      onOpenCommandsModal={vi.fn()}
+      onOpenWorkflowsModal={vi.fn()}
+      onSelectWorkflow={vi.fn()}
+      onSelectWorkflowWithSubGroup={vi.fn()}
+      onSendCommand={vi.fn()}
+      clearInput={vi.fn()}
+    />,
+  )
+}
+
+describe('ChatInput warmup', () => {
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+    currentSessionMock.messageCount = 0
+  })
+
+  it('triggers warmup on first keystroke in an empty session', () => {
+    currentSessionMock.messageCount = 0
+    renderChatInput()
+
+    const textarea = screen.getByTestId('chat-input-textarea')
+    fireEvent.change(textarea, { target: { value: 'hello' } })
+
+    expect(authFetchMock).toHaveBeenCalledWith('/api/sessions/s1/warmup', { method: 'POST' })
+  })
+
+  it('does not trigger warmup when the session has messages', () => {
+    currentSessionMock.messageCount = 5
+    renderChatInput()
+
+    const textarea = screen.getByTestId('chat-input-textarea')
+    fireEvent.change(textarea, { target: { value: 'hello' } })
+
+    expect(authFetchMock).not.toHaveBeenCalledWith('/api/sessions/s1/warmup', { method: 'POST' })
+  })
+})

--- a/web/src/components/plan/ChatMessage.tsx
+++ b/web/src/components/plan/ChatMessage.tsx
@@ -1,4 +1,3 @@
-import { ScrollArea } from '../shared/ScrollArea'
 import { memo, useCallback, useRef, useState } from 'react'
 import type { Message } from '@shared/types.js'
 import type { TaskCompletedPayload } from '@shared/protocol.js'
@@ -83,7 +82,7 @@ function UserMessage({ message, messageId, sessionId }: UserMessageProps) {
     const ok = await replayMessage(sessionId, messageId)
     setPending(false)
     if (ok) {
-      loadSession(sessionId)
+      loadSession(sessionId, true)
     } else {
       setError('Failed to replay')
     }
@@ -96,7 +95,7 @@ function UserMessage({ message, messageId, sessionId }: UserMessageProps) {
     const ok = await replayMessage(sessionId, messageId, editContent)
     setPending(false)
     if (ok) {
-      loadSession(sessionId)
+      loadSession(sessionId, true)
       setEditing(false)
     } else {
       setError('Failed to send')
@@ -277,12 +276,12 @@ export const ChatMessage = memo(function ChatMessage({
     return (
       <div className="feed-item bg-bg-tertiary/30 border-l-2 border-accent-primary rounded-r p-2">
         <div className="text-accent-primary text-xs mb-0.5">Tool: {message.toolName}</div>
-        <ScrollArea horizontal className="max-h-32">
+        <div className="max-h-32 overflow-x-auto">
           <pre className="text-text-secondary text-xs whitespace-pre-wrap break-words">
             {message.content.slice(0, 500)}
             {message.content.length > 500 && '...'}
           </pre>
-        </ScrollArea>
+        </div>
       </div>
     )
   }

--- a/web/src/components/plan/MessageList.tsx
+++ b/web/src/components/plan/MessageList.tsx
@@ -2,6 +2,7 @@ import { memo, useState, useRef, useCallback, useEffect, useLayoutEffect } from 
 import type { OverlayScrollbarsComponentRef } from 'overlayscrollbars-react'
 import { ScrollArea } from '../shared/ScrollArea'
 import type { ScrollbarGestureKind } from '../shared/ScrollArea'
+import { useViewport } from '../../hooks/useViewport'
 import { useSessionStore, useIsRunning } from '../../stores/session'
 import { useWorkflowsStore } from '../../stores/workflows'
 import { useDisplaySettings } from '../../stores/settings'
@@ -59,9 +60,7 @@ export const MessageList = memo(function MessageList({
   const [isScrollable, setIsScrollable] = useState(false)
   const [scrolledPastTop, setScrolledPastTop] = useState(false)
 
-  const getViewport = useCallback(() => {
-    return scrollContainerRef.current?.osInstance()?.elements().viewport ?? null
-  }, [scrollContainerRef])
+  const getViewport = useViewport(scrollContainerRef)
 
   useLayoutEffect(() => {
     const el = getViewport()
@@ -139,6 +138,7 @@ export const MessageList = memo(function MessageList({
             displayItems={displayItems}
             highlightedMessageId={highlightedMessageId}
             sessionId={sessionId}
+            scrollContainerRef={scrollContainerRef}
             showThinking={showThinking}
             showVerboseToolOutput={showVerboseToolOutput}
             showStats={showStats}

--- a/web/src/components/plan/PlanPanel.tsx
+++ b/web/src/components/plan/PlanPanel.tsx
@@ -1,7 +1,6 @@
 import { useState, useRef, useEffect, useCallback, useMemo } from 'react'
 import { useSessionStore, useIsRunning } from '../../stores/session'
 import { useDisplaySettings } from '../../stores/settings'
-import type { OverlayScrollbarsComponentRef } from 'overlayscrollbars-react'
 
 import { type TurnStats } from '../../lib/types'
 import type { Message } from '@shared/types.js'
@@ -26,8 +25,11 @@ import { SidebarSummaryHeader } from './SidebarSummaryHeader'
 import { shouldCaptureMessageSearchShortcut } from './message-search-shortcut'
 
 import { groupMessages, type DisplayItem } from './groupMessages.js'
+import { FEED_REVEAL_EVENT } from './feed-window'
 import { usePromptHistory } from '../../hooks/usePromptHistory.js'
 import { useAutoScroll } from '@/hooks/useAutoScroll.ts'
+import { useViewport } from '../../hooks/useViewport'
+import type { OverlayScrollbarsComponentRef } from 'overlayscrollbars-react'
 import { useScrolledSend } from '@/hooks/useScrolledSend.ts'
 import { useKeybindings, useBinding, useAgentSwitchingBindings } from '../../hooks/useKeybindings'
 
@@ -57,9 +59,7 @@ export function PlanPanel({
   const [turnStatsModal, setTurnStatsModal] = useState<TurnStats | null>(null)
   const scrollContainerRef = useRef<OverlayScrollbarsComponentRef<'div'>>(null)
 
-  const getViewport = useCallback(() => {
-    return scrollContainerRef.current?.osInstance()?.elements().viewport ?? null
-  }, [])
+  const getViewport = useViewport(scrollContainerRef)
 
   const session = useSessionStore((state) => state.currentSession)
   const storeMessages = useSessionStore((state) => state.messages)
@@ -164,7 +164,18 @@ export function PlanPanel({
       setAutoScroll(false)
       const element = document.querySelector(`[data-item-index="${index}"]`)
       if (element) {
-        element.scrollIntoView({ behavior: 'smooth', block: 'center' })
+        if (element.hasAttribute('data-placeholder')) {
+          window.dispatchEvent(new CustomEvent(FEED_REVEAL_EVENT, { detail: { index } }))
+          requestAnimationFrame(() =>
+            requestAnimationFrame(() => {
+              document
+                .querySelector(`[data-item-index="${index}"]`)
+                ?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+            }),
+          )
+        } else {
+          element.scrollIntoView({ behavior: 'smooth', block: 'center' })
+        }
       }
     },
     [setAutoScroll],
@@ -268,6 +279,10 @@ export function PlanPanel({
         <MessageList
           displayItems={displayItems}
           scrollContainerRef={scrollContainerRef}
+          // Highlight is intentionally wired to the timeline's FEED_REVEAL_EVENT:
+          // navigation reveals the target placeholder region before scrolling,
+          // so no highlight target is ever an unmounted item. Passing null here
+          // keeps the highlight path dead until a caller reveals first.
           highlightedMessageId={null}
           onLaunchWorkflow={handleLaunchWorkflow}
           onScrollToTop={() => setAutoScroll(false)}

--- a/web/src/components/plan/SubAgentContainer.tsx
+++ b/web/src/components/plan/SubAgentContainer.tsx
@@ -1,5 +1,3 @@
-import { ScrollArea } from '../shared/ScrollArea'
-import type { OverlayScrollbarsComponentRef } from 'overlayscrollbars-react'
 import { memo, useRef, useState, useCallback } from 'react'
 import type { Message, ContextState } from '@shared/types.js'
 import { AssistantMessage } from './AssistantMessage'
@@ -10,6 +8,8 @@ import { useDisplaySettings } from '../../stores/settings'
 import { formatTokens } from '../../lib/format-stats'
 import { useAutoScroll } from '../../hooks/useAutoScroll'
 import { useViewport } from '../../hooks/useViewport'
+import { ScrollArea } from '../shared/ScrollArea'
+import type { OverlayScrollbarsComponentRef } from 'overlayscrollbars-react'
 import { ProgressBar } from '../shared/ProgressBar'
 
 interface SubAgentContainerProps {

--- a/web/src/components/plan/WorkspaceModal.tsx
+++ b/web/src/components/plan/WorkspaceModal.tsx
@@ -84,7 +84,7 @@ export function WorkspaceModal({
           setBusy(false)
           return
         }
-        await refreshSession(sessionId)
+        await refreshSession(sessionId, true)
         onClose()
       } catch (e) {
         setError(e instanceof Error ? e.message : 'Failed to switch workspace')
@@ -118,7 +118,7 @@ export function WorkspaceModal({
         }
         setConfirmDelete(null)
         setForceDeleting(false)
-        await refreshSession(sessionId)
+        await refreshSession(sessionId, true)
         // Refresh the workspace list
         const listRes = await authFetch(`/api/projects/${projectId}/workspaces`)
         const listData = await listRes.json()

--- a/web/src/components/plan/feed-window.ts
+++ b/web/src/components/plan/feed-window.ts
@@ -1,0 +1,1 @@
+export const FEED_REVEAL_EVENT = 'openfox:feed-reveal'

--- a/web/src/components/shared/BackgroundProcessView.tsx
+++ b/web/src/components/shared/BackgroundProcessView.tsx
@@ -1,4 +1,3 @@
-import { ScrollArea } from './ScrollArea'
 import { memo } from 'react'
 import type { BackgroundProcess, LogLine } from '@shared/protocol.js'
 import { tryParseResult } from './tryParseResult'
@@ -36,9 +35,9 @@ export const BackgroundProcessView = memo(function BackgroundProcessView({
   return (
     <div className="space-y-2 text-xs">
       <div className="text-accent-warning">Unknown action: {action}</div>
-      <ScrollArea horizontal className="max-h-[60vh]">
+      <div className="max-h-[60vh] overflow-x-auto">
         <pre className="text-xs bg-bg-primary p-1.5 rounded break-words">{result}</pre>
-      </ScrollArea>
+      </div>
     </div>
   )
 })
@@ -54,13 +53,13 @@ function renderLogs(parsed: Record<string, unknown>) {
 
   return (
     <div className="space-y-2">
-      <ScrollArea className="text-xs font-mono whitespace-pre-wrap bg-bg-primary p-2 rounded max-h-[60vh] break-words">
+      <div className="text-xs font-mono whitespace-pre-wrap bg-bg-primary p-2 rounded max-h-[60vh] break-words overflow-y-auto">
         {lines.map((line, i) => (
           <div key={i} className={line.stream === 'stderr' ? 'text-accent-warning' : ''}>
             {line.content}
           </div>
         ))}
-      </ScrollArea>
+      </div>
       {hasMore && totalLines != null && (
         <div className="text-[10px] text-text-muted">
           Showing {lines.length} of {totalLines} lines

--- a/web/src/components/shared/DevServerView.tsx
+++ b/web/src/components/shared/DevServerView.tsx
@@ -1,4 +1,3 @@
-import { ScrollArea } from './ScrollArea'
 import { memo } from 'react'
 import { tryParseResult } from './tryParseResult'
 
@@ -41,7 +40,7 @@ function renderLogs(data: LogsData) {
   const lines = data.logs.split('\n')
   return (
     <div className="space-y-2">
-      <ScrollArea className="text-xs font-mono whitespace-pre-wrap bg-bg-primary p-2 rounded max-h-[60vh] break-words">
+      <div className="text-xs font-mono whitespace-pre-wrap bg-bg-primary p-2 rounded max-h-[60vh] break-words overflow-y-auto">
         {lines.map((line, i) => {
           const isStderr = line.startsWith('[stderr] ')
           return (
@@ -50,7 +49,7 @@ function renderLogs(data: LogsData) {
             </div>
           )
         })}
-      </ScrollArea>
+      </div>
       {data.hasMore && (
         <div className="text-[10px] text-text-muted">
           Showing {data.limit} of {data.total} lines

--- a/web/src/components/shared/DiagnosticsView.tsx
+++ b/web/src/components/shared/DiagnosticsView.tsx
@@ -1,4 +1,3 @@
-import { ScrollArea } from './ScrollArea'
 import { memo } from 'react'
 import type { Diagnostic } from '@shared/types.js'
 
@@ -59,7 +58,7 @@ export const DiagnosticsView = memo(function DiagnosticsView({ diagnostics }: Di
       </div>
 
       {/* Diagnostic list */}
-      <ScrollArea className="max-h-48">
+      <div className="max-h-48 overflow-y-auto">
         {diagnostics.map((d, i) => {
           const config = severityConfig[d.severity]
           return (
@@ -80,7 +79,7 @@ export const DiagnosticsView = memo(function DiagnosticsView({ diagnostics }: Di
             </div>
           )
         })}
-      </ScrollArea>
+      </div>
     </div>
   )
 })

--- a/web/src/components/shared/DiffView.tsx
+++ b/web/src/components/shared/DiffView.tsx
@@ -1,4 +1,3 @@
-import { ScrollArea } from './ScrollArea'
 import { memo, useMemo, useState } from 'react'
 import { CodeHighlight } from './CodeHighlight'
 import { getLanguageFromPath } from '../../lib/syntax-highlighter'
@@ -74,11 +73,11 @@ export const FilePreview = memo(function FilePreview({ content, filePath }: File
   const language = useMemo(() => getLanguageFromPath(filePath), [filePath])
 
   return (
-    <ScrollArea className="rounded border border-border max-h-[45vh]">
+    <div className="rounded border border-border max-h-[45vh] overflow-y-auto">
       <DiffSection type="added">
         <CodeHighlight code={content} language={language} variant="block" showLineNumbers />
       </DiffSection>
-    </ScrollArea>
+    </div>
   )
 })
 
@@ -248,9 +247,9 @@ export const ReadFileView = memo(function ReadFileView({ result, metadata, fileP
     const strippedContent = stripLineNumbers(content)
 
     return (
-      <ScrollArea className="rounded border border-border max-h-[45vh] p-2">
+      <div className="rounded border border-border max-h-[45vh] p-2 overflow-y-auto">
         <Markdown content={strippedContent} />
-      </ScrollArea>
+      </div>
     )
   }
 
@@ -261,9 +260,9 @@ export const ReadFileView = memo(function ReadFileView({ result, metadata, fileP
   const startLine = startMatch ? parseInt(startMatch[1]!, 10) : 1
 
   return (
-    <ScrollArea className="rounded border border-border max-h-[45vh]">
+    <div className="rounded border border-border max-h-[45vh] overflow-y-auto">
       <CodeHighlight code={strippedContent} language={language} variant="block" showLineNumbers startLine={startLine} />
-    </ScrollArea>
+    </div>
   )
 })
 

--- a/web/src/components/shared/Markdown.streaming.test.tsx
+++ b/web/src/components/shared/Markdown.streaming.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment happy-dom
+import '@testing-library/jest-dom/vitest'
+import { cleanup, render, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { Markdown } from './Markdown'
+
+const highlightCodeMock = vi.hoisted(() => vi.fn())
+
+vi.mock('../../lib/syntax-highlighter', () => ({
+  highlightCode: highlightCodeMock,
+  useShikiTheme: () => 'github-dark-default',
+}))
+
+vi.mock('../../stores/settings', () => ({
+  useDisplaySettings: () => ({ showSyntaxHighlighting: true }),
+}))
+
+vi.mock('../../hooks/useCopyToClipboard', () => ({
+  useCopyToClipboard: () => ({ copied: false, copy: vi.fn() }),
+}))
+
+describe('Markdown streaming highlight deferral', () => {
+  beforeEach(() => {
+    highlightCodeMock.mockReset()
+    highlightCodeMock.mockImplementation(async (code: string) => `<pre data-testid="highlighted">${code}</pre>`)
+  })
+
+  afterEach(cleanup)
+
+  it('does not call highlightCode while streaming with an open code block', () => {
+    const { getByText } = render(<Markdown content={'```js\nconst x = 1'} isStreaming />)
+
+    expect(highlightCodeMock).not.toHaveBeenCalled()
+    expect(getByText('const x = 1')).toBeInTheDocument()
+  })
+
+  it('highlights the code block exactly once when it closes during streaming', async () => {
+    const { rerender, container } = render(<Markdown content={'```js\nconst x = 1'} isStreaming />)
+    expect(highlightCodeMock).not.toHaveBeenCalled()
+
+    rerender(<Markdown content={'```js\nconst x = 1\n```'} isStreaming />)
+    await waitFor(() => expect(highlightCodeMock).toHaveBeenCalledTimes(1))
+    expect(container.querySelector('[data-testid="highlighted"]')).toBeTruthy()
+
+    rerender(<Markdown content={'```js\nconst x = 1\n```'} isStreaming />)
+    await waitFor(() => expect(highlightCodeMock).toHaveBeenCalledTimes(1))
+  })
+
+  it('highlights a closed code block when streaming ends', async () => {
+    const { rerender } = render(<Markdown content={'```js\nconst x = 1'} isStreaming />)
+    expect(highlightCodeMock).not.toHaveBeenCalled()
+
+    rerender(<Markdown content={'```js\nconst x = 1'} />)
+    await waitFor(() => expect(highlightCodeMock).toHaveBeenCalledTimes(1))
+  })
+
+  it('keeps highlighting closed blocks when not streaming (default behavior)', async () => {
+    const { container } = render(<Markdown content={'```js\nconst x = 1\n```'} />)
+
+    await waitFor(() => expect(highlightCodeMock).toHaveBeenCalledTimes(1))
+    expect(container.querySelector('[data-testid="highlighted"]')).toBeTruthy()
+  })
+
+  it('does not re-highlight stable closed blocks across renders', async () => {
+    const { rerender } = render(<Markdown content={'```js\nconst x = 1\n```'} />)
+    await waitFor(() => expect(highlightCodeMock).toHaveBeenCalledTimes(1))
+
+    rerender(<Markdown content={'```js\nconst x = 1\n```'} />)
+    await waitFor(() => expect(highlightCodeMock).toHaveBeenCalledTimes(1))
+  })
+
+  it('skips highlighting for plain text blocks', async () => {
+    render(<Markdown content={'```text\nplain output\n```'} />)
+    await waitFor(() => expect(highlightCodeMock).not.toHaveBeenCalled())
+  })
+
+  it('skips highlighting for very large blocks (tool outputs)', async () => {
+    const big = 'line of code\n'.repeat(400) // > 5000 chars
+    const { container } = render(<Markdown content={`\`\`\`bash\n${big}\`\`\``} />)
+
+    await waitFor(() => expect(highlightCodeMock).not.toHaveBeenCalled())
+    expect(container.textContent).toContain('line of code')
+  })
+})

--- a/web/src/components/shared/Markdown.test.tsx
+++ b/web/src/components/shared/Markdown.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 import { describe, it, expect } from 'vitest'
-import { Markdown } from './Markdown'
+import { Markdown, getMarkdownCacheBytesForTest } from './Markdown'
 import { renderToString } from 'react-dom/server'
 
 describe('Markdown', () => {
@@ -104,6 +104,110 @@ describe('Markdown', () => {
       expect(html).toContain('<ol')
       expect(html).toContain('verifier')
       expect(html).toContain('reviewer')
+    })
+  })
+
+  describe('plain text fast path', () => {
+    it('renders plain prose as a single paragraph with the same styling as markdown paragraphs', () => {
+      const html = renderToString(<Markdown content="Hello world, this is plain prose." />)
+
+      expect(html).toContain(
+        '<p class="text-text-primary mb-1.5 last:mb-0 leading-tight break-words whitespace-pre-line">Hello world, this is plain prose.</p>',
+      )
+    })
+
+    it('preserves paragraph breaks in plain prose', () => {
+      const html = renderToString(<Markdown content={'First paragraph.\n\nSecond paragraph.'} />)
+
+      expect(html).toContain('First paragraph.')
+      expect(html).toContain('Second paragraph.')
+      expect(html).toContain('whitespace-pre-line')
+    })
+
+    it('linkifies bare URLs like the markdown path does', () => {
+      const html = renderToString(<Markdown content={'See https://example.com/docs for details'} />)
+
+      expect(html).toContain('<a href="https://example.com/docs"')
+      expect(html).toContain('example.com/docs')
+    })
+
+    it('applies the muted color for muted plain text', () => {
+      const html = renderToString(<Markdown content="Quiet thought." muted />)
+
+      expect(html).toContain('text-text-muted')
+      expect(html).toContain('Quiet thought.')
+    })
+
+    it('renders empty or whitespace-only content as nothing', () => {
+      const html = renderToString(<Markdown content="   " />)
+
+      expect(html).not.toContain('<p')
+    })
+
+    it('still routes markdown syntax to the full parser', () => {
+      const html = renderToString(<Markdown content="This has **bold** text." />)
+
+      expect(html).toContain('<strong')
+      expect(html).toContain('bold')
+    })
+
+    it('renders the muted variant distinctly even when the same content was rendered before', () => {
+      // Same content string, different context: the parse cache must not
+      // serve the non-muted node to the muted render.
+      const normal = renderToString(<Markdown content="Quiet thought." />)
+      const mutedHtml = renderToString(<Markdown content="Quiet thought." muted />)
+
+      expect(normal).toContain('text-text-primary')
+      expect(mutedHtml).toContain('text-text-muted')
+      expect(normal).not.toBe(mutedHtml)
+    })
+
+    it('evicts large cached entries so the byte budget is not exceeded', () => {
+      // ~30 entries of ~800KB each would blow past the 20MB budget — the
+      // byte-bounded eviction must kick in. Keep the payloads small enough
+      // that the parse itself stays fast for CI.
+      const big = `# Heading\n\n${'x'.repeat(800_000)}`
+      for (let i = 0; i < 30; i++) {
+        renderToString(<Markdown content={`${big} ${i}`} />)
+      }
+      // The byte budget caps total key bytes — verify it stayed bounded
+      // (30 × ~800KB = 24MB would exceed 20MB without eviction).
+      expect(getMarkdownCacheBytesForTest()).toBeLessThanOrEqual(20 * 1024 * 1024)
+      // And the cache still works for fresh content
+      const html = renderToString(<Markdown content={`${big} fresh`} />)
+      expect(html).toContain('Heading')
+    }, 30_000)
+  })
+
+  describe('markdown edge cases (full parser routing)', () => {
+    it('routes strikethrough (~~text~~) to the full parser', () => {
+      const html = renderToString(<Markdown content="This is ~~deleted~~ text." />)
+
+      expect(html).toContain('<del')
+      expect(html).toContain('deleted')
+      expect(html).not.toContain('~~deleted~~')
+    })
+
+    it('routes blockquotes without space after > to the full parser', () => {
+      const html = renderToString(<Markdown content=">quoted without space" />)
+
+      expect(html).toContain('<blockquote')
+      expect(html).toContain('quoted without space')
+    })
+
+    it('routes ordered list items with ) delimiter to the full parser', () => {
+      const html = renderToString(<Markdown content="1) First item\n2) Second item" />)
+
+      expect(html).toContain('<ol')
+      expect(html).toContain('First item')
+      expect(html).toContain('Second item')
+    })
+
+    it('routes angular autolinks (<https://…>) to the full parser', () => {
+      const html = renderToString(<Markdown content="See <https://example.com/page> here" />)
+
+      expect(html).toContain('<a href="https://example.com/page"')
+      expect(html).not.toContain('&lt;https://example.com/page&gt;')
     })
   })
 

--- a/web/src/components/shared/Markdown.tsx
+++ b/web/src/components/shared/Markdown.tsx
@@ -1,4 +1,3 @@
-import { ScrollArea } from './ScrollArea'
 import { memo, useMemo, useEffect, useState, useRef } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
@@ -11,31 +10,71 @@ interface MarkdownProps {
   content: string
   className?: string
   muted?: boolean
+  isStreaming?: boolean
+}
+
+// Blocks larger than this are rendered without shiki (tool outputs, dumps).
+const SKIP_HIGHLIGHT_THRESHOLD = 5000
+
+// Cache the parsed markdown output per content string + render options.
+// Non-streaming messages are immutable, so re-parsing them on every re-render
+// (session switch, theme change, unrelated state updates) wastes main-thread
+// CPU. Keyed by content + options — cheap string compare, no hashing needed.
+// Bounded both by entry count and by total key+content bytes: large tool
+// outputs can each weigh hundreds of KB.
+const markdownRenderCache = new Map<string, React.ReactNode>()
+const MARKDOWN_CACHE_MAX = 100
+const MARKDOWN_CACHE_MAX_BYTES = 20 * 1024 * 1024
+let markdownCacheBytes = 0
+
+// Exposed for tests: verifies the byte-bounded eviction without parsing tens
+// of MB of markdown.
+export function getMarkdownCacheBytesForTest(): number {
+  return markdownCacheBytes
+}
+
+function cacheMarkdown(key: string, node: React.ReactNode): React.ReactNode {
+  markdownRenderCache.set(key, node)
+  markdownCacheBytes += key.length
+  while (markdownRenderCache.size > MARKDOWN_CACHE_MAX || markdownCacheBytes > MARKDOWN_CACHE_MAX_BYTES) {
+    const firstKey = markdownRenderCache.keys().next().value
+    if (firstKey === undefined) break
+    markdownRenderCache.delete(firstKey)
+    markdownCacheBytes -= firstKey.length
+  }
+  return node
 }
 
 const CodeBlock = memo(function CodeBlock({
   language,
   codeString,
   showSyntaxHighlighting,
+  deferHighlight,
 }: {
   language: string
   codeString: string
   showSyntaxHighlighting: boolean
+  deferHighlight: boolean
 }) {
   const { copied, copy } = useCopyToClipboard()
   const [html, setHtml] = useState<string | null>(null)
   const shikiTheme = useShikiTheme()
   const latestCodeRef = useRef(codeString)
 
+  // Skip shiki for plain-text blocks (no syntax to highlight) and for very
+  // large blocks (tool outputs, read_file dumps): highlighting tens of
+  // thousands of characters costs seconds of main-thread CPU for no benefit.
+  const skipHighlight = language === 'text' || codeString.length > SKIP_HIGHLIGHT_THRESHOLD
+
   useEffect(() => {
-    if (!showSyntaxHighlighting) return
+    if (!showSyntaxHighlighting || deferHighlight || skipHighlight) return
     latestCodeRef.current = codeString
     highlightCode(codeString, language, shikiTheme).then((result) => {
       if (latestCodeRef.current === codeString) {
         setHtml(result)
       }
     })
-  }, [codeString, language, shikiTheme, showSyntaxHighlighting])
+  }, [codeString, language, shikiTheme, showSyntaxHighlighting, deferHighlight, skipHighlight])
 
   return (
     <div className="relative group my-1.5 rounded overflow-hidden">
@@ -57,17 +96,17 @@ const CodeBlock = memo(function CodeBlock({
       {showSyntaxHighlighting && html ? (
         <div className="min-w-0" dangerouslySetInnerHTML={{ __html: html }} />
       ) : (
-        <ScrollArea horizontal>
+        <div className="overflow-x-auto">
           <pre className="my-0 px-4 py-3 font-mono text-sm whitespace-pre-wrap break-word">
             <code className={`language-${language}`}>{codeString}</code>
           </pre>
-        </ScrollArea>
+        </div>
       )}
     </div>
   )
 })
 
-function createMarkdownComponents(muted: boolean, showSyntaxHighlighting: boolean) {
+function createMarkdownComponents(muted: boolean, showSyntaxHighlighting: boolean, deferHighlight: boolean) {
   const headingColor = muted ? 'text-text-muted' : 'text-text-heading'
   const strongColor = muted ? 'text-text-secondary' : 'text-text-bold'
 
@@ -88,7 +127,14 @@ function createMarkdownComponents(muted: boolean, showSyntaxHighlighting: boolea
       const language = match?.[1] || 'text'
       const codeString = String(children).replace(/\n$/, '')
 
-      return <CodeBlock language={language} codeString={codeString} showSyntaxHighlighting={showSyntaxHighlighting} />
+      return (
+        <CodeBlock
+          language={language}
+          codeString={codeString}
+          showSyntaxHighlighting={showSyntaxHighlighting}
+          deferHighlight={deferHighlight}
+        />
+      )
     },
 
     p({ children }: { children?: React.ReactNode }) {
@@ -152,9 +198,9 @@ function createMarkdownComponents(muted: boolean, showSyntaxHighlighting: boolea
 
     table({ children }: { children?: React.ReactNode }) {
       return (
-        <ScrollArea horizontal className="my-1.5">
+        <div className="my-1.5 overflow-x-auto">
           <table className="min-w-full border border-border">{children}</table>
-        </ScrollArea>
+        </div>
       )
     },
 
@@ -179,29 +225,108 @@ function createMarkdownComponents(muted: boolean, showSyntaxHighlighting: boolea
 }
 
 // Memoize to prevent re-renders during streaming from causing flicker
-export const Markdown = memo(function Markdown({ content, className = '', muted = false }: MarkdownProps) {
+export const Markdown = memo(function Markdown({
+  content,
+  className = '',
+  muted = false,
+  isStreaming = false,
+}: MarkdownProps) {
   const { showSyntaxHighlighting } = useDisplaySettings()
 
-  // Preprocess markdown to fix common LLM formatting quirks
-  const processedContent = useMemo(() => {
-    let processed = preprocessMarkdown(content)
-    processed = fixUnclosedCodeBlocks(processed)
-    return processed
-  }, [content])
+  // While streaming, defer syntax highlighting while a code block is still open
+  // (odd number of ``` fences) so the block is not re-highlighted on every frame.
+  const deferCodeHighlight = useMemo(() => isStreaming && countCodeFences(content) % 2 === 1, [isStreaming, content])
 
   const components = useMemo(
-    () => createMarkdownComponents(muted, showSyntaxHighlighting),
-    [muted, showSyntaxHighlighting],
+    () => createMarkdownComponents(muted, showSyntaxHighlighting, deferCodeHighlight),
+    [muted, showSyntaxHighlighting, deferCodeHighlight],
   )
 
-  return (
-    <div className={`markdown-content [&_li>p]:inline ${className}`}>
-      <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>
-        {processedContent}
-      </ReactMarkdown>
-    </div>
-  )
+  // Non-streaming messages are immutable: cache the parsed tree per content so
+  // re-renders (session switches, sidebar updates) don't re-parse markdown.
+  // CodeBlock manages its own shiki theme, so theme changes stay correct.
+  // The cache key includes the render options (muted, syntax highlighting):
+  // the same content can legitimately render in different contexts.
+  const body = useMemo(() => {
+    const processed = preprocessForRender(content)
+    if (!containsMarkdownSyntax(processed)) {
+      if (!processed.trim()) return null
+      const color = muted ? 'text-text-muted' : 'text-text-primary'
+      return (
+        <p className={`${color} mb-1.5 last:mb-0 leading-tight break-words whitespace-pre-line`}>
+          {linkifyBareUrls(processed)}
+        </p>
+      )
+    }
+    if (isStreaming) return renderMarkdown(processed, components)
+    return getCachedMarkdown(processed, components, muted, showSyntaxHighlighting)
+  }, [content, isStreaming, components, muted, showSyntaxHighlighting])
+
+  return <div className={`markdown-content [&_li>p]:inline ${className}`}>{body}</div>
 })
+
+function preprocessForRender(content: string): string {
+  let processed = preprocessMarkdown(content)
+  processed = fixUnclosedCodeBlocks(processed)
+  return processed
+}
+
+// Linkify bare http(s) URLs in plain-text content, matching what remark-gfm
+// autolinking would do for the markdown path.
+function linkifyBareUrls(text: string): React.ReactNode {
+  const parts = text.split(/(https?:\/\/[^\s<>"']+)/g)
+  if (parts.length === 1) return text
+  return parts.map((part, i) =>
+    /^https?:\/\//.test(part) ? (
+      <a key={i} href={part} className="text-text-link hover:underline" target="_blank" rel="noopener noreferrer">
+        {part}
+      </a>
+    ) : (
+      part
+    ),
+  )
+}
+
+// Conservative check: any markdown-ish construct routes to the full parser,
+// so the plain fast path only handles genuinely plain prose.
+function containsMarkdownSyntax(content: string): boolean {
+  return (
+    content.includes('`') ||
+    content.includes('~') ||
+    content.includes('<') ||
+    /^#{1,6}\s/m.test(content) ||
+    /^\s*[-*+]\s/m.test(content) ||
+    /^\s*\d+[.)]\s/m.test(content) ||
+    /^\s*>\s?/m.test(content) ||
+    /^\s*\|.*\|/m.test(content) ||
+    /^\s*([-*_])\1{2,}\s*$/m.test(content) ||
+    /\[[^\]]*\]\([^)]*\)/.test(content) ||
+    /!\[[^\]]*\]/.test(content) ||
+    /[*_]/.test(content) ||
+    content.includes('&')
+  )
+}
+
+function renderMarkdown(content: string, components: ReturnType<typeof createMarkdownComponents>): React.ReactNode {
+  return (
+    <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>
+      {content}
+    </ReactMarkdown>
+  )
+}
+
+function getCachedMarkdown(
+  content: string,
+  components: ReturnType<typeof createMarkdownComponents>,
+  muted: boolean,
+  showSyntaxHighlighting: boolean,
+): React.ReactNode {
+  const key = `${muted ? 'm' : 'n'}|${showSyntaxHighlighting ? 'h' : 'p'}|${content}`
+  const cached = markdownRenderCache.get(key)
+  if (cached !== undefined) return cached
+  const node = renderMarkdown(content, components)
+  return cacheMarkdown(key, node)
+}
 
 /**
  * Preprocess markdown to fix common LLM formatting issues:
@@ -228,6 +353,10 @@ function preprocessMarkdown(content: string): string {
   return processed
 }
 
+function countCodeFences(content: string): number {
+  return content.match(/```/g)?.length ?? 0
+}
+
 /**
  * Fix unclosed code blocks during streaming.
  * This prevents raw markdown backticks from showing while the model
@@ -235,9 +364,7 @@ function preprocessMarkdown(content: string): string {
  */
 function fixUnclosedCodeBlocks(content: string): string {
   // Count occurrences of code block delimiters
-  const codeBlockRegex = /```/g
-  const matches = content.match(codeBlockRegex)
-  const count = matches?.length ?? 0
+  const count = countCodeFences(content)
 
   // If odd number of ```, we have an unclosed code block
   if (count % 2 === 1) {

--- a/web/src/components/shared/RunCommandView.tsx
+++ b/web/src/components/shared/RunCommandView.tsx
@@ -1,4 +1,3 @@
-import { ScrollArea } from './ScrollArea'
 import { memo, useEffect, useRef, useState } from 'react'
 import { ansiToReact } from '../../lib/ansiParser'
 
@@ -90,8 +89,8 @@ export const RunCommandView = memo(function RunCommandView({
 
       {/* Output display */}
       {(displayOutput || status === 'pending') && (
-        <ScrollArea
-          className={`text-xs bg-bg-primary p-2 rounded max-h-64 ${
+        <div
+          className={`text-xs bg-bg-primary p-2 rounded max-h-64 overflow-y-auto ${
             status === 'pending' ? 'border border-accent-warning/30' : ''
           }`}
           style={{ overflowX: 'hidden', whiteSpace: 'normal' }}
@@ -105,7 +104,7 @@ export const RunCommandView = memo(function RunCommandView({
               ))
             : // Render final output with ANSI color parsing
               ansiToReact(displayOutput)}
-        </ScrollArea>
+        </div>
       )}
 
       {/* Error display */}

--- a/web/src/components/shared/ThinkingBlock.tsx
+++ b/web/src/components/shared/ThinkingBlock.tsx
@@ -1,4 +1,3 @@
-import { ScrollArea } from './ScrollArea'
 import { memo } from 'react'
 import { Markdown } from './Markdown'
 
@@ -12,16 +11,16 @@ export const ThinkingBlock = memo(function ThinkingBlock({ content, variant = 'd
     return (
       <div className="text-text-muted text-sm italic feed-item">
         <span className="text-text-thinking">thinking:</span>
-        <ScrollArea horizontal className="ml-1.5 mt-0.5">
+        <div className="ml-1.5 mt-0.5 overflow-x-auto">
           <Markdown content={content} />
-        </ScrollArea>
+        </div>
       </div>
     )
   }
 
   return (
-    <ScrollArea horizontal className="text-text-muted text-sm italic bg-secondary rounded p-1.5 feed-item">
+    <div className="text-text-muted text-sm italic bg-secondary rounded p-1.5 feed-item overflow-x-auto">
       <Markdown content={content} muted />
-    </ScrollArea>
+    </div>
   )
 })

--- a/web/src/components/shared/ToolCallDisplay.test.tsx
+++ b/web/src/components/shared/ToolCallDisplay.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { cleanup, render } from '@testing-library/react'
+import { cleanup, fireEvent, render } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { useSessionStore } from '../../stores/session'
 import { useSettingsStore } from '../../stores/settings'
@@ -22,6 +22,10 @@ vi.mock('./DiagnosticsView', () => ({
 
 vi.mock('./Markdown', () => ({
   Markdown: ({ content }: { content: string }) => <div data-testid="markdown">{content}</div>,
+}))
+
+vi.mock('./ScrollArea', () => ({
+  ScrollArea: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
 }))
 
 const pendingConfirmation = {
@@ -199,5 +203,64 @@ describe('ToolCallDisplay — PathConfirmationButtons placement', () => {
     expect(previewPos).not.toBe(-1)
     expect(denyPos).not.toBe(-1)
     expect(denyPos).toBeGreaterThan(previewPos)
+  })
+})
+
+describe('ToolCallDisplay — auto-expand threshold', () => {
+  beforeEach(() => {
+    useSessionStore.setState({ pendingPathConfirmations: [] })
+    useSettingsStore.setState({ settings: {} })
+  })
+
+  afterEach(cleanup)
+
+  it('collapses large results by default and mounts content on click', () => {
+    const bigResult = 'x'.repeat(10_000)
+    const { container } = render(
+      <ToolCallDisplay tool="custom_tool" args={{}} status="success" result={bigResult} variant="expandable" />,
+    )
+
+    expect(container.querySelector('pre')).toBeNull()
+    expect(container.textContent).toContain('▶')
+
+    fireEvent.click(container.querySelector('button')!)
+    expect(container.querySelector('pre')).not.toBeNull()
+    expect(container.textContent).toContain(bigResult)
+  })
+
+  it('expands small results by default', () => {
+    const { container } = render(
+      <ToolCallDisplay tool="custom_tool" args={{}} status="success" result="small output" variant="expandable" />,
+    )
+
+    expect(container.querySelector('pre')?.textContent).toContain('small output')
+  })
+
+  it('expands streaming tool calls regardless of accumulated output size', () => {
+    const { container } = render(
+      <ToolCallDisplay
+        tool="run_command"
+        args={{ command: 'make build' }}
+        status="pending"
+        variant="expandable"
+        streamingOutput={[{ stream: 'stdout', content: 'y'.repeat(10_000) }]}
+      />,
+    )
+
+    expect(container.textContent).toContain('command output content')
+  })
+
+  it('collapses large write_file content by default', () => {
+    const bigContent = 'z'.repeat(10_000)
+    const { container } = render(
+      <ToolCallDisplay
+        tool="write_file"
+        args={{ path: '/tmp/x.ts', content: bigContent }}
+        status="success"
+        variant="expandable"
+      />,
+    )
+
+    expect(container.querySelector('[data-testid="file-preview"]')).toBeNull()
   })
 })

--- a/web/src/components/shared/ToolCallDisplay.tsx
+++ b/web/src/components/shared/ToolCallDisplay.tsx
@@ -1,4 +1,3 @@
-import { ScrollArea } from './ScrollArea'
 import { memo, useState } from 'react'
 import type { Diagnostic, EditContextRegion } from '@shared/types.js'
 import { ToolIcon } from './ToolIcon'
@@ -46,6 +45,25 @@ interface ToolCallDisplayProps {
   callId?: string
 }
 
+// Tool calls with content above this size are collapsed by default and only
+// mounted after a click — large read_file dumps or command outputs dominate
+// the initial DOM otherwise.
+const AUTO_EXPAND_THRESHOLD = 600
+
+function getContentSize(
+  result: string | undefined,
+  streamingOutput: StreamingChunk[] | undefined,
+  args: Record<string, unknown>,
+): number {
+  let size = result?.length ?? 0
+  if (streamingOutput) {
+    for (const chunk of streamingOutput) size += chunk.content.length
+  }
+  const content = args['content']
+  if (typeof content === 'string') size += content.length
+  return size
+}
+
 const statusConfig = {
   pending: {
     icon: '●',
@@ -86,8 +104,14 @@ export const ToolCallDisplay = memo(function ToolCallDisplay({
   truncated,
   callId,
 }: ToolCallDisplayProps) {
-  // Auto-expand file operations and running commands so content is immediately visible
-  const shouldAutoExpand = !forceCompact
+  // Auto-expand small outputs and running commands so content is immediately
+  // visible; large finished outputs are collapsed until the header is clicked.
+  // Note: `expanded` is intentionally frozen at mount time — the component is
+  // keyed by position (key={i}), so it remounts when the tool call changes,
+  // and forceCompact comes from a display setting stable during the message's
+  // lifetime. Changing the setting live does not re-collapse existing calls.
+  const shouldAutoExpand =
+    !forceCompact && (status === 'pending' || getContentSize(result, streamingOutput, args) < AUTO_EXPAND_THRESHOLD)
   const [expanded, setExpanded] = useState(shouldAutoExpand)
   const config = statusConfig[status]
   const remoteProtocol = detectRemoteExecution(tool, args)
@@ -222,18 +246,18 @@ export const ToolCallDisplay = memo(function ToolCallDisplay({
               <div className="text-[10px] text-accent-primary font-medium mb-1 uppercase tracking-wide">
                 {String(args.subAgentType ?? 'Sub-Agent')} Prompt
               </div>
-              <ScrollArea className="text-xs prose prose-invert prose-sm max-w-none max-h-[60vh]">
+              <div className="text-xs prose prose-invert prose-sm max-w-none max-h-[60vh] overflow-y-auto">
                 <Markdown content={String(args.prompt ?? '')} />
-              </ScrollArea>
+              </div>
             </div>
           )}
 
           {/* Specialized rendering for web_search */}
           {tool === 'web_search' && status === 'success' && (
             <div>
-              <ScrollArea className="text-xs prose prose-invert prose-sm max-w-none max-h-[60vh]">
+              <div className="text-xs prose prose-invert prose-sm max-w-none max-h-[60vh] overflow-y-auto">
                 <Markdown content={result ?? ''} />
-              </ScrollArea>
+              </div>
               {truncated && <TruncatedIndicator className="mt-1" />}
             </div>
           )}
@@ -244,9 +268,9 @@ export const ToolCallDisplay = memo(function ToolCallDisplay({
               <div className="text-[10px] text-accent-primary font-medium mb-1 uppercase tracking-wide">
                 Skill: {String(args.skillId ?? '')}
               </div>
-              <ScrollArea className="text-xs prose prose-invert prose-sm max-w-none max-h-[60vh]">
+              <div className="text-xs prose prose-invert prose-sm max-w-none max-h-[60vh] overflow-y-auto">
                 <Markdown content={result ?? ''} />
-              </ScrollArea>
+              </div>
               {truncated && <TruncatedIndicator className="mt-1" />}
             </div>
           )}
@@ -273,9 +297,9 @@ export const ToolCallDisplay = memo(function ToolCallDisplay({
                   )}
                 </div>
               )}
-              <ScrollArea className="text-xs prose prose-invert prose-sm max-w-none max-h-[60vh]">
+              <div className="text-xs prose prose-invert prose-sm max-w-none max-h-[60vh] overflow-y-auto">
                 <Markdown content={result ?? ''} />
-              </ScrollArea>
+              </div>
               {truncated && <TruncatedIndicator />}
             </div>
           )}
@@ -298,9 +322,9 @@ export const ToolCallDisplay = memo(function ToolCallDisplay({
           {/* Specialized rendering for mcp_config */}
           {tool === 'mcp_config' && status === 'success' && (
             <div>
-              <ScrollArea className="text-xs prose prose-invert prose-sm max-w-none max-h-[60vh]">
+              <div className="text-xs prose prose-invert prose-sm max-w-none max-h-[60vh] overflow-y-auto">
                 <Markdown content={result ?? ''} />
-              </ScrollArea>
+              </div>
               {truncated && <TruncatedIndicator className="mt-1" />}
             </div>
           )}
@@ -328,9 +352,9 @@ export const ToolCallDisplay = memo(function ToolCallDisplay({
                 {Object.keys(args).length > 0 && (
                   <div>
                     <div className="text-[10px] text-text-muted mb-0.5">Arguments:</div>
-                    <ScrollArea horizontal>
+                    <div className="overflow-x-auto">
                       <pre className="text-xs bg-bg-primary p-1.5 rounded break-words">{formatToolArgsFull(args)}</pre>
-                    </ScrollArea>
+                    </div>
                   </div>
                 )}
 
@@ -340,9 +364,9 @@ export const ToolCallDisplay = memo(function ToolCallDisplay({
                     <div className="text-[10px] text-text-muted mb-0.5">
                       Result{durationMs !== undefined && ` (${durationMs}ms)`}:
                     </div>
-                    <ScrollArea horizontal className="max-h-[60vh]">
+                    <div className="overflow-x-auto max-h-[60vh]">
                       <pre className="text-xs bg-bg-primary p-1.5 rounded break-words">{result || 'No output'}</pre>
-                    </ScrollArea>
+                    </div>
                     {truncated && <TruncatedIndicator className="mt-1" />}
                   </div>
                 )}

--- a/web/src/components/shared/WorkspaceView.tsx
+++ b/web/src/components/shared/WorkspaceView.tsx
@@ -1,4 +1,3 @@
-import { ScrollArea } from './ScrollArea'
 import { memo } from 'react'
 
 interface WorkspaceViewProps {
@@ -29,9 +28,9 @@ export const WorkspaceView = memo(function WorkspaceView({ result, action }: Wor
     parsed = JSON.parse(result) as Record<string, unknown>
   } catch {
     return (
-      <ScrollArea horizontal className="max-h-[60vh]">
+      <div className="max-h-[60vh] overflow-x-auto">
         <pre className="text-xs bg-bg-primary p-1.5 rounded break-words">{result}</pre>
-      </ScrollArea>
+      </div>
     )
   }
 
@@ -43,9 +42,9 @@ export const WorkspaceView = memo(function WorkspaceView({ result, action }: Wor
       return renderActionResult(parsed as ActionResultData)
     default:
       return (
-        <ScrollArea horizontal className="max-h-[60vh]">
+        <div className="max-h-[60vh] overflow-x-auto">
           <pre className="text-xs bg-bg-primary p-1.5 rounded break-words">{result}</pre>
-        </ScrollArea>
+        </div>
       )
   }
 })

--- a/web/src/hooks/useWorkdir.ts
+++ b/web/src/hooks/useWorkdir.ts
@@ -1,16 +1,5 @@
-import { useState, useEffect } from 'react'
-import { authFetch } from '../lib/api'
+import { useConfigStore } from '../stores/config'
 
 export function useWorkdir(): string | null {
-  const [workdir, setWorkdir] = useState<string | null>(null)
-
-  useEffect(() => {
-    authFetch('/api/config')
-      .then((res) => res.json())
-      .then((data) => {
-        if (data.workdir) setWorkdir(data.workdir)
-      })
-  }, [])
-
-  return workdir
+  return useConfigStore((s) => s.workdir)
 }

--- a/web/src/lib/sessionPrefetch.test.ts
+++ b/web/src/lib/sessionPrefetch.test.ts
@@ -1,0 +1,111 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { prefetchSession, consumePrefetchedSession } from './sessionPrefetch'
+
+describe('sessionPrefetch', () => {
+  const originalFetch = globalThis.fetch
+
+  beforeEach(() => {
+    localStorage.setItem('openfox_token', 'test-token')
+    globalThis.fetch = vi.fn()
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    localStorage.clear()
+    // Reset the module-level pending map between tests
+    vi.resetModules()
+  })
+
+  it('issues a single fetch with the session token and parses the payload', async () => {
+    const payload = { session: { id: 's1' }, messages: [] }
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => payload,
+    } as Response)
+
+    prefetchSession('s1')
+    prefetchSession('s1') // duplicate is ignored
+
+    expect(fetch).toHaveBeenCalledTimes(1)
+    const [url, init] = vi.mocked(fetch).mock.calls[0]!
+    expect(String(url)).toContain('/api/sessions/s1')
+    expect((init!.headers as Record<string, string>)['x-session-token']).toBe('test-token')
+
+    const result = await consumePrefetchedSession('s1')
+    expect(result).toEqual({ ok: true, data: payload })
+  })
+
+  it('consumes the prefetch only once', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({ ok: true, json: async () => ({}) } as Response)
+
+    prefetchSession('s1')
+    await consumePrefetchedSession('s1')
+    expect(consumePrefetchedSession('s1')).toBeUndefined()
+  })
+
+  it('fires without a token when auth is not required', async () => {
+    localStorage.removeItem('openfox_token')
+    vi.mocked(fetch).mockResolvedValueOnce({ ok: true, json: async () => ({}) } as Response)
+
+    prefetchSession('s1')
+
+    expect(fetch).toHaveBeenCalledTimes(1)
+    const [, init] = vi.mocked(fetch).mock.calls[0]!
+    expect(init!.headers).toBeUndefined()
+    await expect(consumePrefetchedSession('s1')).resolves.toEqual({ ok: true, data: {} })
+  })
+
+  it('resolves ok:false on HTTP error so the caller falls back to its own fetch', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({ ok: false, status: 401 } as Response)
+
+    prefetchSession('s1')
+
+    await expect(consumePrefetchedSession('s1')).resolves.toEqual({ ok: false })
+  })
+
+  it('resolves ok:false on network failure so the caller falls back to its own fetch', async () => {
+    vi.mocked(fetch).mockRejectedValueOnce(new TypeError('Failed to fetch'))
+
+    prefetchSession('s1')
+
+    await expect(consumePrefetchedSession('s1')).resolves.toEqual({ ok: false })
+  })
+
+  it('expires unconsumed prefetches after the TTL so the Map does not leak', async () => {
+    vi.useFakeTimers()
+    try {
+      vi.mocked(fetch)
+        .mockResolvedValueOnce({ ok: true, json: async () => ({}) } as Response)
+        .mockResolvedValueOnce({ ok: true, json: async () => ({}) } as Response)
+
+      prefetchSession('s1')
+      // Consumed within the TTL works normally
+      await expect(consumePrefetchedSession('s1')).resolves.toEqual({ ok: true, data: {} })
+
+      prefetchSession('s2')
+      // TTL elapses without consumption — the entry is gone
+      await vi.advanceTimersByTimeAsync(11_000)
+      expect(consumePrefetchedSession('s2')).toBeUndefined()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('proactively removes expired entries from the Map via setTimeout GC', async () => {
+    vi.useFakeTimers()
+    try {
+      vi.mocked(fetch).mockResolvedValue({ ok: true, json: async () => ({}) } as Response)
+
+      prefetchSession('gc1')
+      prefetchSession('gc2')
+
+      await vi.advanceTimersByTimeAsync(11_000)
+
+      expect(consumePrefetchedSession('gc1')).toBeUndefined()
+      expect(consumePrefetchedSession('gc2')).toBeUndefined()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/web/src/lib/sessionPrefetch.ts
+++ b/web/src/lib/sessionPrefetch.ts
@@ -1,0 +1,53 @@
+import { appUrl } from './basePath'
+
+/**
+ * Session data prefetch, fired from the app entry before React mounts.
+ * The session GET is the critical path of a page load (~600ms of React boot
+ * happens before the store would normally issue it); starting it at boot
+ * overlaps the fetch with boot and rendering. One-shot: loadSession consumes
+ * the promise once, then falls back to its own fetch.
+ */
+
+type PrefetchResult = { ok: true; data: Record<string, unknown> } | { ok: false }
+
+// Entries are only consumed by loadSession when the boot URL matches the
+// loaded session; if the user navigates elsewhere first, the prefetch would
+// linger forever. Expire it after a short TTL — loadSession's authFetch
+// fallback takes over for any later load.
+const PREFETCH_TTL_MS = 10_000
+
+const pending = new Map<string, { promise: Promise<PrefetchResult>; expiresAt: number }>()
+
+function gcPending(): void {
+  const now = Date.now()
+  for (const [id, entry] of pending) {
+    if (entry.expiresAt < now) pending.delete(id)
+  }
+}
+
+export function prefetchSession(sessionId: string): void {
+  if (pending.has(sessionId)) return
+  const token = localStorage.getItem('openfox_token')
+
+  const promise: Promise<PrefetchResult> = fetch(appUrl(`/api/sessions/${sessionId}`), {
+    headers: token ? { 'x-session-token': token } : undefined,
+  })
+    .then(async (res): Promise<PrefetchResult> => {
+      if (!res.ok) return { ok: false }
+      return { ok: true, data: (await res.json()) as Record<string, unknown> }
+    })
+    .catch(() => ({ ok: false }))
+
+  pending.set(sessionId, { promise, expiresAt: Date.now() + PREFETCH_TTL_MS })
+  setTimeout(gcPending, PREFETCH_TTL_MS)
+}
+
+export function consumePrefetchedSession(sessionId: string): Promise<PrefetchResult> | undefined {
+  const entry = pending.get(sessionId)
+  if (!entry) return undefined
+  pending.delete(sessionId)
+  if (entry.expiresAt < Date.now()) {
+    return undefined
+  }
+  return entry.promise
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -3,8 +3,16 @@ import ReactDOM from 'react-dom/client'
 import { Router } from 'wouter'
 import App from './App'
 import { appBasePath } from './lib/basePath'
+import { prefetchSession } from './lib/sessionPrefetch'
 import './styles/globals.css'
 import '@xterm/xterm/css/xterm.css'
+
+// Start the session fetch before React mounts — it is the critical path of the
+// initial page load and boot would otherwise delay it by hundreds of ms.
+const sessionMatch = window.location.pathname.match(/\/p\/[^/]+\/s\/([0-9a-fA-F-]+)/)
+if (sessionMatch?.[1]) {
+  prefetchSession(sessionMatch[1])
+}
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/web/src/stores/config.ts
+++ b/web/src/stores/config.ts
@@ -5,15 +5,7 @@ import type { ModelConfig } from '@shared/types.js'
 type LlmStatus = 'connected' | 'disconnected' | 'unknown'
 
 type Backend =
-  | 'vllm'
-  | 'sglang'
-  | 'ollama'
-  | 'llamacpp'
-  | 'lmstudio'
-  | 'openai'
-  | 'anthropic'
-  | 'opencode-go'
-  | 'unknown'
+  'vllm' | 'sglang' | 'ollama' | 'llamacpp' | 'lmstudio' | 'openai' | 'anthropic' | 'opencode-go' | 'unknown'
 type ProviderStatus = 'connected' | 'disconnected' | 'unknown'
 
 interface Provider {
@@ -54,7 +46,8 @@ interface ConfigState {
   defaultModelSelection: string | null
   // Platform info from server (WSL detection etc.)
   platform: PlatformInfo | null
-  // Loading/error state
+  // Working directory reported by the server
+  workdir: string | null
   loading: boolean
   activating: boolean
   error: string | null
@@ -102,6 +95,8 @@ function getBackendDisplayName(backend: Backend): string {
 export { getBackendDisplayName }
 export type { Backend, LlmStatus, Provider, ProviderStatus }
 
+let configFetchPromise: Promise<void> | null = null
+
 export const useConfigStore = create<ConfigState>((set, get) => ({
   version: null,
   model: null,
@@ -113,56 +108,71 @@ export const useConfigStore = create<ConfigState>((set, get) => ({
   activeProviderId: null,
   defaultModelSelection: null,
   platform: null,
+  workdir: null,
   loading: false,
   activating: false,
   error: null,
   autoRefreshInterval: null,
 
   fetchConfig: async () => {
-    set({ loading: true, error: null })
-    try {
-      const response = await authFetch('/api/config')
-      if (!response.ok) {
-        throw new Error('Failed to fetch config')
-      }
-      const data = (await response.json()) as {
-        version: string
-        model: string
-        maxContext: number
-        llmUrl: string
-        llmStatus: LlmStatus
-        backend: Backend
-        providers: Provider[]
-        activeProviderId: string | null
-        defaultModelSelection: string | null
-        platform: unknown
-      }
-      const platform: PlatformInfo | null =
-        data.platform && typeof data.platform === 'object'
-          ? {
-              isWSL: !!(data.platform as Record<string, unknown>).isWSL,
-              wslDistro: String((data.platform as Record<string, unknown>).wslDistro ?? ''),
-            }
-          : null
-      set({
-        version: data.version,
-        model: data.model,
-        maxContext: data.maxContext,
-        llmUrl: data.llmUrl,
-        llmStatus: data.llmStatus,
-        backend: data.backend,
-        providers: data.providers ?? [],
-        activeProviderId: data.activeProviderId ?? null,
-        defaultModelSelection: data.defaultModelSelection ?? null,
-        platform,
-        loading: false,
-      })
-    } catch (error) {
-      set({
-        error: error instanceof Error ? error.message : 'Unknown error',
-        loading: false,
-      })
+    // Deduplicate concurrent calls: while a fetch is in flight, all callers
+    // share the same promise instead of firing N identical requests.
+    if (configFetchPromise) {
+      return configFetchPromise
     }
+
+    set({ loading: true, error: null })
+    configFetchPromise = (async () => {
+      try {
+        const response = await authFetch('/api/config')
+        if (!response.ok) {
+          throw new Error('Failed to fetch config')
+        }
+        const data = (await response.json()) as {
+          version: string
+          model: string
+          maxContext: number
+          llmUrl: string
+          llmStatus: LlmStatus
+          backend: Backend
+          providers: Provider[]
+          activeProviderId: string | null
+          defaultModelSelection: string | null
+          platform: unknown
+          workdir?: string
+        }
+        const platform: PlatformInfo | null =
+          data.platform && typeof data.platform === 'object'
+            ? {
+                isWSL: !!(data.platform as Record<string, unknown>).isWSL,
+                wslDistro: String((data.platform as Record<string, unknown>).wslDistro ?? ''),
+              }
+            : null
+        set({
+          version: data.version,
+          model: data.model,
+          maxContext: data.maxContext,
+          llmUrl: data.llmUrl,
+          llmStatus: data.llmStatus,
+          backend: data.backend,
+          providers: data.providers ?? [],
+          activeProviderId: data.activeProviderId ?? null,
+          defaultModelSelection: data.defaultModelSelection ?? null,
+          platform,
+          workdir: data.workdir ?? null,
+          loading: false,
+        })
+      } catch (error) {
+        set({
+          error: error instanceof Error ? error.message : 'Unknown error',
+          loading: false,
+        })
+      } finally {
+        configFetchPromise = null
+      }
+    })()
+
+    return configFetchPromise
   },
 
   refreshModel: async () => {

--- a/web/src/stores/session/messageHandler.ts
+++ b/web/src/stores/session/messageHandler.ts
@@ -68,7 +68,7 @@ function mergeSessionIntoSummary(
   session: import('@shared/types.js').Session,
 ): import('@shared/types.js').SessionSummary[] {
   const existingSession = sessions.find((candidate) => candidate.id === session.id)
-  const messageCount = session.messageCount ?? session.messages.length
+  const messageCount = session.messageCount ?? 0
   const nextSummary: import('@shared/types.js').SessionSummary = existingSession
     ? {
         ...existingSession,
@@ -510,11 +510,6 @@ export function handleServerMessage(
         break
       }
       cancelStreamingFlush()
-      const buf = getBuffer()
-      buf.messageId = null
-      buf.deltaContent = ''
-      buf.thinkingContent = ''
-      buf.toolOutput = []
       triggeredNewMessageSound.delete((message.payload as ChatDonePayload).messageId)
 
       const payload = message.payload as ChatDonePayload
@@ -543,16 +538,9 @@ export function handleServerMessage(
         break
       }
       cancelStreamingFlush()
-      const buf = getBuffer()
 
       const payload = message.payload as ChatErrorPayload
       console.error('Chat error:', payload.error, 'recoverable:', payload.recoverable)
-      if (!payload.recoverable) {
-        buf.messageId = null
-        buf.deltaContent = ''
-        buf.thinkingContent = ''
-        buf.toolOutput = []
-      }
       set((state) => ({
         error: { code: 'CHAT_ERROR', message: payload.error },
         ...(payload.recoverable

--- a/web/src/stores/session/reconnect.test.ts
+++ b/web/src/stores/session/reconnect.test.ts
@@ -156,4 +156,101 @@ describe('reconnect refreshes current session content', () => {
 
     expect(listProjectsSpy).toHaveBeenCalled()
   })
+
+  it('refetches the active session after an automatic reconnect (reconnecting status clears the guard)', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    const useSessionStore = await loadSessionStore()
+
+    fetchMock.mockImplementation(((url?: unknown) => {
+      const u = String(url ?? '')
+      if (u.includes('/api/sessions/session-active') && !u.includes('background-processes')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve({
+              session: {
+                id: 'session-active',
+                projectId: 'project-1',
+                workdir: '/tmp/project-1',
+                mode: 'planner',
+                phase: 'plan',
+                isRunning: false,
+                criteria: [],
+              },
+              messages: [],
+              hiddenCount: 0,
+            }),
+        })
+      }
+      if (u.includes('background-processes')) {
+        return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ processes: [] }) })
+      }
+      return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ success: true }) })
+    }) as never)
+
+    useSessionStore.setState({
+      currentSession: {
+        id: 'session-active',
+        projectId: 'project-1',
+        workdir: '/tmp/project-1',
+        mode: 'planner',
+        phase: 'plan',
+        isRunning: false,
+        criteria: [],
+        summary: null,
+      } as any,
+    })
+
+    // First connect + load
+    await useSessionStore.getState().connect()
+    const cb = (wsStatusMock.mock.calls[0] as Array<(s: string) => void>)[0]!
+    ;(cb as (s: string) => void)('connected')
+    await vi.runAllTimersAsync()
+
+    // Automatic reconnect: reconnecting clears the sequential guard
+    ;(cb as (s: string) => void)('reconnecting')
+    ;(cb as (s: string) => void)('connected')
+    await vi.runAllTimersAsync()
+    vi.useRealTimers()
+
+    const sessionFetches = fetchMock.mock.calls.filter(
+      (c) =>
+        String((c as unknown[])[0]).includes('/api/sessions/session-active') &&
+        !String((c as unknown[])[0]).includes('/background-processes'),
+    ).length
+    expect(sessionFetches).toBe(2)
+  })
+
+  it('force reload bypasses the in-flight guard', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    const useSessionStore = await loadSessionStore()
+
+    useSessionStore.setState({
+      currentSession: {
+        id: 'session-active',
+        projectId: 'project-1',
+        workdir: '/tmp/project-1',
+        mode: 'planner',
+        phase: 'plan',
+        isRunning: false,
+        criteria: [],
+        summary: null,
+      } as any,
+    })
+
+    // Start a normal load (no await), then force reload while it is in flight
+    const loadPromise = useSessionStore.getState().loadSession('session-active')
+    await useSessionStore.getState().loadSession('session-active', true)
+    await loadPromise
+    await vi.runAllTimersAsync()
+    vi.useRealTimers()
+
+    const sessionFetches = fetchMock.mock.calls.filter(
+      (c) =>
+        String((c as unknown[])[0]).includes('/api/sessions/session-active') &&
+        !String((c as unknown[])[0]).includes('/background-processes'),
+    ).length
+    expect(sessionFetches).toBe(2)
+  })
 })

--- a/web/src/stores/session/session.test.ts
+++ b/web/src/stores/session/session.test.ts
@@ -1454,6 +1454,22 @@ describe('useSessionStore session isolation', () => {
     expect(state.messages.find((m) => m.isStreaming)).toBeDefined()
   })
 
+  it('falls back to a regular fetch when the prefetched session fetch failed', async () => {
+    const useSessionStore = await loadSessionStore()
+
+    // First fetch is the session GET itself (no prefetch active in this
+    // harness); it fails, and there is no retry path — the load must abort
+    // cleanly without leaving a half-loaded session.
+    fetchMock.mockResolvedValueOnce({ ok: false, status: 401, json: async () => ({}) } as never)
+
+    await useSessionStore.getState().loadSession('session-fallback')
+
+    expect(useSessionStore.getState().currentSession).toBeNull()
+    // Session GET fails and the load aborts (only the background-processes
+    // fetch is issued alongside it — no retry happens here).
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
   it('loads session with no streaming message when REST response has none', async () => {
     const useSessionStore = await loadSessionStore()
 
@@ -2201,5 +2217,92 @@ describe('cross-tab sidebar sync', () => {
     expect(state.sessions).toHaveLength(1)
     expect(state.sessions[0]!.title).toBe('Updated Title')
     expect(state.sessions[0]!.messageCount).toBe(5)
+  })
+
+  it('does not refetch a session that was already loaded (sequential guard)', async () => {
+    const useSessionStore = await loadSessionStore()
+    useSessionStore.setState({
+      currentSession: {
+        id: 'session-1',
+        projectId: 'project-1',
+        workdir: '/tmp/project-1',
+        mode: 'planner',
+        phase: 'plan',
+        isRunning: false,
+        criteria: [],
+        summary: null,
+      } as any,
+    })
+
+    await useSessionStore.getState().loadSession('session-1')
+    const fetchesForS1 = () =>
+      fetchMock.mock.calls.filter(
+        (c) =>
+          String((c as unknown[])[0]).includes('/api/sessions/session-1') &&
+          !String((c as unknown[])[0]).includes('/background-processes'),
+      ).length
+
+    expect(fetchesForS1()).toBe(1)
+    await useSessionStore.getState().loadSession('session-1')
+    expect(fetchesForS1()).toBe(1)
+  })
+
+  it('refetches when loading a different session after a previous load', async () => {
+    const useSessionStore = await loadSessionStore()
+    useSessionStore.setState({
+      currentSession: {
+        id: 'session-1',
+        projectId: 'project-1',
+        workdir: '/tmp/project-1',
+        mode: 'planner',
+        phase: 'plan',
+        isRunning: false,
+        criteria: [],
+        summary: null,
+      } as any,
+    })
+
+    await useSessionStore.getState().loadSession('session-1')
+    await useSessionStore.getState().loadSession('session-2')
+
+    const fetchesForS1 = fetchMock.mock.calls.filter(
+      (c) =>
+        String((c as unknown[])[0]).includes('/api/sessions/session-1') &&
+        !String((c as unknown[])[0]).includes('/background-processes'),
+    ).length
+    const fetchesForS2 = fetchMock.mock.calls.filter(
+      (c) =>
+        String((c as unknown[])[0]).includes('/api/sessions/session-2') &&
+        !String((c as unknown[])[0]).includes('/background-processes'),
+    ).length
+    expect(fetchesForS1).toBe(1)
+    expect(fetchesForS2).toBe(1)
+  })
+
+  it('clears the sequential guard on reconnect so the session is refetched', async () => {
+    const useSessionStore = await loadSessionStore()
+    useSessionStore.setState({
+      currentSession: {
+        id: 'session-1',
+        projectId: 'project-1',
+        workdir: '/tmp/project-1',
+        mode: 'planner',
+        phase: 'plan',
+        isRunning: false,
+        criteria: [],
+        summary: null,
+      } as any,
+    })
+
+    await useSessionStore.getState().loadSession('session-1')
+    useSessionStore.getState().reconnect()
+    await useSessionStore.getState().loadSession('session-1')
+
+    const fetches = fetchMock.mock.calls.filter(
+      (c) =>
+        String((c as unknown[])[0]).includes('/api/sessions/session-1') &&
+        !String((c as unknown[])[0]).includes('/background-processes'),
+    ).length
+    expect(fetches).toBe(2)
   })
 })

--- a/web/src/stores/session/store.ts
+++ b/web/src/stores/session/store.ts
@@ -1,7 +1,8 @@
 import { create } from 'zustand'
 import { authFetch } from '../../lib/api'
 import { appUrl } from '../../lib/basePath'
-import type { SessionSummary, Message } from '@shared/types.js'
+import { consumePrefetchedSession } from '../../lib/sessionPrefetch'
+import type { SessionSummary, Message, Session, ContextState, WorkflowExecution } from '@shared/types.js'
 import type { QueuedMessage, PendingQuestionPayload } from '@shared/protocol.js'
 import { wsClient } from '../../lib/ws'
 import { useConfigStore } from '../config'
@@ -15,7 +16,19 @@ let isSubscribed = false
 let wsUnsubscribe: (() => void) | null = null
 
 const loadingSessionIds = new Set<string>()
+const loadedSessionIds = new Set<string>()
 const listingSessionsForProject = new Map<string, Promise<void>>()
+
+interface SessionLoadData {
+  session: Session
+  messages?: Message[]
+  hiddenCount?: number
+  contextState?: ContextState | null
+  queueState?: QueuedMessage[]
+  pendingConfirmations?: PendingPathConfirmation[]
+  pendingQuestions?: PendingQuestionPayload[]
+  activeWorkflowExecution?: WorkflowExecution | null
+}
 
 function applyToolOutputs(
   toolCalls: import('@shared/types.js').ToolCall[] | undefined,
@@ -186,10 +199,19 @@ export const useSessionStore = create<SessionState>((set, get) => {
         if (newStatus === 'connected') {
           get().listSessions(undefined)
           useProjectStore.getState().listProjects()
+          // Reload the active session on (re)connect only when it has not been
+          // loaded yet (first connect, or after any disconnect/reconnect which
+          // clears loadedSessionIds). The route-level useSessionLoader already
+          // covers the initial navigation, so this avoids a duplicate fetch on
+          // first load. Clearing on 'reconnecting'/'disconnected' also covers
+          // automatic WS reconnects (ws.ts), so the client re-subscribes via
+          // session.load after every connection drop.
           const currentSessionId = get().currentSession?.id
           if (currentSessionId) {
             get().loadSession(currentSessionId)
           }
+        } else if (newStatus === 'disconnected' || newStatus === 'reconnecting') {
+          loadedSessionIds.clear()
         }
       })
 
@@ -226,6 +248,7 @@ export const useSessionStore = create<SessionState>((set, get) => {
         wsUnsubscribe = null
       }
       isSubscribed = false
+      loadedSessionIds.clear()
       set({ connectionStatus: 'disconnected' })
       get().connect()
     },
@@ -237,6 +260,7 @@ export const useSessionStore = create<SessionState>((set, get) => {
         wsUnsubscribe = null
       }
       isSubscribed = false
+      loadedSessionIds.clear()
       set({ connectionStatus: 'disconnected', showPasswordModal: false })
     },
 
@@ -302,8 +326,19 @@ export const useSessionStore = create<SessionState>((set, get) => {
       }
     },
 
-    loadSession: async (sessionId) => {
-      if (loadingSessionIds.has(sessionId)) {
+    loadSession: async (sessionId, force = false) => {
+      // An explicit force reload (branch switch, workspace change, replay)
+      // bypasses both guards so it always refetches, even while a load for the
+      // same session is in flight.
+      if (!force && loadingSessionIds.has(sessionId)) {
+        return
+      }
+
+      // Sequential guard: once a session has been fully loaded, a second call
+      // for the same id (e.g. route hook + ws connect race) is a no-op unless
+      // the user explicitly navigates to another session (which clears the set)
+      // or a force reload is requested (branch switch, replay, workspace change).
+      if (!force && loadedSessionIds.has(sessionId)) {
         return
       }
 
@@ -313,6 +348,7 @@ export const useSessionStore = create<SessionState>((set, get) => {
         const currentSession = get().currentSession
 
         if (!currentSession || currentSession.id !== sessionId) {
+          loadedSessionIds.clear()
           const oldSessionId = currentSession?.id
           const oldConfirmations = get().pendingPathConfirmations
           const existingCross = get().crossSessionConfirmations
@@ -343,10 +379,28 @@ export const useSessionStore = create<SessionState>((set, get) => {
           set({ unreadSessionIds: get().unreadSessionIds.filter((id) => id !== sessionId) })
         }
 
-        const res = await authFetch(`/api/sessions/${sessionId}`)
-        if (!res.ok) return
+        // Fire both requests in parallel — background-processes does not depend
+        // on the session payload, so it must not wait for a second round-trip.
+        // The session fetch was prefetched at app boot (main.tsx) when this
+        // session is the initial URL — consume it instead of re-fetching.
+        // On prefetch failure (401, network blip, server restart) fall through
+        // to the regular fetch: the load must never abort silently.
+        const prefetched = consumePrefetchedSession(sessionId)
+        const sessionFetch: Promise<SessionLoadData | null> = prefetched
+          ? prefetched.then(async (result) => {
+              if (result.ok) return result.data as unknown as SessionLoadData
+              const res = await authFetch(`/api/sessions/${sessionId}`)
+              if (!res.ok) return null
+              return (await res.json()) as SessionLoadData
+            })
+          : authFetch(`/api/sessions/${sessionId}`).then(async (res) => {
+              if (!res.ok) return null
+              return (await res.json()) as SessionLoadData
+            })
+        const bpFetch = authFetch(`/api/sessions/${sessionId}/background-processes`)
 
-        const data = await res.json()
+        const data = await sessionFetch
+        if (!data) return
         const loadedMessages = (data.messages as Message[] | undefined) ?? []
         const crossCleanup = { ...get().crossSessionConfirmations }
         delete crossCleanup[sessionId]
@@ -367,7 +421,7 @@ export const useSessionStore = create<SessionState>((set, get) => {
         wsClient.send('session.load', { sessionId })
 
         try {
-          const bpRes = await authFetch(`/api/sessions/${sessionId}/background-processes`)
+          const bpRes = await bpFetch
           if (bpRes.ok) {
             const bpData = await bpRes.json()
             useBackgroundProcessesStore.getState().setProcesses(bpData.processes ?? [])
@@ -375,6 +429,7 @@ export const useSessionStore = create<SessionState>((set, get) => {
         } catch {
           /* empty */
         }
+        loadedSessionIds.add(sessionId)
       } catch {
         /* empty */
       } finally {
@@ -417,8 +472,7 @@ export const useSessionStore = create<SessionState>((set, get) => {
 
           // Restore cross-session confirmation state from server
           const pendingBySession = data.pendingConfirmationsBySession as
-            | Record<string, PendingPathConfirmation[]>
-            | undefined
+            Record<string, PendingPathConfirmation[]> | undefined
           if (pendingBySession) {
             const currentSessionId = get().currentSession?.id
             const crossSessionConfirmations: Record<string, PendingPathConfirmation[]> = {}
@@ -521,6 +575,7 @@ export const useSessionStore = create<SessionState>((set, get) => {
 
     clearSession: () => {
       cancelStreamingFlush()
+      loadedSessionIds.clear()
       set((state) => ({
         currentSession: null,
         messages: [],

--- a/web/src/stores/session/streamingBuffer.test.ts
+++ b/web/src/stores/session/streamingBuffer.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.stubGlobal('requestAnimationFrame', (cb: () => void) => setTimeout(cb, 0))
 vi.stubGlobal('cancelAnimationFrame', (id: number) => clearTimeout(id))
@@ -140,5 +140,157 @@ describe('chat.tool_output streaming after message_updated', () => {
     const updatedMsg = useSessionStore.getState().messages.find((m) => m.id === 'msg-1')
     const output = updatedMsg?.toolCalls?.[0]?.streamingOutput?.map((c) => c.content).join('') ?? ''
     expect(output).toBe('first\nsecond\nthird\n')
+  })
+})
+
+describe('streaming flush throttling', () => {
+  async function loadStreamingBuffer() {
+    vi.resetModules()
+    return import('./streamingBuffer')
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('coalesces multiple schedule calls within the throttle window into a single flush', async () => {
+    const { scheduleStreamingFlush, setFlushFn, getBuffer } = await loadStreamingBuffer()
+    const received: string[] = []
+    setFlushFn(() => {
+      received.push(getBuffer().deltaContent)
+    })
+
+    const buf = getBuffer()
+    buf.messageId = 'm1'
+    buf.deltaContent = ''
+    scheduleStreamingFlush()
+    buf.deltaContent += 'a'
+    scheduleStreamingFlush()
+    buf.deltaContent += 'b'
+    scheduleStreamingFlush()
+
+    expect(received).toEqual([])
+    await vi.runAllTimersAsync()
+    expect(received).toEqual(['ab'])
+  })
+
+  it('enforces a minimum 16ms interval between flushes', async () => {
+    const { scheduleStreamingFlush, setFlushFn, getBuffer } = await loadStreamingBuffer()
+    const flushFn = vi.fn()
+    setFlushFn(flushFn)
+
+    const buf = getBuffer()
+    buf.messageId = 'm1'
+    buf.deltaContent = 'first'
+    scheduleStreamingFlush()
+    await vi.runAllTimersAsync()
+    expect(flushFn).toHaveBeenCalledTimes(1)
+
+    buf.deltaContent = 'second'
+    scheduleStreamingFlush()
+    expect(flushFn).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(8)
+    expect(flushFn).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(10)
+    expect(flushFn).toHaveBeenCalledTimes(2)
+  })
+
+  it('flushes pending content immediately and clears the buffer on cancel', async () => {
+    const { scheduleStreamingFlush, cancelStreamingFlush, setFlushFn, getBuffer } = await loadStreamingBuffer()
+    const flushFn = vi.fn()
+    setFlushFn(flushFn)
+
+    const buf = getBuffer()
+    buf.messageId = 'm1'
+    buf.deltaContent = 'partial'
+    scheduleStreamingFlush()
+    cancelStreamingFlush()
+
+    expect(flushFn).toHaveBeenCalledTimes(1)
+    expect(buf.messageId).toBeNull()
+    expect(buf.deltaContent).toBe('')
+    expect(buf.thinkingContent).toBe('')
+    expect(buf.toolOutput).toEqual([])
+
+    await vi.runAllTimersAsync()
+    expect(flushFn).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses the rAF fast path when enough time elapsed since the last flush', async () => {
+    const { scheduleStreamingFlush, setFlushFn, getBuffer } = await loadStreamingBuffer()
+    const flushFn = vi.fn()
+    setFlushFn(flushFn)
+
+    const buf = getBuffer()
+    buf.messageId = 'm1'
+    buf.deltaContent = 'first'
+    scheduleStreamingFlush()
+    await vi.runAllTimersAsync()
+    expect(flushFn).toHaveBeenCalledTimes(1)
+
+    // More than the throttle window elapses before the next schedule
+    await vi.advanceTimersByTimeAsync(150)
+
+    buf.deltaContent = 'second'
+    scheduleStreamingFlush()
+    // The rAF stub fires on a 0ms timer — no 100ms throttle delay
+    await vi.runAllTimersAsync()
+    expect(flushFn).toHaveBeenCalledTimes(2)
+  })
+
+  it('renders the first delta of the next message immediately after cancel', async () => {
+    const { scheduleStreamingFlush, cancelStreamingFlush, setFlushFn, getBuffer } = await loadStreamingBuffer()
+    const flushFn = vi.fn()
+    setFlushFn(flushFn)
+
+    const buf = getBuffer()
+    buf.messageId = 'm1'
+    buf.deltaContent = 'first'
+    scheduleStreamingFlush()
+    await vi.runAllTimersAsync()
+    expect(flushFn).toHaveBeenCalledTimes(1)
+
+    // Terminal event: commit remaining content
+    cancelStreamingFlush()
+    expect(flushFn).toHaveBeenCalledTimes(2)
+
+    // Next message starts right away — its first delta must not be throttled
+    buf.messageId = 'm2'
+    buf.deltaContent = 'next message'
+    scheduleStreamingFlush()
+    await vi.runAllTimersAsync()
+    expect(flushFn).toHaveBeenCalledTimes(3)
+  })
+
+  it('cancels a pending rAF flush on cancel', async () => {
+    const cancelRafSpy = vi.spyOn(globalThis, 'cancelAnimationFrame')
+    const { scheduleStreamingFlush, cancelStreamingFlush, setFlushFn, getBuffer } = await loadStreamingBuffer()
+    const flushFn = vi.fn()
+    setFlushFn(flushFn)
+
+    const buf = getBuffer()
+    buf.messageId = 'm1'
+    buf.deltaContent = 'first'
+    scheduleStreamingFlush()
+    await vi.runAllTimersAsync()
+    expect(flushFn).toHaveBeenCalledTimes(1)
+
+    // More than the throttle window elapses so the next schedule takes the rAF path
+    await vi.advanceTimersByTimeAsync(150)
+    cancelRafSpy.mockClear()
+
+    buf.deltaContent = 'second'
+    scheduleStreamingFlush()
+    cancelStreamingFlush()
+
+    expect(cancelRafSpy).toHaveBeenCalledTimes(1)
+    expect(flushFn).toHaveBeenCalledTimes(2)
+
+    await vi.runAllTimersAsync()
+    expect(flushFn).toHaveBeenCalledTimes(2)
   })
 })

--- a/web/src/stores/session/streamingBuffer.ts
+++ b/web/src/stores/session/streamingBuffer.ts
@@ -8,6 +8,12 @@ const buffer: StreamingBuffer = {
 }
 
 let flushFn: (() => void) | null = null
+let pendingTimer: ReturnType<typeof setTimeout> | number | null = null
+let pendingTimerKind: 'raf' | 'timeout' | null = null
+let lastFlushTime = 0
+// One render per frame at most (~60fps). Deltas arriving within the same
+// frame are coalesced into a single render via the rAF fast path below.
+const MIN_STREAM_FLUSH_INTERVAL_MS = 16
 
 export function setFlushFn(fn: () => void) {
   flushFn = fn
@@ -17,10 +23,54 @@ export function getBuffer(): StreamingBuffer {
   return buffer
 }
 
-export function scheduleStreamingFlush() {
+function clearPendingTimer() {
+  if (pendingTimer === null) return
+  if (pendingTimerKind === 'raf') {
+    cancelAnimationFrame(pendingTimer as number)
+  } else {
+    clearTimeout(pendingTimer)
+  }
+  pendingTimer = null
+  pendingTimerKind = null
+}
+
+function doFlush() {
+  pendingTimer = null
+  pendingTimerKind = null
+  lastFlushTime = Date.now()
   flushFn?.()
 }
 
+export function scheduleStreamingFlush() {
+  if (pendingTimer !== null) return
+  const elapsed = Date.now() - lastFlushTime
+  if (elapsed >= MIN_STREAM_FLUSH_INTERVAL_MS) {
+    // Fast path: enough time passed since the last flush — defer to the next
+    // animation frame so deltas arriving in the same frame coalesce into one render.
+    // rAF is paused in hidden tabs, so fall back to a timeout there.
+    if (typeof document !== 'undefined' && document.hidden) {
+      pendingTimer = setTimeout(doFlush, 0)
+      pendingTimerKind = 'timeout'
+    } else {
+      pendingTimer = requestAnimationFrame(doFlush)
+      pendingTimerKind = 'raf'
+    }
+  } else {
+    // Throttle: wait until the minimum interval has elapsed since the last flush.
+    pendingTimer = setTimeout(doFlush, MIN_STREAM_FLUSH_INTERVAL_MS - elapsed)
+    pendingTimerKind = 'timeout'
+  }
+}
+
 export function cancelStreamingFlush() {
-  // No-op: flush is synchronous now
+  clearPendingTimer()
+  flushFn?.()
+  buffer.messageId = null
+  buffer.deltaContent = ''
+  buffer.thinkingContent = ''
+  buffer.toolOutput = []
+  // The flush above is a terminal commit (end of message, error, session switch).
+  // Reset the throttle window so the first delta of the next message renders
+  // immediately instead of waiting out the remaining interval.
+  lastFlushTime = 0
 }

--- a/web/src/stores/session/types.ts
+++ b/web/src/stores/session/types.ts
@@ -73,7 +73,7 @@ export interface SessionState {
   submitPassword: (password: string) => Promise<void>
   cancelPassword: () => void
   createSession: (projectId: string, title?: string) => Promise<Session | null>
-  loadSession: (sessionId: string) => Promise<void>
+  loadSession: (sessionId: string, force?: boolean) => Promise<void>
   listSessions: (projectId?: string, limit?: number) => Promise<void>
   deleteSession: (sessionId: string) => Promise<boolean>
   renameSession: (sessionId: string, title: string) => Promise<boolean>


### PR DESCRIPTION
### Summary

Cette PR accélère massivement le chargement et le rendu des sessions OpenFox. Sur une session de test (79 items rendus), le premier item est rendu en ~1.1s (avant ~4s), le blocage du main thread passe de ~5.1s à ~0.7s, et les endpoints serveur passent de ~700ms à ~10-40ms.

**P0 — Troncature du streamingOutput au snapshot (correctif racine)** : analyse de la DB prod — 97% du poids d'un snapshot de 47.4MB était du `streamingOutput` (stdout/stderr brut de `run_command`, 41.5MB). Or `RunCommandView` n'affiche le streamingOutput que pendant l'exécution ; une fois la commande finie, il n'affiche que `result` (déjà plafonné à 50KB côté serveur). Le streamingOutput était donc **doublement stocké** : result (affiché) + flux intégral (jamais affiché). Le snapshot ne garde désormais que les **derniers 1MB** par tool call terminé (marqueur `streamingOutputTruncated`) — un seuil volontairement haut qui préserve le contrat de données (les sorties normales gardent leur intégralité dans le snapshot, seuls les dumps pathologiques > 1MB sont tronqués). Les tool calls en cours gardent leur flux intégral (reload mid-run intact) et les events bruts `tool.output` ne sont jamais modifiés.

**P1 — Tool calls repliés** : les tool calls terminés avec un contenu > 600 chars (result + streamingOutput + args.content) sont repliés par défaut (▶), le contenu n'est monté dans le DOM qu'au clic. Les tool calls en streaming restent auto-expandés. Résultat : 148 → 31 blocs `<pre>` dans le DOM initial.

**P2 — Virtualisation bottom-anchored du feed** : seuls les ~30 derniers items sont montés, les anciens sont des placeholders (`content-visibility: auto`), révélés par lots de 20 via un sentinel IntersectionObserver + cascade en haut de liste. Ré-ancrage automatique quand un gros lot arrive au chargement initial (mais pas quand l'utilisateur a scrollé dans l'historique — un replay WS après reconnexion ne fait pas sauter la vue). Le contenu n'est jamais perdu : le scroll jusqu'en haut monte tout.

**P3 — Caches serveur** : cache du snapshot parsé par session dans l'EventStore (LRU 16 entrées / 128MB), invalidé sur tous les chemins d'écriture (append, batch, truncate, cleanup). Le cache des prompts utilisateurs récents (sidebar) réutilise le même snapshot et est borné à 64 entrées. GET `/api/sessions/:id` (session 47MB) : ~700ms → ~10-40ms. GET `/api/sessions` : ~650ms → ~3ms.

**P4 — Rendu** :
- Fast path texte brut dans `Markdown` (skip ReactMarkdown pour la prose, `whitespace-pre-line`, linkification des URLs nues) + cache de parse clé par contenu + options (muted/highlighting), borné par entrées (100) et par octets (20MB). Les constructions markdown rares (`~~barré~~`, blockquotes sans espace, `1)` items, autolinks angulaires) sont routées vers le parser complet.
- **Scrollbars** : les ~56 sous-scrolls statiques du feed (sorties de tool calls, diffs, tables markdown, thinking) passent en `overflow` natif — c'est là que se trouvait le coût CPU (~68 instances OverlayScrollbars → 8). Le **scroll principal de la liste conserve OverlayScrollbars** (scrollbar thématisée, drag → sortie naturelle de l'auto-scroll, conforme au changelog, y compris le nouveau `onScrollbarGesture`/`useViewport` du develop).
- Prefetch de la session au boot (`main.tsx`) consommé par `loadSession` avec fallback `authFetch` en cas d'échec, et évincé après 10s s'il n'est pas consommé.
- Streaming rendu à la fréquence de rafraîchissement (~60fps, coalescing par frame via rAF, min 16ms entre flushes) et déduplication des fetch config/workdir/session — travaux antérieurs inclus dans cette branche.
- Réduction du payload serveur : `toClientSession` (messages vidés + `messageCount`), ~120× plus petit.

### Motivation

**Le problème** : ouvrir une longue session était pénible. Trois causes, mesurées sur une copie de la DB prod :
1. **Serveur** : chaque GET `/api/sessions/:id` re-parsait le snapshot JSON (47MB) — ~700ms par appel, et la liste des sessions (sidebar) re-parsait les snapshots de toutes les sessions à chaque rendu — ~650ms.
2. **Client** : le montage DOM initial était massif — 148 blocs `<pre>` (sorties de tool calls auto-expandées) + ~68 instances OverlayScrollbars initialisées — ~2.4s de longtask sur le premier commit.
3. **Racine** : 97% du poids des snapshots était du streamingOutput jamais affiché après coup (voir P0) — le volume de données lui-même, pas seulement le parsing.

**La stratégie** : traiter les trois niveaux — la racine (P0 : ne plus persister ce qui n'est jamais affiché), le coût par requête (P3 : caches), et le coût de rendu (P1/P2/P4 : moins de DOM, moins de re-renders). Le résultat est visible dès le premier paint (~1.1s vs ~4s) et sur chaque navigation (API ~10ms vs ~700ms).

### AI-Enhanced Development

Tell what models helped shape this PR:

- **AI Models:** DeepSeek V4 Flash

### Cache Impact

Does this PR affect anything cached — system prompts, tool definitions, skills, or other context?

- **No** — le cache KV de prompts système (`cached_system_prompt`/`cached_tools`/`cached_hash`) est hashé depuis `instructionContent` (fichiers disque), `skills`, `toolFingerprint` et `modelName` ; il ne dépend ni des messages, ni des events, ni des snapshots. Les caches ajoutés (snapshot EventStore, prompts sidebar) vivent uniquement dans la couche events et sont invalidés sur chaque écriture. `cache-preservation-bug.test.ts` passe.

---

### Informations techniques pour la revue

**Mesures (Playwright, dev server, copie DB prod, session `2942a489`)**

| Métrique | Avant | Après |
|---|---|---|
| Premier item rendu | ~4.0s | ~1.1s |
| Somme des longtasks | ~5.1s | ~0.7s |
| Longtask max | 2422ms | ~430ms |
| Blocs `<pre>` initiaux | 148 | 31 |
| Reveal scroll (session 158 msg) | — | 79ms, sans trou |
| GET session (47MB) | ~700ms | ~10-40ms |
| GET liste sessions | ~650ms | ~3ms |

**Impact P0 sur le poids des snapshots (même snapshot, avec/sans troncature)**

| Session | streamingOutput brut | Avec troncature 1MB | Troncations |
|---|---|---|---|
| 1c9707e3 (206 msg) | 41.5MB | **1.2MB** | 1 (dump > 1MB) |
| 1716ea0a (1944 msg) | 4.5MB | **4.5MB** (inchangé) | 0 — intégralité préservée |

La troncature ne touche que les sorties > 1MB : la session 1716ea0a (4.5MB de streaming répartis sur 1944 messages) n'est **pas du tout tronquée** — son snapshot conserve l'intégralité. Le gain disque vient des sessions avec des dumps géants (1c9707e3 : 41.5MB → 1.2MB).

**Points d'attention pour la revue**
- `AUTO_EXPAND_THRESHOLD = 600` dans `ToolCallDisplay` : seuil calibré sur mesure pour atteindre < 40 blocs `<pre>` ; les sorties > 600 chars sont des dumps d'outils (read_file, run_command). `expanded` est figé au mount (le composant est keyé par position) — changer `forceCompact` en direct ne re-plie pas les appels existants.
- `SNAPSHOT_STREAMING_TAIL_BYTES = 1MB` dans `buildSnapshot`/`buildSnapshotFromSessionState` : tronque le streamingOutput des tool calls **terminés** uniquement, et seulement au-delà de 1MB — le contrat de données (intégralité pour les sorties normales) est préservé ; les pending gardent tout ; les events `tool.output` ne sont jamais modifiés (source de vérité jusqu'à `cleanupOldEvents`, documenté).
- `BULK_APPEND_THRESHOLD = 5` dans `ChatFeedItems` : la livraison du store est chunkée au chargement ; le ré-ancrage ne s'applique pas si l'utilisateur a scrollé dans l'historique (`userScrolledRef`).
- Cache snapshot : la mutation de snapshot dans `truncateSessionMessages` clone avant mutation (le snapshot est partagé avec le cache).
- Prefetch : fetch avant le boot React ; en échec (401, réseau), `loadSession` retombe sur `authFetch` ; entrée évincée après 10s si non consommée.
- Streaming : `MIN_STREAM_FLUSH_INTERVAL_MS = 16` (coalescing par frame, ~60fps) — les deltas d'une même frame ne font qu'un seul re-render, flush final jamais perdu.
- CI : ajout de `overlayscrollbars` + `overlayscrollbars-react` au package.json racine — le workflow ne fait que `npm ci` à la racine, or ces deps n'étaient déclarées que dans `web/package.json` (échec pré-existant, affectait aussi d'autres PR).
- Premier chargement après restart serveur : ~600ms one-shot pour parser les 2 snapshots de 47MB, puis tout est en cache.
- **Rebase** : la branche a été rebasée sur develop (2.0.105) incluant le commit auto-scroll de conrad (`onScrollbarGesture`/`useViewport`/magnetic scrollbar) — fusion vérifiée, tests useAutoScroll de conrad inclus (3066 tests verts).

**Validation**
- `npm run test:unit` : 3066 passed / 0 failed (247 fichiers, 26 skipped)
- `npm run typecheck`, `eslint`, `prettier --check` : clean
- CI : **lint, typecheck, duplicate, ai-disclosure, test — tous ✅** (sur le head précédent ; re-run en cours sur le head actuel)

**Fichiers principaux**
- Serveur : `src/server/events/fold-state.ts` (troncature streamingOutput au snapshot), `src/server/events/store.ts` (caches + invalidation), `src/server/events/session.ts`, `src/server/session/client-session.ts` (+ test), `src/server/index.ts`, `src/server/ws/protocol.ts`
- Web : `web/src/components/shared/ToolCallDisplay.tsx`, `web/src/components/shared/Markdown.tsx`, `web/src/components/plan/ChatFeedItems.tsx` (+ `feed-window.ts`), `web/src/components/plan/MessageList.tsx`, `web/src/components/plan/PlanPanel.tsx`, `web/src/lib/sessionPrefetch.ts`, `web/src/main.tsx`, `web/src/stores/session/store.ts`, `web/src/stores/session/streamingBuffer.ts`