### PR TITLE
fix: delete customized commands

### DIFF
--- a/src/server/commands/registry.test.ts
+++ b/src/server/commands/registry.test.ts
@@ -219,6 +219,24 @@ describe('CRUD', () => {
     }
   })
 
+  it('should delete a user override without deleting the built-in command', async () => {
+    const defaults = await loadDefaultCommands()
+    const defaultCommand = defaults[0]
+    if (!defaultCommand) return
+
+    await saveCommand(tempDir, {
+      metadata: { ...defaultCommand.metadata, name: 'Customized Command' },
+      prompt: 'Customized prompt.',
+    })
+
+    const result = await deleteCommand(tempDir, defaultCommand.metadata.id)
+    expect(result.success).toBe(true)
+
+    const commands = await loadAllCommands(tempDir)
+    const restoredDefault = commands.find((command) => command.metadata.id === defaultCommand.metadata.id)
+    expect(restoredDefault).toEqual(defaultCommand)
+  })
+
   it('should return false when deleting non-existent command', async () => {
     const result = await deleteCommand(tempDir, 'nonexistent')
     expect(result.success).toBe(false)

--- a/src/server/commands/registry.ts
+++ b/src/server/commands/registry.ts
@@ -129,15 +129,14 @@ export async function deleteCommand(
   configDir: string,
   commandId: string,
 ): Promise<{ success: boolean; reason?: string }> {
-  const isDefault = await isDefaultCommand(commandId)
-  if (isDefault) {
-    return { success: false, reason: 'Cannot delete built-in defaults' }
-  }
   const filePath = join(getCommandsDir(configDir), `${commandId}${COMMAND_EXTENSION}`)
   try {
     await unlink(filePath)
     return { success: true }
   } catch {
+    if (await isDefaultCommand(commandId)) {
+      return { success: false, reason: 'Cannot delete built-in defaults' }
+    }
     return { success: false }
   }
 }

--- a/web/src/stores/commands.test.ts
+++ b/web/src/stores/commands.test.ts
@@ -1,0 +1,41 @@
+// @vitest-environment happy-dom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { authFetch } from '../lib/api'
+import { useCommandsStore, type CommandInfo } from './commands'
+
+vi.mock('../lib/api', () => ({
+  authFetch: vi.fn(),
+}))
+
+const mockedAuthFetch = vi.mocked(authFetch)
+
+function command(id: string): CommandInfo {
+  return { id, name: id }
+}
+
+describe('commands store deletion', () => {
+  beforeEach(() => {
+    mockedAuthFetch.mockReset()
+    useCommandsStore.setState({
+      defaults: [],
+      userItems: [command('user-command')],
+      projectItems: [command('project-command')],
+      loading: false,
+    })
+  })
+
+  it('removes a deleted project command from client state', async () => {
+    mockedAuthFetch.mockResolvedValue(
+      new Response(JSON.stringify({ success: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+
+    const result = await useCommandsStore.getState().deleteCommand('project-command')
+
+    expect(result).toEqual({ success: true })
+    expect(useCommandsStore.getState().userItems).toEqual([command('user-command')])
+    expect(useCommandsStore.getState().projectItems).toEqual([])
+  })
+})

--- a/web/src/stores/commands.ts
+++ b/web/src/stores/commands.ts
@@ -87,6 +87,7 @@ export const useCommandsStore = create<CommandsState>((set, get) => ({
       if (res.ok) {
         set((state) => ({
           userItems: state.userItems.filter((c) => c.id !== commandId),
+          projectItems: state.projectItems.filter((c) => c.id !== commandId),
         }))
         return { success: true }
       }


### PR DESCRIPTION
### Summary

Fixes #184.

Custom commands could remain undeletable in two cases:

- a project-scoped command was deleted by the API but left in the client store, so it continued to appear until a refresh;
- a user override sharing a built-in command ID was rejected before its override file could be removed.

The command store now removes successful deletions from both global and project collections. The registry now attempts to remove the user override first and only protects the built-in command when no override file exists. Regression tests cover both paths and confirm the bundled default becomes visible again after its override is deleted.

Validation:

- `npx vitest run src/server/commands/registry.test.ts web/src/stores/commands.test.ts` — 27 passed
- `npm run lint` — passed
- changed-file Prettier check — passed
- `npm run typecheck:server` — passed
- changed-source jscpd scan — 0 clones
- server bundle and declaration build — passed

Repository-wide Windows limitations observed on unchanged code:

- web typecheck cannot resolve the existing `overlayscrollbars` imports after `npm ci`;
- the full test suite contains Unix-only `bash`, `sleep`, and `tail` assumptions plus Windows temp-directory lock failures;
- the full build completes server output, then its Unix `mkdir -p`/`cp` shell chain fails under PowerShell.

### AI-Enhanced Development

Tell what models helped shape this PR:

- **AI Models:** OpenAI Codex (GPT-5)

### Cache Impact

Does this PR affect anything cached — system prompts, tool definitions, skills, or other context?

- **No**