### PR TITLE
fix: enforce workflow git context integrity

### DIFF
--- a/src/server/db/sessions.ts
+++ b/src/server/db/sessions.ts
@@ -14,8 +14,7 @@ function getProjectDangerLevel(projectId: string): DangerLevel {
   try {
     const db = getDatabase()
     const row = db.prepare('SELECT danger_level FROM projects WHERE id = ?').get(projectId) as
-      | { danger_level: string | null }
-      | undefined
+      { danger_level: string | null } | undefined
     return (row?.danger_level as DangerLevel) ?? 'normal'
   } catch {
     return 'normal'
@@ -235,6 +234,17 @@ export function updateSessionCachedPrompt(
   ).run(systemPrompt, JSON.stringify(tools), hash, now, id)
 }
 
+export function clearSessionCachedPrompt(id: string): void {
+  const db = getDatabase()
+  const now = new Date().toISOString()
+
+  db.prepare(
+    `
+    UPDATE sessions SET cached_system_prompt = NULL, cached_tools = NULL, cached_hash = NULL, updated_at = ? WHERE id = ?
+  `,
+  ).run(now, id)
+}
+
 export function getSessionCachedPrompt(id: string): {
   systemPrompt: string
   tools: import('../llm/types.js').LLMToolDefinition[]
@@ -248,8 +258,7 @@ export function getSessionCachedPrompt(id: string): {
   `,
     )
     .get(id) as
-    | { cached_system_prompt: string | null; cached_tools: string | null; cached_hash: string | null }
-    | undefined
+    { cached_system_prompt: string | null; cached_tools: string | null; cached_hash: string | null } | undefined
 
   if (!row || !row.cached_system_prompt || !row.cached_tools || !row.cached_hash) {
     return null
@@ -282,8 +291,7 @@ export function getSessionMessageCount(id: string): number {
   try {
     const db = getDatabase()
     const row = db.prepare(`SELECT message_count FROM sessions WHERE id = ?`).get(id) as
-      | { message_count: number }
-      | undefined
+      { message_count: number } | undefined
     return row?.message_count ?? 0
   } catch {
     // Database not initialized (test scenarios) - return 0

--- a/src/server/session/manager.execution-context.test.ts
+++ b/src/server/session/manager.execution-context.test.ts
@@ -64,8 +64,16 @@ const mockProviderManager = {
 import { loadConfig } from '../config.js'
 import { closeDatabase, getDatabase, initDatabase } from '../db/index.js'
 import { createProject } from '../db/projects.js'
+import { updateSessionBranch } from '../db/sessions.js'
 import { initEventStore } from '../events/index.js'
 import { SessionManager } from './manager.js'
+
+async function setSessionBranch(manager: SessionManager, sessionId: string, branch: string) {
+  updateSessionBranch(sessionId, branch)
+  // Force the manager to reload from DB so session.branch reflects the write
+  await new Promise<void>((resolve) => setImmediate(resolve))
+  expect(manager.getSession(sessionId)?.branch).toBe(branch)
+}
 
 describe('SessionManager.switchWorkspace – execution context integrity (issue #190)', () => {
   let workdir: string
@@ -149,5 +157,79 @@ describe('SessionManager.switchWorkspace – execution context integrity (issue 
     const cached = manager.getCachedPrompt(session.id)
     expect(cached).toBeDefined()
     expect(cached?.hash).toBe('stable-hash')
+  })
+
+  // ==========================================================================
+  // Issue #183 — assertExecutionGitContext fail-closed semantics
+  // ==========================================================================
+
+  describe('assertExecutionGitContext fail-closed semantics', () => {
+    it('blocks (fail-closed) when expected branch is set but actual branch is null (detached HEAD / unresolvable)', async () => {
+      // Session says feat-x, git cannot resolve a branch (e.g. detached HEAD,
+      // broken repository, .git missing inside the workdir). We refuse to
+      // run — the agent must not start on the wrong tree.
+      const session = manager.createSession(projectId, 'Ctx-fc-1', undefined, undefined, '/ws/openfox/feat-x')
+      await setSessionBranch(manager, session.id, 'feat-x')
+      mockGetGitBranch.mockResolvedValue(null)
+
+      const result = await manager.assertExecutionGitContext(session.id)
+
+      expect(result.ok).toBe(false)
+      if (result.ok === false) {
+        expect(result.expectedBranch).toBe('feat-x')
+        expect(result.actualBranch).toBeNull()
+        expect(result.workdir).toBe('/ws/openfox/feat-x')
+        expect(result.reason).toContain('/ws/openfox/feat-x')
+        expect(result.reason).toContain('feat-x')
+        expect(result.reason).toMatch(/unavailable|unknown|cannot|no branch/i)
+        expect(result.reason).toMatch(/no agent|no checkout|no file/i)
+      }
+    })
+
+    it('allows (non-git or unbound) when expected branch is null and actual branch is null', async () => {
+      const session = manager.createSession(projectId, 'Ctx-fc-2')
+      mockGetGitBranch.mockResolvedValue(null)
+
+      const result = await manager.assertExecutionGitContext(session.id)
+
+      expect(result.ok).toBe(true)
+    })
+
+    it('allows (no expectation) when expected branch is null but actual branch is defined', async () => {
+      const session = manager.createSession(projectId, 'Ctx-fc-3')
+      mockGetGitBranch.mockResolvedValue('main')
+
+      const result = await manager.assertExecutionGitContext(session.id)
+
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.actualBranch).toBe('main')
+        expect(result.expectedBranch).toBeNull()
+      }
+    })
+
+    it('allows when expected and actual branch match', async () => {
+      const session = manager.createSession(projectId, 'Ctx-fc-4', undefined, undefined, '/ws/openfox/feat-x')
+      await setSessionBranch(manager, session.id, 'feat-x')
+      mockGetGitBranch.mockResolvedValue('feat-x')
+
+      const result = await manager.assertExecutionGitContext(session.id)
+
+      expect(result.ok).toBe(true)
+    })
+
+    it('blocks when expected and actual branch differ', async () => {
+      const session = manager.createSession(projectId, 'Ctx-fc-5', undefined, undefined, '/ws/openfox/feat-x')
+      await setSessionBranch(manager, session.id, 'feat-x')
+      mockGetGitBranch.mockResolvedValue('main')
+
+      const result = await manager.assertExecutionGitContext(session.id)
+
+      expect(result.ok).toBe(false)
+      if (result.ok === false) {
+        expect(result.expectedBranch).toBe('feat-x')
+        expect(result.actualBranch).toBe('main')
+      }
+    })
   })
 })

--- a/src/server/session/manager.execution-context.test.ts
+++ b/src/server/session/manager.execution-context.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Session Manager – Execution Context Integrity Tests (RED)
+ *
+ * Issue #190: Refresh agent context after workspace or branch mutation during a turn.
+ *
+ * These tests pin two related responsibilities of SessionManager.switchWorkspace:
+ *   - It MUST invalidate the cached system prompt so the next LLM call (same-turn
+ *     continuation AND next user turn) rebuilds against the new workdir/branch
+ *     instead of serving a stale prompt that still embeds the previous workspace.
+ *   - It MUST emit a fresh session.updated event so the frontend never displays
+ *     a stale workspace/branch label after an authoritative mutation.
+ *
+ * The tests are RED until SessionManager.switchWorkspace (or its collaborators)
+ * actually clears the cached prompt on success.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+const { mockGetGitBranch, mockGetWorkspacesDir, mockRunGit, mockGetCommitsBehind } = vi.hoisted(() => {
+  const mockGetGitBranch = vi.fn(async (_cwd: string) => 'feat-x' as string | null)
+  const mockGetWorkspacesDir = vi.fn(
+    async (_projectName: string, _projectDir: string) => '/tmp/openfox-workspaces',
+  )
+  const mockRunGit = vi.fn(async (_cwd: string, _args: string[]) => undefined as void)
+  const mockGetCommitsBehind = vi.fn(async (_cwd: string, _branch: string) => 0 as number | null)
+  return { mockGetGitBranch, mockGetWorkspacesDir, mockRunGit, mockGetCommitsBehind }
+})
+
+vi.mock('../lsp/index.js', () => ({
+  getLspManager: vi.fn(() => ({ name: 'mock-lsp' })),
+  shutdownLspManager: vi.fn(async () => {}),
+}))
+
+vi.mock('../git/workspace.js', async (importOriginal) => {
+  const actual = (await importOriginal()) as any
+  return {
+    ...actual,
+    getGitBranch: mockGetGitBranch as any,
+    getWorkspacesDir: mockGetWorkspacesDir as any,
+    runGit: mockRunGit as any,
+    getCommitsBehind: mockGetCommitsBehind as any,
+    ensureWorkspace: vi.fn(async () => undefined),
+    workspaceExists: vi.fn(async () => true),
+    validateRef: vi.fn(async () => undefined),
+    resolveAndValidateSourceBranch: vi.fn(async () => 'origin/HEAD'),
+  }
+})
+
+vi.mock('../dev-server/manager.js', () => ({
+  devServerManager: { stop: vi.fn(async () => undefined) },
+}))
+
+const mockProviderManager = {
+  getCurrentModelContext: vi.fn(() => 200000),
+  getLLMClient: vi.fn(() => ({})),
+  createClient: vi.fn(() => undefined),
+  getActiveProviderId: vi.fn(() => 'test-provider'),
+  getCurrentModel: vi.fn(() => 'global-model'),
+}
+
+import { loadConfig } from '../config.js'
+import { closeDatabase, getDatabase, initDatabase } from '../db/index.js'
+import { createProject } from '../db/projects.js'
+import { initEventStore } from '../events/index.js'
+import { SessionManager } from './manager.js'
+
+describe('SessionManager.switchWorkspace – execution context integrity (issue #190)', () => {
+  let workdir: string
+  let projectId: string
+  let manager: SessionManager
+
+  beforeEach(async () => {
+    closeDatabase()
+    const config = loadConfig()
+    config.database.path = ':memory:'
+    initDatabase(config)
+    initEventStore(getDatabase())
+
+    workdir = await mkdtemp(join(tmpdir(), 'openfox-manager-exec-ctx-'))
+    projectId = createProject('OpenFox', workdir).id
+    manager = new SessionManager(mockProviderManager as any)
+
+    mockGetGitBranch.mockClear()
+    mockGetGitBranch.mockResolvedValue('feat-x')
+    mockGetWorkspacesDir.mockClear()
+    mockGetWorkspacesDir.mockResolvedValue('/tmp/openfox-workspaces')
+    mockRunGit.mockClear()
+    mockRunGit.mockResolvedValue(undefined)
+    mockGetCommitsBehind.mockClear()
+    mockGetCommitsBehind.mockResolvedValue(0)
+  })
+
+  afterEach(async () => {
+    closeDatabase()
+    await rm(workdir, { recursive: true, force: true })
+  })
+
+  it('invalidates the cached prompt after a successful workspace switch (next-turn sees fresh context)', async () => {
+    // Session starts on /tmp/project (original workdir) with no workspace
+    const session = manager.createSession(projectId, 'Ctx-1')
+
+    // Simulate that the previous turn warmed up the prompt with the OLD workdir.
+    // The cached prompt embeds `Working directory: /tmp/project` — the
+    // stale state. This is exactly what buildTopLevelSystemPrompt(workdir) does.
+    manager.setCachedPrompt(session.id, 'System prompt with Working directory: /tmp/project', [], 'old-hash')
+    expect(manager.getCachedPrompt(session.id)).toBeDefined()
+
+    // Authoritative mutation: switch to workspace feat-x (it exists)
+    await manager.switchWorkspace(session.id, 'feat-x')
+
+    // Issue #190: the next turn MUST rebuild the prompt against the new workdir.
+    // Therefore the cached prompt must be cleared (so assembleRequest rebuilds).
+    const cachedAfter = manager.getCachedPrompt(session.id)
+    expect(cachedAfter).toBeUndefined()
+  })
+
+  it('invalidates the cached prompt after a successful branch change on the current workspace (same-turn sees fresh context)', async () => {
+    // Session currently on /ws/openfox/feat-x with branch=feat-x (default mock)
+    const session = manager.createSession(projectId, 'Ctx-2', undefined, undefined, '/ws/openfox/feat-x')
+    // Pre-seed a cached prompt referencing branch=feat-x workdir
+    manager.setCachedPrompt(session.id, 'System prompt with Working directory: /ws/openfox/feat-x', [], 'feat-hash')
+    expect(manager.getCachedPrompt(session.id)).toBeDefined()
+
+    // Branch change: same workspace, different branch. The first getGitBranch
+    // call (early-return check) sees the PRE-mutation branch 'feat-x', so the
+    // switch is NOT a no-op. Subsequent getGitBranch calls return 'feat-y'
+    // to simulate a successful applyBranchIfNeeded.
+    mockGetGitBranch.mockResolvedValueOnce('feat-x')
+    mockGetGitBranch.mockResolvedValue('feat-y')
+    await manager.switchWorkspace(session.id, 'feat-x', 'feat-y')
+
+    // The cached prompt must be cleared so the next LLM call rebuilds against the new branch
+    const cachedAfter = manager.getCachedPrompt(session.id)
+    expect(cachedAfter).toBeUndefined()
+  })
+
+  it('does not invalidate the cached prompt when switchWorkspace is a no-op (no real mutation)', async () => {
+    // Session already on /ws/openfox/feat-x — switching to feat-x without branch change
+    // is a no-op and must NOT manufacture a fake refreshed context.
+    const session = manager.createSession(projectId, 'Ctx-3', undefined, undefined, '/ws/openfox/feat-x')
+    manager.setCachedPrompt(session.id, 'Stable system prompt with Working directory: /ws/openfox/feat-x', [], 'stable-hash')
+
+    await manager.switchWorkspace(session.id, 'feat-x')
+
+    // Cache should be untouched on a no-op mutation
+    const cached = manager.getCachedPrompt(session.id)
+    expect(cached).toBeDefined()
+    expect(cached?.hash).toBe('stable-hash')
+  })
+})

--- a/src/server/session/manager.ts
+++ b/src/server/session/manager.ts
@@ -212,6 +212,49 @@ export class SessionManager {
     return { workdir: effectiveWorkdir, branch }
   }
 
+  /**
+   * Verify the session's effective workdir is on the branch the session was
+   * bound to. Used as an early gate by write workflows (Dev & Verify) so we
+   * never write files against the wrong tree when the session branch and the
+   * actual git branch have diverged (#183).
+   *
+   * - Non-git projects (neither side has a branch) are always considered OK.
+   * - If only one side has a branch, we do NOT block — a session without an
+   *   explicit branch expectation is allowed to operate without drift checks.
+   * - If BOTH sides have a branch and they differ, we block with a reason that
+   *   includes the workdir, expected branch, and actual branch.
+   */
+  async assertExecutionGitContext(sessionId: string): Promise<
+    | { ok: true; workdir: string; actualBranch: string | null; expectedBranch: string | null }
+    | {
+        ok: false
+        reason: string
+        workdir: string
+        expectedBranch: string | null
+        actualBranch: string | null
+      }
+  > {
+    const session = this.requireSession(sessionId)
+    const expectedBranch = session.branch ?? null
+    const { workdir, branch: actualBranch } = await this.getActualBranchPair(sessionId)
+
+    if (!expectedBranch || !actualBranch || expectedBranch === actualBranch) {
+      return { ok: true, workdir, actualBranch, expectedBranch }
+    }
+
+    return {
+      ok: false,
+      reason:
+        `Git context mismatch before Dev & Verify: session branch is '${expectedBranch}' ` +
+        `but workdir '${workdir}' is actually on '${actualBranch}'. ` +
+        `Refusing to write — no agent was run, no checkout was performed. ` +
+        `Use the workspace tool to switch to branch '${expectedBranch}' (or update the session branch) and retry.`,
+      workdir,
+      expectedBranch,
+      actualBranch,
+    }
+  }
+
   // ============================================================================
   // Session Lifecycle
   // ============================================================================

--- a/src/server/session/manager.ts
+++ b/src/server/session/manager.ts
@@ -219,11 +219,16 @@ export class SessionManager {
    * never write files against the wrong tree when the session branch and the
    * actual git branch have diverged (#183).
    *
-   * - Non-git projects (neither side has a branch) are always considered OK.
-   * - If only one side has a branch, we do NOT block — a session without an
-   *   explicit branch expectation is allowed to operate without drift checks.
-   * - If BOTH sides have a branch and they differ, we block with a reason that
-   *   includes the workdir, expected branch, and actual branch.
+   * Decision matrix (fail-closed):
+   *   - expectedBranch null                 → ok, regardless of actualBranch.
+   *   - expectedBranch set, actualBranch set, equal    → ok.
+   *   - expectedBranch set, actualBranch set, differ   → BLOCKED.
+   *   - expectedBranch set, actualBranch null          → BLOCKED (we cannot
+   *     verify the workdir is on the right branch — detached HEAD, broken
+   *     repository, missing .git, etc.).
+   *
+   * Returning `{ ok: true }` for a session that has a branch expectation but
+   * no resolvable actual branch would be fail-open and is forbidden.
    */
   async assertExecutionGitContext(sessionId: string): Promise<
     | { ok: true; workdir: string; actualBranch: string | null; expectedBranch: string | null }
@@ -239,10 +244,32 @@ export class SessionManager {
     const expectedBranch = session.branch ?? null
     const { workdir, branch: actualBranch } = await this.getActualBranchPair(sessionId)
 
-    if (!expectedBranch || !actualBranch || expectedBranch === actualBranch) {
+    // No expectation → always allowed (covers non-git projects and unbound sessions).
+    if (!expectedBranch) {
       return { ok: true, workdir, actualBranch, expectedBranch }
     }
 
+    // Expectation set + matching actual branch → allowed.
+    if (actualBranch && expectedBranch === actualBranch) {
+      return { ok: true, workdir, actualBranch, expectedBranch }
+    }
+
+    // Expectation set + actual branch unresolved → fail closed.
+    if (!actualBranch) {
+      return {
+        ok: false,
+        reason:
+          `Cannot verify Git context for workdir '${workdir}': expected branch '${expectedBranch}' ` +
+          `but the actual branch is unavailable (detached HEAD, missing .git, or unreadable repository). ` +
+          `Refusing to write — no agent was run, no checkout was performed. ` +
+          `Use the workspace tool to switch to branch '${expectedBranch}' (or repair the workdir) and retry.`,
+        workdir,
+        expectedBranch,
+        actualBranch: null,
+      }
+    }
+
+    // Expectation set + actual branch differs → fail closed.
     return {
       ok: false,
       reason:

--- a/src/server/session/manager.ts
+++ b/src/server/session/manager.ts
@@ -29,6 +29,7 @@ import {
   updateSessionDangerLevel,
   updateSessionRunning,
   updateSessionCachedPrompt,
+  clearSessionCachedPrompt,
   updateSessionWorkdir,
   updateSessionBranch,
   updateSessionMessageCount,
@@ -1295,6 +1296,18 @@ export class SessionManager {
     this.resetWarmup(sessionId)
   }
 
+  /**
+   * Invalidate the cached system prompt so the next LLM call rebuilds against
+   * the current workdir/branch. Called after any authoritative workspace or
+   * branch mutation so same-turn continuations and the next user turn do not
+   * keep seeing the previous workspace in the system prompt.
+   */
+  clearCachedPrompt(sessionId: string): void {
+    clearSessionCachedPrompt(sessionId)
+    this.resetWarmup(sessionId)
+    this.setDynamicContextChanged(sessionId, true)
+  }
+
   getCachedPrompt(
     sessionId: string,
   ): { systemPrompt: string; tools: import('../llm/types.js').LLMToolDefinition[]; hash: string } | undefined {
@@ -1527,6 +1540,12 @@ export class SessionManager {
       const wsDirForBranch = await getWorkspacesDir(project.name, project.workdir)
       const effectiveWorkdir = target === 'original' ? project.workdir : resolve(wsDirForBranch, target)
       const actualBranch = await getGitBranch(effectiveWorkdir)
+
+      // Issue #190: the workdir/branch just changed, so any previously cached
+      // system prompt is now stale. Clear it so the next LLM call (same-turn
+      // continuation or next user turn) rebuilds against the new authoritative
+      // state instead of serving the old prompt.
+      this.clearCachedPrompt(sessionId)
 
       if (actualBranch) {
         updateSessionBranch(sessionId, actualBranch)

--- a/src/server/workflows/executor-mode.test.ts
+++ b/src/server/workflows/executor-mode.test.ts
@@ -116,6 +116,12 @@ describe('executeWorkflow mode changes', () => {
       resumeWorkflow: vi.fn(),
       getActiveWorkflowExecution: vi.fn(() => null),
       cancelWorkflow: vi.fn(),
+      assertExecutionGitContext: vi.fn(async () => ({
+        ok: true as const,
+        workdir: '/tmp/test',
+        expectedBranch: null,
+        actualBranch: null,
+      })),
     }
 
     options = {

--- a/src/server/workflows/executor-resume-nudge.test.ts
+++ b/src/server/workflows/executor-resume-nudge.test.ts
@@ -125,6 +125,12 @@ function createMockOptions(extra?: Partial<OrchestratorOptions>): OrchestratorOp
       resumeWorkflow: vi.fn(),
       getActiveWorkflowExecution: vi.fn(() => null),
       cancelWorkflow: vi.fn(),
+      assertExecutionGitContext: vi.fn(async () => ({
+        ok: true as const,
+        workdir: '/tmp/test',
+        expectedBranch: null,
+        actualBranch: null,
+      })),
     } as any,
     sessionId: 'test-session',
     llmClient: { getModel: () => 'test-model' } as any,

--- a/src/server/workflows/executor.execution-context.test.ts
+++ b/src/server/workflows/executor.execution-context.test.ts
@@ -1,0 +1,276 @@
+/**
+ * Workflow Executor – Execution Context Integrity Tests (RED)
+ *
+ * These tests pin the behaviour expected for issue #190:
+ *   "Refresh agent context after workspace or branch mutation during a turn".
+ *
+ * Goal of the test pack:
+ *   1. Before the first agent step of Dev & Verify, if the actual Git branch on
+ *      the effective workdir differs from the session's persisted branch, the
+ *      executor MUST block immediately, with no file written and no automatic
+ *      checkout performed.
+ *   2. After an official workspace or branch mutation within a turn, the agent
+ *      receives authoritative post-mutation context in the same turn (no stale
+ *      pre-mutation branch/workdir served).
+ *   3. The next turn receives the current workspace/branch context.
+ *   4. When the mutation fails, the agent must NOT be served a refreshed,
+ *      fake post-mutation context.
+ *
+ * These tests are RED until the executor and its collaborators implement the
+ * gating + cache invalidation. They MUST NOT be touched by the implementation
+ * phase — only the production code under src/server is allowed to change.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { WorkflowDefinition } from './types.js'
+import type { OrchestratorOptions } from '../runner/types.js'
+
+const { runAgentTurnMock } = vi.hoisted(() => ({
+  runAgentTurnMock: vi.fn(
+    async (
+      _opts: any,
+      _metrics: any,
+      _agentId: string,
+      _append: any,
+      extra: { onToolExecuted?: (tc: any, tr: any) => void } | undefined,
+    ) => {
+      extra?.onToolExecuted?.({ name: 'step_done', arguments: {} }, { success: true, output: '' })
+      return { returnValueResult: 'completed', returnValueContent: '' }
+    },
+  ),
+}))
+
+// Mock event store (same shape as executor-mode.test.ts)
+vi.mock('../events/index.js', () => ({
+  getEventStore: () => ({
+    append: vi.fn(),
+  }),
+  getCurrentContextWindowId: vi.fn(() => undefined),
+}))
+
+vi.mock('../chat/orchestrator.js', () => ({
+  runAgentTurn: runAgentTurnMock,
+  createMessageStartEvent: vi.fn(() => ({ type: 'message.start', data: {} })),
+  TurnMetrics: class TurnMetrics {
+    start = vi.fn()
+    end = vi.fn()
+    getMetrics = vi.fn(() => ({ durationMs: 0, tokenCount: 0 }))
+  },
+}))
+
+vi.mock('../sub-agents/manager.js', () => ({
+  executeSubAgent: vi.fn(async () => ({ content: '', result: 'success' })),
+}))
+
+vi.mock('../agents/registry.js', () => ({
+  loadAllAgentsDefault: vi.fn(async () => []),
+  findAgentById: vi.fn(() => undefined),
+  resolveDefaultAgentId: vi.fn(() => 'planner'),
+}))
+
+vi.mock('../tools/index.js', () => ({
+  getToolRegistryForAgent: vi.fn(() => ({ tools: [], definitions: [], execute: vi.fn() })),
+}))
+
+vi.mock('./shell.js', () => ({
+  executeShellCommand: vi.fn(async () => ({ stdout: '', stderr: '', exitCode: 0 })),
+}))
+
+vi.mock('../utils/logger.js', () => ({
+  logger: { debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+
+vi.mock('../../shared/stats.js', () => ({
+  computeSessionStats: vi.fn(() => ({ generationTokens: 0, avgGenerationSpeed: 0, responseCount: 0, llmCallCount: 0 })),
+}))
+
+vi.mock('../git/diff.js', () => ({
+  formatGitDiffFiles: vi.fn(async () => '(none)'),
+}))
+
+import { executeWorkflow } from './executor.js'
+
+describe('executeWorkflow – execution context integrity', () => {
+  let setMode: ReturnType<typeof vi.fn>
+  let setPhase: ReturnType<typeof vi.fn>
+  let blockWorkflow: ReturnType<typeof vi.fn>
+  let startWorkflow: ReturnType<typeof vi.fn>
+  let completeWorkflow: ReturnType<typeof vi.fn>
+  let mockSessionManager: any
+  let options: OrchestratorOptions
+  let workflow: WorkflowDefinition
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    setMode = vi.fn()
+    setPhase = vi.fn()
+    blockWorkflow = vi.fn()
+    startWorkflow = vi.fn()
+    completeWorkflow = vi.fn()
+
+    mockSessionManager = {
+      requireSession: vi.fn(() => ({
+        workdir: '/tmp/project',
+        workspace: null,
+        branch: 'feat-x',
+        messages: [],
+        metadataEntries: {},
+      })),
+      setMode,
+      setPhase,
+      blockWorkflow,
+      startWorkflow,
+      completeWorkflow,
+      getEffectiveWorkdir: vi.fn().mockReturnValue('/tmp/project'),
+      addMessage: vi.fn(),
+      updateWorkflowStep: vi.fn(),
+      waitAtStep: vi.fn(),
+      resumeWorkflow: vi.fn(),
+      getActiveWorkflowExecution: vi.fn(() => null),
+      cancelWorkflow: vi.fn(),
+      // Issue #183 gate — overridden per test below
+      assertExecutionGitContext: vi.fn(async () => ({
+        ok: true as const,
+        workdir: '/tmp/project',
+        expectedBranch: 'feat-x',
+        actualBranch: 'main',
+      })),
+    }
+
+    options = {
+      sessionManager: mockSessionManager,
+      sessionId: 'test-session',
+      llmClient: { getModel: () => 'test-model' } as any,
+    }
+
+    workflow = {
+      metadata: { id: 'default', name: 'Build & Verify', description: '', version: '1' },
+      entryStep: 'build',
+      settings: { maxIterations: 10 },
+      steps: [
+        {
+          id: 'build',
+          name: 'Implement',
+          type: 'agent',
+          phase: 'build',
+          agentId: 'builder',
+          transitions: [{ when: { type: 'always' }, goto: '$done' }],
+        },
+      ],
+    }
+  })
+
+  it('blocks before the first agent step when actual git branch differs from session branch', async () => {
+    // Session says we're on feat-x, Git actually says we're on main
+    mockSessionManager.requireSession.mockReturnValue({
+      workdir: '/tmp/project',
+      workspace: null,
+      branch: 'feat-x',
+      messages: [],
+      metadataEntries: {},
+    })
+    mockSessionManager.assertExecutionGitContext.mockResolvedValue({
+      ok: false,
+      reason:
+        "Git context mismatch before Dev & Verify: session branch is 'feat-x' but workdir '/tmp/project' is actually on 'main'. Refusing to write — no agent was run, no checkout was performed.",
+      workdir: '/tmp/project',
+      expectedBranch: 'feat-x',
+      actualBranch: 'main',
+    })
+
+    const result = await executeWorkflow(workflow, options)
+
+    expect(result.finalAction.type).toBe('BLOCKED')
+    if (result.finalAction.type === 'BLOCKED') {
+      expect(result.finalAction.reason).toMatch(/branch/i)
+      expect(result.finalAction.reason).toContain('feat-x')
+      expect(result.finalAction.reason).toContain('main')
+    }
+    // The agent MUST NOT be invoked — no file can be written if no agent runs
+    expect(runAgentTurnMock).not.toHaveBeenCalled()
+    // The workflow must NOT be marked as started (no DB write before the gate)
+    expect(startWorkflow).not.toHaveBeenCalled()
+    expect(blockWorkflow).not.toHaveBeenCalled()
+    expect(completeWorkflow).not.toHaveBeenCalled()
+  })
+
+  it('blocks without invoking runAgentTurn and without performing any checkout', async () => {
+    // First step of Dev & Verify (build) must not run if branch is drifted
+    mockSessionManager.requireSession.mockReturnValue({
+      workdir: '/tmp/project',
+      workspace: '/ws/feat',
+      branch: 'feat-x',
+      messages: [],
+      metadataEntries: {},
+    })
+    mockSessionManager.assertExecutionGitContext.mockResolvedValue({
+      ok: false,
+      reason:
+        "Git context mismatch before Dev & Verify: session branch is 'feat-x' but workdir '/ws/feat' is actually on 'main'.",
+      workdir: '/ws/feat',
+      expectedBranch: 'feat-x',
+      actualBranch: 'main',
+    })
+
+    await executeWorkflow(workflow, options)
+
+    // Critical: agent must NOT have been called, therefore no file could have been written
+    expect(runAgentTurnMock).not.toHaveBeenCalled()
+    // The session manager should NOT have been asked to perform any checkout
+    // (switchWorkspace is the only function that does branch mutations in tests;
+    // since we didn't mock it, an attempt to call it would throw)
+    expect(mockSessionManager.switchWorkspace).toBeUndefined()
+    expect(startWorkflow).not.toHaveBeenCalled()
+  })
+
+  it('proceeds with the first agent step when actual branch matches session branch', async () => {
+    // Healthy state: session.branch === actualBranch
+    mockSessionManager.requireSession.mockReturnValue({
+      workdir: '/tmp/project',
+      workspace: null,
+      branch: 'main',
+      messages: [],
+      metadataEntries: {},
+    })
+    mockSessionManager.assertExecutionGitContext.mockResolvedValue({
+      ok: true,
+      workdir: '/tmp/project',
+      expectedBranch: 'main',
+      actualBranch: 'main',
+    })
+
+    await executeWorkflow(workflow, options)
+
+    // The gate must NOT block healthy flows
+    expect(runAgentTurnMock).toHaveBeenCalledTimes(1)
+    expect(completeWorkflow).toHaveBeenCalled()
+  })
+
+  it('does not serve a refreshed fake context when the mutation has failed upstream', async () => {
+    // If a prior turn's mutation failed (e.g. checkout of a non-existent branch
+    // left the session with the original branch), the executor must rely on the
+    // authoritative actualBranchPair and block if it differs from session.branch —
+    // it must NOT pretend that the workspace is on the new branch.
+    mockSessionManager.requireSession.mockReturnValue({
+      workdir: '/tmp/project',
+      workspace: null,
+      branch: 'feat-x',
+      messages: [],
+      metadataEntries: {},
+    })
+    mockSessionManager.assertExecutionGitContext.mockResolvedValue({
+      ok: false,
+      reason:
+        "Git context mismatch before Dev & Verify: session branch is 'feat-x' but workdir '/tmp/project' is actually on 'main'.",
+      workdir: '/tmp/project',
+      expectedBranch: 'feat-x',
+      actualBranch: 'main',
+    })
+
+    const result = await executeWorkflow(workflow, options)
+
+    expect(result.finalAction.type).toBe('BLOCKED')
+    expect(runAgentTurnMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/server/workflows/executor.execution-context.test.ts
+++ b/src/server/workflows/executor.execution-context.test.ts
@@ -224,6 +224,39 @@ describe('executeWorkflow – execution context integrity', () => {
     expect(startWorkflow).not.toHaveBeenCalled()
   })
 
+  it('blocks fail-closed when expected branch is set but actual branch is unresolvable', async () => {
+    // Detached HEAD / broken workdir: actualBranch is null even though
+    // session.branch is set. We must block — the agent must not run.
+    mockSessionManager.requireSession.mockReturnValue({
+      workdir: '/tmp/project',
+      workspace: '/ws/feat',
+      branch: 'feat-x',
+      messages: [],
+      metadataEntries: {},
+    })
+    mockSessionManager.assertExecutionGitContext.mockResolvedValue({
+      ok: false,
+      reason:
+        "Cannot verify Git context for workdir '/ws/feat': expected branch 'feat-x' but the actual branch is unavailable. " +
+        "Refusing to write — no agent was run, no checkout was performed.",
+      workdir: '/ws/feat',
+      expectedBranch: 'feat-x',
+      actualBranch: null,
+    })
+
+    const result = await executeWorkflow(workflow, options)
+
+    expect(result.finalAction.type).toBe('BLOCKED')
+    if (result.finalAction.type === 'BLOCKED') {
+      expect(result.finalAction.reason).toMatch(/unavailable/i)
+      expect(result.finalAction.reason).toContain('feat-x')
+      expect(result.finalAction.reason).toMatch(/no agent|no checkout|no file/i)
+    }
+    expect(runAgentTurnMock).not.toHaveBeenCalled()
+    expect(startWorkflow).not.toHaveBeenCalled()
+    expect(completeWorkflow).not.toHaveBeenCalled()
+  })
+
   it('proceeds with the first agent step when actual branch matches session branch', async () => {
     // Healthy state: session.branch === actualBranch
     mockSessionManager.requireSession.mockReturnValue({

--- a/src/server/workflows/executor.ts
+++ b/src/server/workflows/executor.ts
@@ -288,6 +288,58 @@ export async function executeWorkflow(
 
   logger.debug('Workflow executor starting', { sessionId, workflow: workflow.metadata.id })
 
+  // Resolve the workflow execution id up-front so we can block it on early
+  // failures (git-context drift, start condition) even on resume. On fresh
+  // starts it stays undefined until the marker is emitted below.
+  let executionId: string | undefined
+  if (isResume) {
+    const activeExec = sessionManager.getActiveWorkflowExecution(sessionId)
+    if (activeExec) {
+      executionId = activeExec.id
+    }
+  }
+
+  // Issue #183: early gate on git context drift. Before any agent step, any
+  // shell step, or any file write, refuse to start a write workflow when the
+  // session branch and the actual git branch on the effective workdir differ.
+  // We do NOT auto-checkout — we surface the discrepancy and block.
+  const ctxCheck = await sessionManager.assertExecutionGitContext(sessionId)
+  if (!ctxCheck.ok) {
+    logger.warn('Workflow blocked: git context drift detected', {
+      sessionId,
+      workflow: workflow.metadata.id,
+      workdir: ctxCheck.workdir,
+      expectedBranch: ctxCheck.expectedBranch,
+      actualBranch: ctxCheck.actualBranch,
+    })
+    emitWorkflowMessage(
+      eventStore,
+      sessionId,
+      `Runner blocked: ${ctxCheck.reason}`,
+      getCurrentWindowMessageOptions(sessionId),
+      onMessage,
+    )
+    if (executionId) {
+      sessionManager.blockWorkflow(
+        sessionId,
+        executionId,
+        workflow.metadata.id,
+        workflow.metadata.name,
+        workflow.metadata.color,
+      )
+    }
+    sessionManager.setPhase(sessionId, 'blocked')
+    return {
+      finalAction: {
+        type: 'BLOCKED',
+        reason: ctxCheck.reason,
+        blockedCriteria: [],
+      },
+      iterations: 0,
+      totalTime: (performance.now() - startTime) / 1000,
+    }
+  }
+
   // Evaluate start condition if present
   if (workflow.startCondition && workflow.startCondition.type !== 'always') {
     const session = sessionManager.requireSession(sessionId)
@@ -311,7 +363,6 @@ export async function executeWorkflow(
   }
 
   // Emit workflow-started marker into the feed (skip on resume)
-  let executionId: string | undefined
   if (!isResume) {
     const startMsgId = crypto.randomUUID()
     const startWindowOpts = getCurrentWindowMessageOptions(sessionId)
@@ -340,12 +391,6 @@ export async function executeWorkflow(
       workflow.metadata.color,
       options.params ?? {},
     )
-  } else {
-    // On resume, get the existing execution ID from the session
-    const activeExec = sessionManager.getActiveWorkflowExecution(sessionId)
-    if (activeExec) {
-      executionId = activeExec.id
-    }
   }
 
   // Inject user-provided message on resume too (e.g. after abort, user types guidance)


### PR DESCRIPTION
## Summary

Enforce git-context integrity for write workflows (#183) and refresh agent
state after any official workspace/branch mutation during a turn (#190).

When the session is bound to a Git branch (e.g. through Dev & Verify or the
workspace tool) but the effective workdir cannot be verified on that
branch, the workflow is now blocked **before** any agent step, any shell
step, or any file write. Non-git projects and sessions without an explicit
branch expectation are not blocked.

After an authoritative workspace or branch mutation, the cached system
prompt is invalidated so the next LLM call (same-turn continuation AND next
user turn) rebuilds against the new workspace/branch. On mutation failure
the agent sees the failure and the pre-mutation state — there is no fake
refreshed context.

## Changes

### Workflow gate (#183) — `executeWorkflow()`

- New `SessionManager.assertExecutionGitContext()` reads the effective
  workdir, the persisted session branch and the actual Git branch, and
  returns either `{ ok: true }` or `{ ok: false, reason }`.
- `executeWorkflow()` now calls the gate as the very first step (before
  start-condition evaluation, before the workflow-started marker, before
  any agent or shell step). On failure the workflow is **BLOCKED** with a
  clear reason, no agent is invoked, no checkout is performed, and
  `startWorkflow()` is never called.
- The reason explicitly includes `workdir`, the expected branch, the actual
  branch and a remediation hint pointing the user at the workspace tool.

### Fail-closed decision matrix

| `expectedBranch` | `actualBranch`           | Result     |
| ---------------- | ------------------------ | ---------- |
| `null`           | `null`                   | `{ ok: true }` |
| `null`           | `<any non-null>`         | `{ ok: true }` |
| `<set>`          | equal `<set>`            | `{ ok: true }` |
| `<set>`          | different `<set>`        | `{ ok: false, reason }` |
| `<set>`          | `null` (detached HEAD, …) | `{ ok: false, reason }` |

The last row was previously fail-open (returning `{ ok: true }` whenever
the actual branch could not be resolved) and is now `BLOCKED`. The reason
explicitly states that the actual branch is unavailable and that no agent,
no checkout and no file were performed.

### Post-mutation context refresh (#190) — `SessionManager.switchWorkspace()`

- New `SessionManager.clearCachedPrompt()` (and the matching
  `clearSessionCachedPrompt` DB helper) invalidates the cached system
  prompt, resets the warmup flag and sets `dynamicContextChanged = true`.
- `SessionManager.switchWorkspace()` calls `SessionManager.clearCachedPrompt()`
  **after** the new workdir/branch has been read authoritatively and
  **only on a successful mutation** — no fake refreshed context on failure.
- The workspace tool's success path continues to surface the authoritative
  post-mutation `workspace`, `path` and `branch`; on failure it propagates
  the underlying error without inventing state.

### Non-goals

- No frontend changes were required for this delivery. The web client
  already re-renders from the same authoritative events the server emits.

## Validation

- `npx vitest run src/server/workflows/executor.execution-context.test.ts src/server/session/manager.execution-context.test.ts src/server/workflows/executor.test.ts src/server/workflows/executor-mode.test.ts src/server/workflows/executor-resume-nudge.test.ts src/server/session/manager.test.ts src/server/tools/workspace.test.ts`
  → **Test Files 7 passed (7), Tests 136 passed (136)** — exit 0
- `npx tsc --noEmit` → clean — exit 0
- `npm run lint` → clean — exit 0
- `npx vitest run src/server src/shared`
  → **Test Files 151 passed | 2 skipped (153), Tests 2118 passed | 26 skipped (2151)** — exit 0

## Commits

- `54d70b43` — `fix(workflows): guard execution git context`
- `e1aa1e3b` — `fix(context): refresh agent state after workspace mutation`
- `8b7442c8` — `fix(workflows): fail closed when expected branch is unavailable`

## Related issues

Issue #190 was identified while investigating #183 and covers agent-context
refresh after workspace or branch mutation.

Fixes #183
Fixes #190