### PR TITLE
fix: keep clear-all confirmation visible

### DIFF
--- a/web/src/components/plan/CriteriaEditor.test.tsx
+++ b/web/src/components/plan/CriteriaEditor.test.tsx
@@ -1,12 +1,16 @@
 // @vitest-environment happy-dom
 import '@testing-library/jest-dom/vitest'
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { CriteriaEditor } from './CriteriaEditor'
 import { authFetch } from '../../lib/api'
 
 vi.mock('../../lib/api', () => ({
   authFetch: vi.fn(() => Promise.resolve(new Response(null, { status: 200 }))),
+}))
+
+vi.mock('../shared/Modal', () => ({
+  Modal: () => null,
 }))
 
 vi.mock('../../stores/agents', () => ({
@@ -111,5 +115,28 @@ describe('CriteriaEditor', () => {
 
     expect(screen.getByText('[3] New one')).toBeInTheDocument()
     expect(screen.getByText('[4] New two')).toBeInTheDocument()
+  })
+
+  it('shows the clear-all confirmation inside the footer for a long criteria list', () => {
+    render(
+      <CriteriaEditor
+        sessionId="session-1"
+        entries={Array.from({ length: 16 }, (_, index) => ({
+          id: String(index),
+          description: `Criterion ${index}`,
+          status: 'pending',
+        }))}
+      />,
+    )
+
+    const clearButton = screen.getByRole('button', { name: 'Clear all' })
+    const footer = clearButton.parentElement
+    expect(footer).not.toBeNull()
+
+    fireEvent.click(clearButton)
+
+    expect(within(footer!).getByText('Clear all criteria?')).toBeInTheDocument()
+    expect(within(footer!).getByRole('button', { name: 'Yes' })).toBeInTheDocument()
+    expect(within(footer!).getByRole('button', { name: 'No' })).toBeInTheDocument()
   })
 })

--- a/web/src/components/plan/CriteriaEditor.tsx
+++ b/web/src/components/plan/CriteriaEditor.tsx
@@ -293,31 +293,10 @@ export function CriteriaEditor({ entries, sessionId }: CriteriaEditorProps) {
             Add
           </button>
         )}
-        {criteria.length > 0 && (
-          <button
-            onClick={() => setClearConfirm(true)}
-            className="flex items-center gap-1 text-xs text-text-muted hover:text-accent-error transition-colors ml-auto cursor-pointer"
-            title="Clear all criteria"
-          >
-            <TrashIcon className="w-3 h-3" />
-            Clear all
-          </button>
-        )}
-        <button
-          onClick={() => setShowInfo(true)}
-          className="flex items-center gap-1 text-xs text-text-muted hover:text-accent-primary transition-colors cursor-pointer"
-          title="About criteria"
-        >
-          <InfoIcon className="w-3 h-3" />
-        </button>
-      </div>
-
-      {/* Clear all confirmation */}
-      {clearConfirm && (
-        <div className="px-1.5 py-1 border-t border-border bg-secondary">
-          <div className="flex items-center gap-2 justify-between">
-            <span className="text-xs text-accent-error">Clear all criteria?</span>
-            <div className="flex items-center gap-2">
+        {criteria.length > 0 &&
+          (clearConfirm ? (
+            <div className="flex items-center gap-2 ml-auto">
+              <span className="text-xs text-accent-error">Clear all criteria?</span>
               <button
                 onClick={handleClearAll}
                 className="text-xs text-accent-error hover:text-accent-error/70 transition-colors cursor-pointer"
@@ -331,9 +310,24 @@ export function CriteriaEditor({ entries, sessionId }: CriteriaEditorProps) {
                 No
               </button>
             </div>
-          </div>
-        </div>
-      )}
+          ) : (
+            <button
+              onClick={() => setClearConfirm(true)}
+              className="flex items-center gap-1 text-xs text-text-muted hover:text-accent-error transition-colors ml-auto cursor-pointer"
+              title="Clear all criteria"
+            >
+              <TrashIcon className="w-3 h-3" />
+              Clear all
+            </button>
+          ))}
+        <button
+          onClick={() => setShowInfo(true)}
+          className="flex items-center gap-1 text-xs text-text-muted hover:text-accent-primary transition-colors cursor-pointer"
+          title="About criteria"
+        >
+          <InfoIcon className="w-3 h-3" />
+        </button>
+      </div>
 
       {/* Info modal */}
       <Modal isOpen={showInfo} onClose={() => setShowInfo(false)} title="About Acceptance Criteria" size="md">


### PR DESCRIPTION
### Summary

Fixes #182.

Keep the clear-all confirmation in the existing CriteriaEditor footer instead of appending a new row below the criteria list. This keeps the confirmation visible when the list is long or scrolled. A regression test uses 16 criteria and verifies that the prompt and Yes/No actions remain inside the footer.

Validation:
- `npx vitest run web/src/components/plan/CriteriaEditor.test.tsx` (5 passed)
- `npm run lint` (passed)
- Prettier check on both changed files (passed)
- jscpd on the changed source file (0 clones)

The repository-wide duplicate hook is not reliable on Windows because its single-quoted test-file ignore is treated literally; it reports 322 pre-existing clones. The full suite, web typecheck, and build also retain the same unrelated Windows/missing-overlay dependency limitations documented in #192. The affected test file passes independently.

### AI-Enhanced Development

Tell what models helped shape this PR:

- **AI Models:** OpenAI Codex (GPT-5)

### Cache Impact

Does this PR affect anything cached — system prompts, tool definitions, skills, or other context?

- **No**