### PR TITLE
feat(settings): warn when RTK auto-rewrite is paired with cmd/PowerShell

### DIFF
--- a/web/src/components/settings/tabs/ToolsTab.test.tsx
+++ b/web/src/components/settings/tabs/ToolsTab.test.tsx
@@ -180,3 +180,79 @@ describe('ToolsTab MCP server toggle isolation', () => {
     expect(JSON.parse((putCalls[0]![1] as Record<string, string>).body as string)).toEqual({ disabled: true })
   })
 })
+
+describe('ToolsTab RTK shell hint (Windows)', () => {
+  const HINT_PATTERN = /RTK only rewrites Unix-style commands/
+
+  const mockFetchWithShells = async (shells: { id: string; label: string; available: boolean }[]) => {
+    const { authFetch } = await import('../../../lib/api')
+    const mockFn = authFetch as ReturnType<typeof vi.fn>
+    mockFn.mockImplementation(async (url: string) => ({
+      ok: true,
+      json: async () => {
+        if (url === '/api/tools/shells') return { shells }
+        if (url === '/api/tools/rtk-check') return { available: true }
+        return { servers: [] }
+      },
+    }))
+  }
+
+  const WINDOWS_SHELLS = [
+    { id: 'cmd', label: 'cmd.exe', available: true },
+    { id: 'powershell', label: 'PowerShell', available: true },
+    { id: 'gitbash', label: 'Git Bash', available: true },
+  ]
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+  afterEach(() => {
+    cleanup()
+    delete mockSettings['tools.useRtk']
+    delete mockSettings['tools.shell']
+  })
+
+  it('shows the hint when RTK is enabled with cmd.exe', async () => {
+    await mockFetchWithShells(WINDOWS_SHELLS)
+    mockSettings['tools.useRtk'] = 'true'
+    mockSettings['tools.shell'] = 'cmd'
+    render(<ToolsTab />)
+    await screen.findByText('cmd.exe')
+    expect(screen.getByText(HINT_PATTERN)).toBeDefined()
+  })
+
+  it('shows the hint when RTK is enabled with PowerShell', async () => {
+    await mockFetchWithShells(WINDOWS_SHELLS)
+    mockSettings['tools.useRtk'] = 'true'
+    mockSettings['tools.shell'] = 'powershell'
+    render(<ToolsTab />)
+    await screen.findByText('Git Bash')
+    expect(screen.getByText(HINT_PATTERN)).toBeDefined()
+  })
+
+  it('hides the hint when the selected shell is Git Bash', async () => {
+    await mockFetchWithShells(WINDOWS_SHELLS)
+    mockSettings['tools.useRtk'] = 'true'
+    mockSettings['tools.shell'] = 'gitbash'
+    render(<ToolsTab />)
+    await screen.findByText('cmd.exe')
+    expect(screen.queryByText(HINT_PATTERN)).toBeNull()
+  })
+
+  it('hides the hint when RTK is disabled', async () => {
+    await mockFetchWithShells(WINDOWS_SHELLS)
+    mockSettings['tools.useRtk'] = 'false'
+    mockSettings['tools.shell'] = 'cmd'
+    render(<ToolsTab />)
+    await screen.findByText('cmd.exe')
+    expect(screen.queryByText(HINT_PATTERN)).toBeNull()
+  })
+
+  it('hides the hint on non-Windows platforms (no shells)', async () => {
+    await mockFetchWithShells([])
+    mockSettings['tools.useRtk'] = 'true'
+    render(<ToolsTab />)
+    await screen.findByText('Enable RTK auto-rewrite')
+    expect(screen.queryByText(HINT_PATTERN)).toBeNull()
+  })
+})

--- a/web/src/components/settings/tabs/ToolsTab.tsx
+++ b/web/src/components/settings/tabs/ToolsTab.tsx
@@ -698,6 +698,12 @@ export function ToolsTab() {
             }
           />
         </div>
+        {shells.length > 0 && settings[SETTINGS_KEYS.TOOLS_USE_RTK] === 'true' && currentShell !== 'gitbash' && (
+          <p className="text-xs text-accent-warning mt-1">
+            RTK only rewrites Unix-style commands — with this shell it will rarely apply and can break some commands.
+            Git Bash is recommended.
+          </p>
+        )}
       </div>
 
       <hr className="border-border" />


### PR DESCRIPTION
## Summary

**Adds a one-line warning under the RTK toggle on Windows when a non-Git-Bash shell is selected.**

On Windows the shell picker and the RTK toggle look independent, but they aren't: RTK only rewrites Unix-style syntax. With cmd.exe or PowerShell it's effectively a no-op that looks enabled — and a few rewrites can even break commands that worked before. This surfaces that fact at the moment the user picks their shell. No behavior change.

Here's what actually happens, measured per shell (each cell: without RTK → with RTK):

| Command the model emits | cmd.exe | PowerShell | Git Bash |
|---|---|---|---|
| `git status` | ✅ → ✅ (compressed) | ✅ → ✅ | ✅ → ✅ |
| `cat file` | ❌ → ✅ **rescued** | ✅ (alias) → ✅ | ✅ → ✅ |
| `head -20 file` | ❌ → ✅ **rescued** | ❌ → ✅ **rescued** | ✅ → ✅ |
| `ls` | ❌ → ❌ | ✅ (alias) → ❌ **broken** | ✅ → ✅ |
| `grep -n pat file` | ❌ → ❌ | ❌ → ❌ | ✅ → ✅ |
| `wc -l file` | ❌ → ❌ | ❌ → ❌ | ✅ → ✅ |
| `find . -name "*.ts"` | ❌ → ✅ **rescued** | ❌ (FIND.EXE) → ✅ **rescued** | ✅ → ✅ |
| `diff a b` | ❌ → ✅ | ✅ (alias) → ✅ | ✅ → ✅ |
| native (`dir`, `type`, cmdlets) | untouched | untouched | n/a |

Git Bash is the only shell where everything works and where RTK actually delivers its token savings — hence the recommendation in the hint.

## What Changed

- `web/src/components/settings/tabs/ToolsTab.tsx` — the warning. Rendered only when the Windows shell list is present, RTK is on, and the selected shell is not Git Bash. Invisible on Linux/macOS (`/api/tools/shells` returns an empty list there).
- `web/src/components/settings/tabs/ToolsTab.test.tsx` — 5 new tests covering when the hint shows (cmd, PowerShell) and when it must not (Git Bash, RTK off, non-Windows).

## How Has This Been Tested?

- [x] Unit tests
- [x] Manual testing

- `ToolsTab.test.tsx` — 8 tests (5 new) pass
- `npm run typecheck` / `npm run lint` — clean
- `npm run test:unit` — all `web/` tests green. 36 pre-existing failures in `src/` (temp-dir `EBUSY` teardown races, POSIX-path assertions) — none touch this web-only diff
- Manual: hint shows with cmd/PowerShell + RTK on; hides with Git Bash or RTK off
- Unix: not run locally — the hint is gated on the Windows-only shell list, deferring to CI

## Breaking Changes

None. Purely additive UI hint — no setting, endpoint, or server behavior changed.

- [ ] This PR introduces breaking changes

## Related Issues

None. Follow-up to the Windows shell picker (#77).

## AI-Enhanced Development

- **Models:** Deepseek V4 Flash (API) + Opus 5. Reviewed by Fable 5 on points of doubt.

## Cache Impact

**No** — settings-UI-only change. System prompts, tool definitions, and nothing under `src/server/` are touched in the diff.

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed

**Key files to review:** `web/src/components/settings/tabs/ToolsTab.tsx`