### PR TITLE
Allow an API key in the manual vision fallback config

### DIFF
--- a/src/cli/config.test.ts
+++ b/src/cli/config.test.ts
@@ -499,6 +499,41 @@ describe('resolveVisionFallback', () => {
     expect(result!.apiKey).toBeUndefined()
   })
 
+  it('passes the api key through when the manual config sets one', () => {
+    const config = makeConfig({
+      visionFallback: {
+        enabled: true,
+        url: 'https://api.openai.com/v1',
+        model: 'gpt-4o-mini',
+        timeout: 120,
+        backend: 'openai' as const,
+        apiKey: 'sk-manual-key',
+      },
+    })
+    const result = resolveVisionFallback(config)
+    expect(result).toBeDefined()
+    expect(result!.baseUrl).toBe('https://api.openai.com/v1')
+    expect(result!.backend).toBe('openai')
+    expect(result!.apiKey).toBe('sk-manual-key')
+  })
+
+  it('keeps using the provider key when providerModelRef resolves', () => {
+    const config = makeConfig({
+      visionFallback: {
+        enabled: true,
+        providerModelRef: 'vision-provider/gpt-4o-vision',
+        url: 'https://api.openai.com/v1',
+        model: 'gpt-4o-mini',
+        timeout: 120,
+        backend: 'openai' as const,
+        apiKey: 'sk-manual-key',
+      },
+    })
+    const result = resolveVisionFallback(config)
+    expect(result).toBeDefined()
+    expect(result!.apiKey).toBe('sk-test-key-123')
+  })
+
   it('handles provider-not-found gracefully by falling back to legacy', () => {
     const config = makeConfig({
       visionFallback: {

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -110,6 +110,7 @@ const visionFallbackSchema = z.object({
   timeout: z.number().default(120),
   backend: z.enum(['ollama', 'openai']).default('ollama'),
   providerModelRef: z.string().optional(),
+  apiKey: z.string().optional(),
 })
 
 const cachedToolSchema = z.object({
@@ -251,6 +252,7 @@ export function resolveVisionFallback(
       model: fallback.model,
       timeout: (fallback.timeout ?? 120) * 1000,
       backend: fallback.backend ?? 'ollama',
+      ...(fallback.apiKey ? { apiKey: fallback.apiKey } : {}),
     }
   }
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -2107,6 +2107,7 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
         timeout?: number
         backend?: VisionBackend
         providerModelRef?: string
+        apiKey?: string
       }
     }
 
@@ -2146,6 +2147,7 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
       timeout: z.number().positive().optional(),
       backend: z.enum(['ollama', 'openai']).optional(),
       providerModelRef: z.string().optional(),
+      apiKey: z.string().optional(),
     })
 
     const parsed = visionFallbackUpdateSchema.safeParse(req.body)
@@ -2197,6 +2199,7 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
       backend: z.enum(['ollama', 'openai']).optional(),
       providerModelRef: z.string().optional(),
       timeout: z.number().positive().optional(),
+      apiKey: z.string().optional(),
     })
 
     const parsed = testSchema.safeParse(req.body)

--- a/web/src/components/onboarding/OnboardingWizard.tsx
+++ b/web/src/components/onboarding/OnboardingWizard.tsx
@@ -18,6 +18,7 @@ interface OnboardingData {
     timeout: number
     backend?: 'ollama' | 'openai'
     providerModelRef?: string
+    apiKey?: string
   }
 }
 
@@ -48,6 +49,7 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
       timeout: number
       backend?: 'ollama' | 'openai'
       providerModelRef?: string
+      apiKey?: string
     }
   }) {
     setSaving(true)

--- a/web/src/components/onboarding/steps/VisionStep.tsx
+++ b/web/src/components/onboarding/steps/VisionStep.tsx
@@ -19,6 +19,7 @@ interface VisionStepProps {
       timeout: number
       backend?: 'ollama' | 'openai'
       providerModelRef?: string
+      apiKey?: string
     }
   }) => void
 }
@@ -27,6 +28,7 @@ export function VisionStep({ onNext }: VisionStepProps) {
   const [enabled, setEnabled] = useState(false)
   const [url, setUrl] = useState('http://localhost:11434')
   const [model, setModel] = useState('qwen3.5:0.8b')
+  const [apiKey, setApiKey] = useState('')
   const [backend, setBackend] = useState<'ollama' | 'openai'>('ollama')
   const [providers, setProviders] = useState<Provider[]>([])
   const [selectedRef, setSelectedRef] = useState<string>('')
@@ -43,6 +45,7 @@ export function VisionStep({ onNext }: VisionStepProps) {
           } else {
             setUrl(data.visionFallback.url ?? 'http://localhost:11434')
             setModel(data.visionFallback.model ?? 'qwen3.5:0.8b')
+            setApiKey(data.visionFallback.apiKey ?? '')
             if (data.visionFallback.backend) {
               setBackend(data.visionFallback.backend)
             }
@@ -84,6 +87,7 @@ export function VisionStep({ onNext }: VisionStepProps) {
           timeout: 120,
           backend,
           providerModelRef: '',
+          apiKey: backend === 'openai' ? apiKey : '',
         },
       })
     }
