### PR TITLE
 fix(windows): open folder, workspace deletion, file search, and permission checks on win32

### DIFF
--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -1,5 +1,5 @@
 import { readFile, writeFile, mkdir } from 'node:fs/promises'
-import { join, dirname } from 'node:path'
+import { join, dirname, basename } from 'node:path'
 import { createHash, privateDecrypt, createPublicKey } from 'node:crypto'
 import { getRuntimeConfig } from './runtime-config.js'
 import type { Mode } from '../cli/main.js'
@@ -11,7 +11,7 @@ function getAuthConfigPath(): string {
 
   if (mode === 'test') {
     const cwd = process.cwd()
-    const base = cwd.endsWith('/e2e') ? cwd : join(cwd, 'e2e')
+    const base = basename(cwd) === 'e2e' ? cwd : join(cwd, 'e2e')
     const testAuthPath = join(base, '.openfox-test', 'auth.json')
     return testAuthPath
   }

--- a/src/server/git/workspace.test.ts
+++ b/src/server/git/workspace.test.ts
@@ -365,61 +365,34 @@ describe('isGitRepository', () => {
 })
 
 describe('deleteWorkspace', () => {
-  it('uses execFileSync instead of execSync for safe deletion', async () => {
+  it('deletes via fs.rm without spawning any process', async () => {
     vi.mocked(stat).mockResolvedValue({ isDirectory: () => true } as any)
 
     await deleteWorkspace(PROJECT_NAME, 'test-ws', CWD)
 
-    expect(execFileSync).toHaveBeenCalledWith('rm', ['-rf', expect.stringContaining('test-ws')], expect.any(Object))
-    expect(execSync).not.toHaveBeenCalled()
-  })
-
-  it('falls back to fs.rm when execFileSync fails', async () => {
-    vi.mocked(stat).mockResolvedValue({ isDirectory: () => true } as any)
-    vi.mocked(execFileSync).mockImplementation(() => {
-      throw new Error('Simulated rm failure')
+    expect(rm).toHaveBeenCalledWith(expect.stringContaining('test-ws'), {
+      recursive: true,
+      force: true,
+      maxRetries: 3,
     })
-
-    await deleteWorkspace(PROJECT_NAME, 'test-ws', CWD)
-
-    expect(rm).toHaveBeenCalledWith(expect.stringContaining('test-ws'), { recursive: true, force: true })
+    expect(execSync).not.toHaveBeenCalled()
+    expect(execFileSync).not.toHaveBeenCalled()
   })
 
-  it('does not create files when workspace name contains shell injection - semicolon', async () => {
-    const maliciousName = 'test; touch ~/.malicious_semicolon'
+  it.each([
+    ['semicolon', 'test; touch ~/.malicious_semicolon'],
+    ['backticks', '`touch ~/.malicious_backtick`'],
+    ['dollar sign', '$HOME/test'],
+    ['command substitution', '$(touch ~/.malicious_substitution)'],
+  ])('does not shell-interpret workspace name - %s', async (_label, maliciousName) => {
     vi.mocked(stat).mockResolvedValue({ isDirectory: () => true } as any)
 
-    // execFileSync passes args directly, no shell interpretation
+    // fs.rm takes the path as plain data — shell metacharacters are inert
     await deleteWorkspace(PROJECT_NAME, maliciousName, CWD)
 
-    expect(execFileSync).toHaveBeenCalledWith('rm', ['-rf', expect.stringContaining(maliciousName)], expect.any(Object))
-  })
-
-  it('does not create files when workspace name contains shell injection - backticks', async () => {
-    const maliciousName = '`touch ~/.malicious_backtick`'
-    vi.mocked(stat).mockResolvedValue({ isDirectory: () => true } as any)
-
-    await deleteWorkspace(PROJECT_NAME, maliciousName, CWD)
-
-    expect(execFileSync).toHaveBeenCalledWith('rm', ['-rf', expect.stringContaining(maliciousName)], expect.any(Object))
-  })
-
-  it('does not create files when workspace name contains shell injection - dollar sign', async () => {
-    const maliciousName = '$HOME/test'
-    vi.mocked(stat).mockResolvedValue({ isDirectory: () => true } as any)
-
-    await deleteWorkspace(PROJECT_NAME, maliciousName, CWD)
-
-    expect(execFileSync).toHaveBeenCalledWith('rm', ['-rf', expect.stringContaining(maliciousName)], expect.any(Object))
-  })
-
-  it('does not create files when workspace name contains shell injection - command substitution', async () => {
-    const maliciousName = '$(touch ~/.malicious_substitution)'
-    vi.mocked(stat).mockResolvedValue({ isDirectory: () => true } as any)
-
-    await deleteWorkspace(PROJECT_NAME, maliciousName, CWD)
-
-    expect(execFileSync).toHaveBeenCalledWith('rm', ['-rf', expect.stringContaining(maliciousName)], expect.any(Object))
+    expect(rm).toHaveBeenCalledTimes(1)
+    expect(execSync).not.toHaveBeenCalled()
+    expect(execFileSync).not.toHaveBeenCalled()
   })
 
   it('throws error when workspace does not exist', async () => {

--- a/src/server/git/workspace.ts
+++ b/src/server/git/workspace.ts
@@ -1,5 +1,5 @@
-import { spawn, execSync, execFileSync } from 'node:child_process'
-import { mkdir } from 'node:fs/promises'
+import { spawn, execSync } from 'node:child_process'
+import { mkdir, rm } from 'node:fs/promises'
 import { resolve, join, isAbsolute } from 'node:path'
 import { homedir, platform } from 'node:os'
 import { logger } from '../utils/logger.js'
@@ -320,12 +320,7 @@ export async function deleteWorkspace(projectName: string, name: string, project
   if (!st?.isDirectory()) {
     throw new Error(`Workspace "${name}" does not exist`)
   }
-  try {
-    execFileSync('rm', ['-rf', wsPath], { stdio: 'ignore' })
-  } catch {
-    const { rm } = await import('node:fs/promises')
-    await rm(wsPath, { recursive: true, force: true })
-  }
+  await rm(wsPath, { recursive: true, force: true, maxRetries: 3 })
   logger.info('Deleted workspace', { projectName, name, path: wsPath })
 }
 

--- a/src/server/routes/file-search.ts
+++ b/src/server/routes/file-search.ts
@@ -38,8 +38,8 @@ interface FileSuggestion {
 }
 
 async function searchFiles(query: string, workdir: string): Promise<FileSuggestion[]> {
-  if (query.endsWith('/')) {
-    return listDirectoryContents(query, workdir)
+  if (/[\\/]$/.test(query)) {
+    return listDirectoryContents(query.replace(/\\/g, '/'), workdir)
   }
 
   const entries = await fg(['**/*'], {

--- a/src/server/utils/openFolder.ts
+++ b/src/server/utils/openFolder.ts
@@ -1,11 +1,19 @@
 import { platform } from 'node:os'
+import { mkdir } from 'node:fs/promises'
 import { execFile } from 'node:child_process'
 import { promisify } from 'node:util'
 
 const execFileP = promisify(execFile)
 
 export async function openFolder(dir: string): Promise<void> {
-  await execFileP('mkdir', ['-p', dir], { timeout: 5000 })
+  await mkdir(dir, { recursive: true })
   const cmd = platform() === 'darwin' ? 'open' : platform() === 'win32' ? 'explorer' : 'xdg-open'
-  await execFileP(cmd, [dir], { timeout: 5000 })
+  try {
+    await execFileP(cmd, [dir], { timeout: 5000 })
+  } catch (err) {
+    // explorer.exe exits with code 1 even when the folder opens successfully
+    if (platform() !== 'win32' || (err as { code?: number | string }).code !== 1) {
+      throw err
+    }
+  }
 }

--- a/src/server/utils/permissions.ts
+++ b/src/server/utils/permissions.ts
@@ -77,6 +77,10 @@ async function getDirInfo(targetPath: string): Promise<DirInfo> {
 }
 
 export async function checkPermissions(targetPath: string) {
+  if (process.platform === 'win32') {
+    // Unix group/sudo-based permission management does not apply on Windows
+    return { success: false, error: 'Automatic permission management is not supported on Windows', status: 501 }
+  }
   try {
     const info = await getDirInfo(targetPath)
     return {
@@ -96,6 +100,14 @@ export async function checkPermissions(targetPath: string) {
 }
 
 export async function fixPermissions(targetPath: string, action: string) {
+  if (process.platform === 'win32') {
+    return {
+      success: false,
+      sudoAvailable: false,
+      error: 'Automatic permission fixes are not supported on Windows',
+      status: 501,
+    }
+  }
   try {
     const info = await getDirInfo(targetPath)
 

--- a/src/server/utils/project-creator.ts
+++ b/src/server/utils/project-creator.ts
@@ -91,9 +91,10 @@ export async function createDirectoryWithGit(projectName: string, workdir: strin
       const exitCode = (gitErr as { status?: number }).status ?? (gitErr as { exitCode?: number }).exitCode
       const isPermission = errMsg.includes('Permission denied') || exitCode === 128
 
-      // Try via sudo -u $USER if permission denied (process may not have correct groups)
+      // Try via sudo -u $USER if permission denied (process may not have correct groups).
+      // No sudo/id on Windows — skip straight to the error.
       let sudoSuccess = false
-      if (isPermission) {
+      if (isPermission && process.platform !== 'win32') {
         try {
           const currentUser = execSync('id -un', { encoding: 'utf-8', windowsHide: true }).trim()
           execSync(`sudo -u ${currentUser} git init`, {


### PR DESCRIPTION
## Summary

Five small server-side fixes for Windows, bundled because they share one root cause: POSIX-only binaries (`mkdir`, `rm`, `id`, `sudo`) or `/`-only path handling. 

The most visible one: the "Open project folder" button in the header (and the plugin "Open folder" links) always returned HTTP 500 on Windows — the feature was dead. 
Workspace deletion also only worked by accident, through its error fallback.

## What Changed

**Modified**

- `src/server/utils/openFolder.ts` — replace `execFile('mkdir', ['-p'])` (ENOENT on stock Windows: `mkdir` is a cmd.exe builtin, not an executable) with `fs.mkdir({ recursive: true })`; tolerate `explorer.exe` exiting with code 1, which it does even when the folder opens successfully.
- `src/server/git/workspace.ts` — `deleteWorkspace()` shelled out to `rm -rf` (ENOENT on Windows, only worked via the `fs.rm` fallback in the catch block); now calls `fs.rm({ recursive, force, maxRetries: 3 })` directly on all platforms — one code path, no process spawn, `maxRetries` absorbs transient Windows file locks (antivirus/indexer).
- `src/server/git/workspace.test.ts` — tests updated for the above: the shell-injection cases now assert that no child process is spawned at all (the path is plain data to `fs.rm`), consolidated with `it.each`.
- `src/server/utils/permissions.ts` — `checkPermissions()`/`fixPermissions()` are built on `id`/`sudo`/`getent`/`chmod`; on Windows they crash (`id` ENOENT) or return nonsense. Early-return a clear 501 on win32 so `PermissionDeniedModal` gets a deterministic answer.
- `src/server/utils/project-creator.ts` — skip the `sudo -u $USER git init` retry on win32: `sudo` doesn't exist there, so the attempt always failed and only delayed the real error.
- `src/server/routes/file-search.ts` — a query ending in a separator lists directory contents, but only `/` was recognized; Windows users typing `src\` got fuzzy-match garbage. Accept a trailing backslash and normalize `\` to `/` before building the glob (fast-glob patterns are POSIX).
- `src/server/auth.ts` — the test-mode auth path checked `cwd.endsWith('/e2e')`, never true with backslash cwds; use `basename(cwd) === 'e2e'` instead.

## Motivation & Context

Part of an ongoing Windows compatibility review of OpenFox on a real Windows 11 machine (follow-up to #73, #74, #77, #87, #93, #97). Clicking the folder icon in the header did nothing on Windows; the server logged:

```
Error: spawn mkdir ENOENT
```

and `GET /api/projects/:id/open-folder` returned 500 on every call. The other four fixes came out of a systematic scan for the same class of bug (POSIX binaries and `/`-only string checks in server code).

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing

- `npx vitest run src/server/auth.test.ts src/server/git/workspace.test.ts src/server/routes/file-search.test.ts` — 79/79 pass on Windows 11.
- `npm run typecheck` — clean (server + web).
- Manual on Windows 11 (server started from PowerShell, so Git-for-Windows binaries don't mask the bugs): header folder icon now opens Explorer with a 200 response (500 before); workspace create/delete works and the directory is really removed from `%LOCALAPPDATA%\openfox\workspaces\...`; typing `src\` in file search lists the directory like `src/` does.
- Unix: not run locally — every change either branches on win32 or is a POSIX no-op (`fs.mkdir`/`fs.rm` replace shelling out to `mkdir`/`rm`; `basename(cwd) === 'e2e'` ⇔ `cwd.endsWith('/e2e')` on POSIX). Deferring to CI.
- Note: the full `npm test` currently has 34 failures **on Windows** on a clean `develop` checkout (encoding/file-tracking/install suites — pre-existing, unrelated to this diff; verified by stashing these changes and re-running). None touch the files changed here.

## Breaking Changes

None. All changes are Windows-only branches or drop-in stdlib replacements with identical observable behavior on Unix.

- [ ] This PR introduces breaking changes

## Related Issues

Follow-up to the Windows compatibility series (#73, #74, #77, #87, #93, #97). 
I haven't checked if there's any opened tickets related to these specific bugs.

## AI-Enhanced Development

- **AI Models:** Claude Fable 5 (via Claude Code) , every fix reproduced and manually verified on a real Windows 11 machine by myself (the human).

## Cache Impact

- **No** — server-side runtime code only; no system prompts, tool definitions, skills, or cached context are touched.

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed

**Key files to review:** `src/server/git/workspace.ts` (deletion path shared by all platforms), `src/server/utils/openFolder.ts`, `src/server/utils/permissions.ts`

---

<details>
<summary><b>Technical investigation</b> — symptoms, root cause, and fix details</summary>

### Symptoms

Open folder (header icon, plugin cards):

```
Error: spawn mkdir ENOENT
GET /api/projects/:id/open-folder → 500 (every call)
```

Even with Git-for-Windows `mkdir.exe` on PATH (server started from Git Bash), the route still failed:

```
Error: Command failed: explorer C:\...  (exit code 1)
```

because `explorer.exe` exits 1 even on success — the folder opened, but the API reported failure.

### Cause

1. `openFolder()` (`src/server/utils/openFolder.ts`) spawned `mkdir -p`: a cmd.exe builtin on Windows, not an executable → ENOENT before `explorer` ever ran. Second bug behind it: `explorer.exe`'s unconditional exit code 1 rejected the promisified `execFile`.
2. `deleteWorkspace()` (`src/server/git/workspace.ts`) ran `execFileSync('rm', ['-rf', path])` → ENOENT on stock Windows; deletion only succeeded because the `catch` fell back to `fs.rm`. The primary path was dead code on win32 and a needless process spawn on Unix.
3. `checkPermissions()`/`fixPermissions()` (`src/server/utils/permissions.ts`) exec `id -un`, `sudo -n true`, `sudo usermod -aG`, `getent group` — ENOENT on Windows unless Git Bash utilities happen to be on PATH, in which case the group/sudo semantics are meaningless anyway. `createDirectoryWithGit()` had the same dead `sudo -u $USER git init` retry.
4. `searchFiles()` (`src/server/routes/file-search.ts`) recognized only `/` as the "list directory" suffix; `\` fell through to fuzzy scoring against the raw backslash string.
5. `getAuthConfigPath()` (`src/server/auth.ts`) tested `cwd.endsWith('/e2e')`; Windows cwds use `\`, so test mode resolved the auth path to `<cwd>/e2e/...` even when already inside `e2e/`.

</details>