@@ -139,10 +143,11 @@ export function VisionStep({ onNext }: VisionStepProps) {
         <VisionModelConfigSection
           {...{ enabled, hasOptions, selectedRef, visionModelOptions }}
           onProviderModelSelect={handleProviderModelSelect}
-          {...{ backend, url, model }}
+          {...{ backend, url, model, apiKey }}
           onBackendChange={handleBackendChange}
           onUrlChange={setUrl}
           onModelChange={setModel}
+          onApiKeyChange={setApiKey}
           noOptionsMessage={noVisionMsg}
         />
 

--- a/web/src/components/shared/VisionModelSelector.tsx
+++ b/web/src/components/shared/VisionModelSelector.tsx
@@ -62,18 +62,22 @@ export interface ManualVisionConfigProps {
   backend: 'ollama' | 'openai'
   url: string
   model: string
+  apiKey: string
   onBackendChange: (backend: 'ollama' | 'openai') => void
   onUrlChange: (url: string) => void
   onModelChange: (model: string) => void
+  onApiKeyChange: (apiKey: string) => void
 }
 
 export function ManualVisionConfig({
   backend,
   url,
   model,
+  apiKey,
   onBackendChange,
   onUrlChange,
   onModelChange,
+  onApiKeyChange,
 }: ManualVisionConfigProps) {
   return (
     <div className="space-y-4">
@@ -110,6 +114,19 @@ export function ManualVisionConfig({
           className="w-full px-4 py-2 bg-bg-secondary border border-border rounded-lg text-text-primary placeholder-text-muted focus:outline-none focus:border-accent-primary"
         />
       </div>
+
+      {backend === 'openai' && (
+        <div>
+          <label className="block text-sm text-text-secondary mb-1">API key (optional)</label>
+          <input
+            type="password"
+            value={apiKey}
+            onChange={(e) => onApiKeyChange(e.target.value)}
+            placeholder="Leave empty for a local server that needs no auth"
+            className="w-full px-4 py-2 bg-bg-secondary border border-border rounded-lg text-text-primary placeholder-text-muted focus:outline-none focus:border-accent-primary"
+          />
+        </div>
+      )}
     </div>
   )
 }
@@ -147,18 +164,12 @@ export function useProviderModelSelectHandler(
   }
 }
 
-export interface VisionModelConfigSectionProps {
+export interface VisionModelConfigSectionProps extends ManualVisionConfigProps {
   enabled: boolean
   hasOptions: boolean
   selectedRef: string
   visionModelOptions: VisionModelOption[]
   onProviderModelSelect: (ref: string) => void
-  backend: 'ollama' | 'openai'
-  url: string
-  model: string
-  onBackendChange: (backend: 'ollama' | 'openai') => void
-  onUrlChange: (url: string) => void
-  onModelChange: (model: string) => void
   noOptionsMessage: string
   children?: ReactNode
 }
@@ -169,14 +180,9 @@ export function VisionModelConfigSection({
   selectedRef,
   visionModelOptions,
   onProviderModelSelect,
-  backend,
-  url,
-  model,
-  onBackendChange,
-  onUrlChange,
-  onModelChange,
   noOptionsMessage,
   children,
+  ...manualConfig
 }: VisionModelConfigSectionProps) {
   if (!enabled) return null
 
@@ -191,14 +197,7 @@ export function VisionModelConfigSection({
         <p className="text-sm text-text-muted italic">{noOptionsMessage}</p>
       )}
 
-      <ManualVisionConfig
-        backend={backend}
-        url={url}
-        model={model}
-        onBackendChange={onBackendChange}
-        onUrlChange={onUrlChange}
-        onModelChange={onModelChange}
-      />
+      <ManualVisionConfig {...manualConfig} />
 
       {children}
     </div>


### PR DESCRIPTION
The vision fallback can already authenticate against a hosted endpoint. `describeImage` sets the header as soon as the backend is openai and a key is present:

```ts
if (isOpenAI && visionModel.apiKey) {
  headers['Authorization'] = `Bearer ${visionModel.apiKey}`
}
```

The catch is that nothing can put a key there unless the vision model comes from a configured provider. `resolveVisionFallback` only forwards `apiKey` in the `providerModelRef` branch. The manual branch returns url, model, timeout and backend, and that is it.

That manual branch is exactly where the onboarding form lands when no provider exposes a vision capable model, which is the common case when your main provider is text only. So picking "OpenAI-compatible" and pointing it at a hosted API sends the request with no Authorization header and gets a 401 back. The form has no field for the key either, and hand editing config.json does not help because `visionFallbackSchema` is a plain `z.object` and drops the field on load.

What changed:

- `apiKey` is an optional field on `visionFallbackSchema`
- `resolveVisionFallback` forwards it in the manual branch
- the PUT and test routes for `/api/config/vision-fallback` accept it
- the onboarding vision step shows a password input for it, only when the backend is openai, since ollama has no use for it

Leaving the field empty gives exactly the current behavior, and `providerModelRef` still takes precedence when it resolves, so a provider key is never shadowed by a manual one. There is a test for each of those two points.

One small refactor came along with it. `VisionModelConfigSectionProps` now extends `ManualVisionConfigProps` instead of restating its fields, because one more field pushed the two blocks past the jscpd threshold. It also means the section no longer threads each field through by hand.

Checked with `npm run typecheck`, `npm run lint` and `npm run duplicate`, all green, and `src/cli/config.test.ts` passes with the two added cases. Note that `npm run format` and a few e2e setup hooks already fail on a clean main in my environment, neither is touched here.
