### PR TITLE
Connect MCP servers that require OAuth

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ _Vision Fallback — Image processing configuration_
 | `OPENFOX_LLM_IDLE_TIMEOUT`           | `300000`                   | LLM stream idle timeout in ms                                   |
 | `OPENFOX_PORT`                       | `10369`                    | Server listen port                                              |
 | `OPENFOX_HOST`                       | `127.0.0.1`                | Server bind host                                                |
+| `OPENFOX_PUBLIC_URL`                 | —                          | Public origin used to build the MCP OAuth redirect URI          |
 | `OPENFOX_WORKDIR`                    | `cwd`                      | Working directory                                               |
 | `OPENFOX_DB_PATH`                    | `./openfox.db`             | SQLite database path                                            |
 | `OPENFOX_LOG_LEVEL`                  | `info`                     | Log level: `debug`, `info`, `warn`, `error`                     |

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -127,6 +127,7 @@ const mcpServerSchema = z.object({
   env: z.record(z.string(), z.string()).optional(),
   url: z.string().optional(),
   headers: z.record(z.string(), z.string()).optional(),
+  oauth: z.boolean().optional(),
   disabledTools: z.array(z.string()).optional(),
   cachedTools: z.array(cachedToolSchema).optional(),
   timeout: z.number().positive().optional(),

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -27,6 +27,8 @@ import {
   setNotifyMcpServersChanged,
 } from './tools/mcp-config.js'
 import { getSessionDisabledServers, setSessionDisabledServers } from './mcp/session-overrides.js'
+import { setMcpOAuthStoreMode, setMcpOAuthStorePath } from './mcp/oauth-store.js'
+import { setMcpOAuthServerPort } from './mcp/oauth-provider.js'
 import { createServerMessage } from '../shared/protocol.js'
 import { createContextStateMessage } from './ws/protocol.js'
 import { createWebSocketServer } from './ws/index.js'
@@ -191,6 +193,9 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
   setMcpManagerForTools(mcpManager)
   setMcpConfigMode(config.mode ?? 'production')
   setMcpConfigPath(config.globalConfigPath)
+  setMcpOAuthStoreMode(config.mode ?? 'production')
+  // OAuth credentials live next to the config they belong to, never inside it.
+  setMcpOAuthStorePath(config.globalConfigPath ? join(dirname(config.globalConfigPath), 'mcp-auth.json') : undefined)
   const mcpServers = (config.mcpServers ?? {}) as Record<string, import('./mcp/types.js').McpServerConfig>
   Promise.all(
     Object.entries(mcpServers).map(([name, serverConfig]) =>
@@ -219,7 +224,9 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
   // Auth middleware for all /api routes (except /api/health and /api/auth/login)
   const authMiddleware = async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     const path = req.path
-    const publicPaths = ['/health', '/auth', '/auth/login', '/auto-update/check', '/changelog']
+    // The MCP OAuth callback is a redirect from an authorization server, so it cannot carry a session
+    // token. It is guarded instead by the single use state it has to present.
+    const publicPaths = ['/health', '/auth', '/auth/login', '/auto-update/check', '/changelog', '/mcp/oauth/callback']
     if (publicPaths.includes(path)) {
       return next()
     }
@@ -2466,7 +2473,7 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
   })
 
   app.post('/api/mcp/servers', async (req, res) => {
-    const { name, transport, command, args, env, url, headers, timeout } = req.body as {
+    const { name, transport, command, args, env, url, headers, oauth, timeout } = req.body as {
       name?: string
       transport?: string
       command?: string
@@ -2474,6 +2481,7 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
       env?: Record<string, string>
       url?: string
       headers?: Record<string, string>
+      oauth?: boolean
       timeout?: number
     }
     if (!name) {
@@ -2485,6 +2493,9 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
     if (timeout !== undefined && (typeof timeout !== 'number' || timeout <= 0)) {
       return res.status(400).json({ error: 'timeout must be a positive number' })
     }
+    if (oauth !== undefined && typeof oauth !== 'boolean') {
+      return res.status(400).json({ error: 'oauth must be a boolean' })
+    }
     try {
       const resolvedTransport: 'stdio' | 'http' = transport === 'http' ? 'http' : 'stdio'
       const serverCfg: import('./mcp/types.js').McpServerConfig = {
@@ -2494,6 +2505,7 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
         ...(env && Object.keys(env).length > 0 ? { env } : {}),
         ...(url ? { url } : {}),
         ...(headers && Object.keys(headers).length > 0 ? { headers } : {}),
+        ...(oauth ? { oauth: true } : {}),
         ...(timeout !== undefined ? { timeout } : {}),
       }
       await mcpManager.addServer(name, serverCfg)
@@ -2539,7 +2551,7 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
     }
 
     const body = req.body as Record<string, unknown>
-    const { transport: rawTransport, command, args, env, url, headers, timeout, disabled } = body
+    const { transport: rawTransport, command, args, env, url, headers, oauth, timeout, disabled } = body
 
     if (rawTransport !== undefined && rawTransport !== 'stdio' && rawTransport !== 'http') {
       return res.status(400).json({ error: `Invalid transport '${String(rawTransport)}'. Must be 'stdio' or 'http'.` })
@@ -2577,6 +2589,9 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
     if (disabled !== undefined && typeof disabled !== 'boolean') {
       return res.status(400).json({ error: 'disabled must be a boolean' })
     }
+    if (oauth !== undefined && typeof oauth !== 'boolean') {
+      return res.status(400).json({ error: 'oauth must be a boolean' })
+    }
 
     try {
       const { loadGlobalConfig, saveGlobalConfig } = await import('../cli/config.js')
@@ -2595,6 +2610,7 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
         ...(env !== undefined ? { env: env as Record<string, string> } : {}),
         ...(url !== undefined ? { url: url as string } : {}),
         ...(headers !== undefined ? { headers: headers as Record<string, string> } : {}),
+        ...(oauth !== undefined ? { oauth: oauth as boolean } : {}),
         ...(timeout !== undefined ? { timeout: timeout as number } : {}),
         ...(disabled !== undefined ? { disabled: disabled as boolean } : {}),
       }
@@ -2635,6 +2651,10 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
     }
     mcpManager.removeServer(name)
 
+    // Removing a server means dropping what it was authorized with, not leaving it behind on disk.
+    const { clearMcpOAuthEntry } = await import('./mcp/oauth-store.js')
+    await clearMcpOAuthEntry(name)
+
     // Persist to global config
     const { loadGlobalConfig, saveGlobalConfig } = await import('../cli/config.js')
     const globalConfig = await loadGlobalConfig(config.mode ?? 'production', config.globalConfigPath)
@@ -2659,6 +2679,145 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
 
     wssExports.broadcastAll(createServerMessage('mcp.servers.changed', { servers: mcpManager.getAllServers() }))
 
+    res.json({ success: true })
+  })
+
+  /** Rendered on the OAuth callback. The message is always one of ours, never anything the caller sent. */
+  function oauthCallbackPage(message: string): string {
+    return `<!doctype html><html lang="en"><head><meta charset="utf-8"><title>OpenFox</title></head><body style="font-family:system-ui;padding:2rem"><p>${message}</p></body></html>`
+  }
+
+  /** Accepts the whole callback URL or just its query string. Anything else yields no state and is refused. */
+  function parseOAuthResponse(value: string): { code?: string; state?: string } {
+    let params: URLSearchParams | null
+    try {
+      params = new URL(value).searchParams
+    } catch {
+      params = value.includes('code=') ? new URLSearchParams(value.replace(/^\?/, '')) : null
+    }
+    if (!params) return { code: value }
+    const code = params.get('code')
+    const state = params.get('state')
+    return { ...(code ? { code } : {}), ...(state ? { state } : {}) }
+  }
+
+  async function applyMcpOAuthResult(name: string): Promise<void> {
+    await mcpManager.connectServer(name)
+    await rebuildMcpTools()
+    for (const s of sessionManager.listSessions()) {
+      sessionManager.setDynamicContextChanged(s.id, true)
+    }
+    wssExports.broadcastAll(createServerMessage('mcp.servers.changed', { servers: mcpManager.getAllServers() }))
+  }
+
+  async function completeMcpOAuth(name: string, serverUrl: string, code: string): Promise<void> {
+    const { auth } = await import('@modelcontextprotocol/sdk/client/auth.js')
+    const { McpOAuthProvider } = await import('./mcp/oauth-provider.js')
+    const { clearMcpOAuthAuthorizationState } = await import('./mcp/oauth-store.js')
+    const provider = new McpOAuthProvider(name, serverUrl)
+    try {
+      const result = await auth(provider, { serverUrl, authorizationCode: code })
+      if (result !== 'AUTHORIZED') {
+        throw new Error('The authorization server did not return a usable grant')
+      }
+    } catch (error) {
+      // The code is spent whatever happened, so the state and the verifier must not outlive the attempt.
+      await clearMcpOAuthAuthorizationState(name, serverUrl)
+      throw error
+    }
+    await applyMcpOAuthResult(name)
+  }
+
+  app.post('/api/mcp/servers/:name/oauth/start', async (req, res) => {
+    const { name } = req.params
+    const server = mcpManager.getServer(name)
+    if (!server) {
+      return res.status(404).json({ error: `MCP server '${name}' not found` })
+    }
+    if (server.config.transport !== 'http' || !server.config.url) {
+      return res.status(400).json({ error: 'OAuth is only available for http transport' })
+    }
+    if (!server.config.oauth) {
+      return res.status(400).json({ error: `MCP server '${name}' is not configured for OAuth` })
+    }
+    try {
+      const { auth } = await import('@modelcontextprotocol/sdk/client/auth.js')
+      const { McpOAuthProvider } = await import('./mcp/oauth-provider.js')
+      const provider = new McpOAuthProvider(name, server.config.url)
+      const result = await auth(provider, { serverUrl: server.config.url })
+      if (result === 'AUTHORIZED') {
+        await applyMcpOAuthResult(name)
+        return res.json({ status: 'authorized' })
+      }
+      const authorizationUrl = provider.pendingAuthorizationUrl
+      if (!authorizationUrl) {
+        return res.status(400).json({ error: 'The server did not produce an authorization URL' })
+      }
+      res.json({ status: 'redirect', authorizationUrl: authorizationUrl.toString(), redirectUri: provider.redirectUrl })
+    } catch (error) {
+      res.status(400).json({ error: error instanceof Error ? error.message : String(error) })
+    }
+  })
+
+  app.get('/api/mcp/oauth/callback', async (req, res) => {
+    const code = typeof req.query['code'] === 'string' ? req.query['code'] : ''
+    const state = typeof req.query['state'] === 'string' ? req.query['state'] : ''
+    if (!code || !state) {
+      return res.status(400).type('html').send(oauthCallbackPage('Missing authorization code or state.'))
+    }
+    const { findMcpOAuthEntryByState } = await import('./mcp/oauth-store.js')
+    const pending = await findMcpOAuthEntryByState(state)
+    if (!pending) {
+      return res.status(400).type('html').send(oauthCallbackPage('No pending authorization matches this callback.'))
+    }
+    try {
+      await completeMcpOAuth(pending.name, pending.entry.serverUrl, code)
+      res.type('html').send(oauthCallbackPage('Authorization complete. You can close this tab and go back to OpenFox.'))
+    } catch (error) {
+      logger.error('MCP OAuth callback failed', { error: error instanceof Error ? error.message : String(error) })
+      res.status(400).type('html').send(oauthCallbackPage('Authorization failed. See the OpenFox logs for details.'))
+    }
+  })
+
+  app.post('/api/mcp/servers/:name/oauth/complete', async (req, res) => {
+    const { name } = req.params
+    const { response } = req.body as { response?: string }
+    const server = mcpManager.getServer(name)
+    if (!server) {
+      return res.status(404).json({ error: `MCP server '${name}' not found` })
+    }
+    if (!server.config.url) {
+      return res.status(400).json({ error: 'OAuth is only available for http transport' })
+    }
+    if (typeof response !== 'string' || !response.trim()) {
+      return res.status(400).json({ error: 'response is required' })
+    }
+    const parsed = parseOAuthResponse(response.trim())
+    if (!parsed.code || !parsed.state) {
+      return res.status(400).json({ error: 'Paste the whole callback URL, both code and state are needed' })
+    }
+    // Never optional: the state is what ties this code to the authorization OpenFox actually started.
+    const { readMcpOAuthEntry } = await import('./mcp/oauth-store.js')
+    const entry = await readMcpOAuthEntry(name, server.config.url)
+    if (!entry?.state || entry.state !== parsed.state) {
+      return res.status(400).json({ error: 'This callback does not match the pending authorization' })
+    }
+    try {
+      await completeMcpOAuth(name, server.config.url, parsed.code)
+      res.json({ server: mcpManager.getServer(name) })
+    } catch (error) {
+      res.status(400).json({ error: error instanceof Error ? error.message : String(error) })
+    }
+  })
+
+  app.delete('/api/mcp/servers/:name/oauth', async (req, res) => {
+    const { name } = req.params
+    if (!mcpManager.getServer(name)) {
+      return res.status(404).json({ error: `MCP server '${name}' not found` })
+    }
+    const { clearMcpOAuthEntry } = await import('./mcp/oauth-store.js')
+    await clearMcpOAuthEntry(name)
+    await applyMcpOAuthResult(name)
     res.json({ success: true })
   })
 
@@ -3001,6 +3160,7 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
         httpServer.listen(listenPort, host, () => {
           const addr = httpServer.address()
           const actualPort = typeof addr === 'object' && addr ? addr.port : listenPort
+          setMcpOAuthServerPort(actualPort)
           const client = getLLMClient()
           logger.info(`OpenFox server running at http://${host}:${actualPort}`)
           logger.info(`WebSocket available at ws://${host}:${actualPort}/ws`)

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -2728,6 +2728,17 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
     await applyMcpOAuthResult(name)
   }
 
+  /**
+   * Tokens are only ever stored for a server that is, right now, an http server with OAuth turned on.
+   * Checking at completion time and not only at start time matters: the server can be reconfigured
+   * while an authorization is pending, and the pending state alone would still match.
+   */
+  function oauthEnabledServerUrl(name: string): string | undefined {
+    const server = mcpManager.getServer(name)
+    if (!server || server.config.transport !== 'http' || !server.config.oauth) return undefined
+    return server.config.url
+  }
+
   app.post('/api/mcp/servers/:name/oauth/start', async (req, res) => {
     const { name } = req.params
     const server = mcpManager.getServer(name)
@@ -2770,6 +2781,10 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
     if (!pending) {
       return res.status(400).type('html').send(oauthCallbackPage('No pending authorization matches this callback.'))
     }
+    const pendingUrl = oauthEnabledServerUrl(pending.name)
+    if (!pendingUrl || pendingUrl !== pending.entry.serverUrl) {
+      return res.status(400).type('html').send(oauthCallbackPage('This server is no longer configured for OAuth.'))
+    }
     try {
       await completeMcpOAuth(pending.name, pending.entry.serverUrl, code)
       res.type('html').send(oauthCallbackPage('Authorization complete. You can close this tab and go back to OpenFox.'))
@@ -2786,8 +2801,9 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
     if (!server) {
       return res.status(404).json({ error: `MCP server '${name}' not found` })
     }
-    if (!server.config.url) {
-      return res.status(400).json({ error: 'OAuth is only available for http transport' })
+    const serverUrl = oauthEnabledServerUrl(name)
+    if (!serverUrl) {
+      return res.status(400).json({ error: `MCP server '${name}' is not configured for OAuth` })
     }
     if (typeof response !== 'string' || !response.trim()) {
       return res.status(400).json({ error: 'response is required' })
@@ -2798,12 +2814,12 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
     }
     // Never optional: the state is what ties this code to the authorization OpenFox actually started.
     const { readMcpOAuthEntry } = await import('./mcp/oauth-store.js')
-    const entry = await readMcpOAuthEntry(name, server.config.url)
+    const entry = await readMcpOAuthEntry(name, serverUrl)
     if (!entry?.state || entry.state !== parsed.state) {
       return res.status(400).json({ error: 'This callback does not match the pending authorization' })
     }
     try {
-      await completeMcpOAuth(name, server.config.url, parsed.code)
+      await completeMcpOAuth(name, serverUrl, parsed.code)
       res.json({ server: mcpManager.getServer(name) })
     } catch (error) {
       res.status(400).json({ error: error instanceof Error ? error.message : String(error) })

--- a/src/server/mcp/manager.test.ts
+++ b/src/server/mcp/manager.test.ts
@@ -62,6 +62,12 @@ vi.mock('@modelcontextprotocol/sdk/client/streamableHttp.js', () => ({
   }),
 }))
 
+/** Options object the mocked StreamableHTTPClientTransport was last constructed with. */
+async function lastHttpTransportOptions(): Promise<any> {
+  const { StreamableHTTPClientTransport } = await import('@modelcontextprotocol/sdk/client/streamableHttp.js')
+  return vi.mocked(StreamableHTTPClientTransport).mock.calls.at(-1)![1]
+}
+
 describe('McpManager', () => {
   let manager: McpManager
 
@@ -201,6 +207,69 @@ describe('McpManager', () => {
       const nonToolMessage = { jsonrpc: '2.0', id: 2, result: { serverInfo: { name: 'test' } } }
       wrappedHandler(nonToolMessage)
       expect(sdkHandler).toHaveBeenCalledWith(nonToolMessage)
+    })
+  })
+
+  describe('addServer oauth', () => {
+    it('should pass an authProvider to the transport when oauth is enabled', async () => {
+      await manager.addServer('oauth-server', {
+        transport: 'http',
+        url: 'https://mcp.example.com/mcp',
+        oauth: true,
+      })
+
+      const opts = await lastHttpTransportOptions()
+      expect(opts.authProvider).toBeDefined()
+    })
+
+    it('should not add an authProvider or touch headers when oauth is unset (back-compat)', async () => {
+      const headers = { 'X-API-Key': 'secret123' }
+      await manager.addServer('plain-server', {
+        transport: 'http',
+        url: 'https://mcp.example.com/mcp',
+        headers,
+      })
+
+      const opts = await lastHttpTransportOptions()
+      expect(opts).not.toHaveProperty('authProvider')
+      expect(opts.requestInit?.headers).toEqual(headers)
+    })
+
+    it('should strip an Authorization header when oauth is enabled, keeping other headers', async () => {
+      await manager.addServer('oauth-headers', {
+        transport: 'http',
+        url: 'https://mcp.example.com/mcp',
+        oauth: true,
+        headers: { Authorization: 'Bearer static-token', 'X-Other': 'kept' },
+      })
+
+      const opts = await lastHttpTransportOptions()
+      expect(opts.requestInit?.headers).toEqual({ 'X-Other': 'kept' })
+    })
+
+    it('should strip a lowercase authorization header too (case-insensitive filter)', async () => {
+      await manager.addServer('oauth-headers-lowercase', {
+        transport: 'http',
+        url: 'https://mcp.example.com/mcp',
+        oauth: true,
+        headers: { authorization: 'Bearer static-token', 'X-Other': 'kept' },
+      })
+
+      const opts = await lastHttpTransportOptions()
+      expect(opts.requestInit?.headers).toEqual({ 'X-Other': 'kept' })
+    })
+
+    it('should keep a static Authorization header when oauth is explicitly disabled', async () => {
+      const headers = { Authorization: 'Bearer static-token' }
+      await manager.addServer('oauth-disabled', {
+        transport: 'http',
+        url: 'https://mcp.example.com/mcp',
+        oauth: false,
+        headers,
+      })
+
+      const opts = await lastHttpTransportOptions()
+      expect(opts.requestInit?.headers).toEqual(headers)
     })
   })
 

--- a/src/server/mcp/manager.ts
+++ b/src/server/mcp/manager.ts
@@ -6,6 +6,18 @@ import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
 import type { McpServerConfig, McpServerState, McpToolInfo, McpManagerOptions, CachedToolInfo } from './types.js'
 import type { LLMToolDefinition } from '../llm/types.js'
 import { logger } from '../utils/logger.js'
+import { McpOAuthProvider } from './oauth-provider.js'
+
+/**
+ * The SDK merges requestInit headers after the ones it derives from the auth provider, so a static
+ * Authorization header would silently shadow the OAuth token and every request would look unauthorized.
+ */
+function withoutAuthorizationHeader(headers: Record<string, string> | undefined): Record<string, string> | undefined {
+  if (!headers) return undefined
+  const kept = Object.entries(headers).filter(([key]) => key.trim().toLowerCase() !== 'authorization')
+  if (kept.length === Object.keys(headers).length) return headers
+  return Object.fromEntries(kept)
+}
 
 /** Rough token estimate: ~4 chars per token for JSON-serialized tool definitions */
 export function estimateToolTokens(
@@ -75,8 +87,12 @@ export class McpManager {
       } else if (entry.config.transport === 'http') {
         if (!entry.config.url) throw new Error('url is required for http transport')
         const httpOpts: StreamableHTTPClientTransportOptions = {}
-        if (entry.config.headers) {
-          httpOpts.requestInit = { headers: entry.config.headers }
+        const headers = entry.config.oauth ? withoutAuthorizationHeader(entry.config.headers) : entry.config.headers
+        if (headers) {
+          httpOpts.requestInit = { headers }
+        }
+        if (entry.config.oauth) {
+          httpOpts.authProvider = new McpOAuthProvider(name, entry.config.url)
         }
         transport = new StreamableHTTPClientTransport(new URL(entry.config.url), httpOpts) as unknown as Transport
       } else {

--- a/src/server/mcp/oauth-provider.test.ts
+++ b/src/server/mcp/oauth-provider.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, afterEach } from 'vitest'
+import { getMcpOAuthRedirectUri, setMcpOAuthServerPort } from './oauth-provider.js'
+
+const ORIGINAL_PUBLIC_URL = process.env['OPENFOX_PUBLIC_URL']
+
+describe('getMcpOAuthRedirectUri', () => {
+  afterEach(() => {
+    if (ORIGINAL_PUBLIC_URL === undefined) delete process.env['OPENFOX_PUBLIC_URL']
+    else process.env['OPENFOX_PUBLIC_URL'] = ORIGINAL_PUBLIC_URL
+    setMcpOAuthServerPort(10369)
+  })
+
+  it('defaults to a loopback URL on the current server port when OPENFOX_PUBLIC_URL is unset', () => {
+    delete process.env['OPENFOX_PUBLIC_URL']
+    setMcpOAuthServerPort(54321)
+
+    expect(getMcpOAuthRedirectUri()).toBe('http://127.0.0.1:54321/api/mcp/oauth/callback')
+  })
+
+  it('uses OPENFOX_PUBLIC_URL as the origin when set', () => {
+    process.env['OPENFOX_PUBLIC_URL'] = 'https://openfox.example.com'
+
+    expect(getMcpOAuthRedirectUri()).toBe('https://openfox.example.com/api/mcp/oauth/callback')
+  })
+
+  it('keeps the prefix when OPENFOX_PUBLIC_URL points at a sub-path deployment', () => {
+    process.env['OPENFOX_PUBLIC_URL'] = 'https://tunnel.example.com/openfox'
+
+    expect(getMcpOAuthRedirectUri()).toBe('https://tunnel.example.com/openfox/api/mcp/oauth/callback')
+  })
+
+  it('does not double the separator when OPENFOX_PUBLIC_URL ends with a slash', () => {
+    process.env['OPENFOX_PUBLIC_URL'] = 'https://tunnel.example.com/openfox/'
+
+    expect(getMcpOAuthRedirectUri()).toBe('https://tunnel.example.com/openfox/api/mcp/oauth/callback')
+  })
+
+  it('drops a query string and a fragment carried by OPENFOX_PUBLIC_URL', () => {
+    process.env['OPENFOX_PUBLIC_URL'] = 'https://openfox.example.com/?next=x#frag'
+
+    expect(getMcpOAuthRedirectUri()).toBe('https://openfox.example.com/api/mcp/oauth/callback')
+  })
+
+  it('rejects a non http URL', () => {
+    process.env['OPENFOX_PUBLIC_URL'] = 'javascript:alert(1)'
+
+    expect(() => getMcpOAuthRedirectUri()).toThrow(/http or https/)
+  })
+
+  it('rejects a value that is not a URL at all', () => {
+    process.env['OPENFOX_PUBLIC_URL'] = 'not a url'
+
+    expect(() => getMcpOAuthRedirectUri()).toThrow(/not a valid URL/)
+  })
+})

--- a/src/server/mcp/oauth-provider.ts
+++ b/src/server/mcp/oauth-provider.ts
@@ -1,0 +1,139 @@
+import { randomBytes } from 'node:crypto'
+import type { OAuthClientProvider } from '@modelcontextprotocol/sdk/client/auth.js'
+import type {
+  OAuthClientInformationMixed,
+  OAuthClientMetadata,
+  OAuthTokens,
+} from '@modelcontextprotocol/sdk/shared/auth.js'
+import {
+  clearMcpOAuthEntry,
+  clearMcpOAuthTokens,
+  readMcpOAuthEntry,
+  saveMcpOAuthClientInformation,
+  saveMcpOAuthCodeVerifier,
+  saveMcpOAuthState,
+  saveMcpOAuthTokens,
+} from './oauth-store.js'
+
+/** API routes are mounted on literal paths, so the callback always sits at the origin root. */
+const CALLBACK_PATH = '/api/mcp/oauth/callback'
+
+let serverPort = 10369
+
+export function setMcpOAuthServerPort(port: number): void {
+  serverPort = port
+}
+
+/**
+ * Where the authorization server sends the browser back.
+ *
+ * The loopback default is what makes this work with no configuration: the browser and the server sit
+ * on the same machine for most installs, and authorization servers treat loopback redirects leniently
+ * because native apps rely on them. When OpenFox is reached through a tunnel, the loopback URL is not
+ * reachable from the browser, so either point OPENFOX_PUBLIC_URL at the public origin and allow that
+ * redirect URI at the provider, or paste the callback URL back by hand.
+ */
+export function getMcpOAuthRedirectUri(): string {
+  const publicUrl = process.env['OPENFOX_PUBLIC_URL']
+  if (!publicUrl) return `http://127.0.0.1:${serverPort}${CALLBACK_PATH}`
+  let base: URL
+  try {
+    base = new URL(publicUrl)
+  } catch {
+    throw new Error('OPENFOX_PUBLIC_URL is not a valid URL')
+  }
+  if (base.protocol !== 'http:' && base.protocol !== 'https:') {
+    throw new Error('OPENFOX_PUBLIC_URL must be an http or https URL')
+  }
+  // Appended rather than resolved, so a subpath deployment keeps its prefix.
+  base.pathname = `${base.pathname.replace(/\/+$/, '')}${CALLBACK_PATH}`
+  base.search = ''
+  base.hash = ''
+  return base.toString()
+}
+
+/**
+ * Persists an MCP server's OAuth credentials and hands authorization URLs back to the caller.
+ *
+ * A browser provider would navigate on redirectToAuthorization. This one runs on the server, so it
+ * records the URL instead and lets the route return it to the UI.
+ */
+export class McpOAuthProvider implements OAuthClientProvider {
+  private authorizationUrl: URL | null = null
+
+  constructor(
+    private readonly serverName: string,
+    private readonly serverUrl: string,
+    private readonly redirectUri: string = getMcpOAuthRedirectUri(),
+  ) {}
+
+  get redirectUrl(): string {
+    return this.redirectUri
+  }
+
+  get clientMetadata(): OAuthClientMetadata {
+    // No token_endpoint_auth_method on purpose: the SDK picks one from what the server advertises.
+    return {
+      client_name: 'OpenFox',
+      redirect_uris: [this.redirectUri],
+      grant_types: ['authorization_code', 'refresh_token'],
+      response_types: ['code'],
+    }
+  }
+
+  /** Set once the SDK has built an authorization URL, null while the stored tokens still work. */
+  get pendingAuthorizationUrl(): URL | null {
+    return this.authorizationUrl
+  }
+
+  async state(): Promise<string> {
+    const value = randomBytes(32).toString('base64url')
+    await saveMcpOAuthState(this.serverName, this.serverUrl, value)
+    return value
+  }
+
+  async clientInformation(): Promise<OAuthClientInformationMixed | undefined> {
+    const entry = await readMcpOAuthEntry(this.serverName, this.serverUrl)
+    return entry?.clientInformation
+  }
+
+  async saveClientInformation(clientInformation: OAuthClientInformationMixed): Promise<void> {
+    await saveMcpOAuthClientInformation(this.serverName, this.serverUrl, clientInformation)
+  }
+
+  async tokens(): Promise<OAuthTokens | undefined> {
+    const entry = await readMcpOAuthEntry(this.serverName, this.serverUrl)
+    return entry?.tokens
+  }
+
+  async saveTokens(tokens: OAuthTokens): Promise<void> {
+    await saveMcpOAuthTokens(this.serverName, this.serverUrl, tokens)
+  }
+
+  redirectToAuthorization(authorizationUrl: URL): void {
+    this.authorizationUrl = authorizationUrl
+  }
+
+  async saveCodeVerifier(codeVerifier: string): Promise<void> {
+    await saveMcpOAuthCodeVerifier(this.serverName, this.serverUrl, codeVerifier)
+  }
+
+  async codeVerifier(): Promise<string> {
+    const entry = await readMcpOAuthEntry(this.serverName, this.serverUrl)
+    if (!entry?.codeVerifier) {
+      throw new Error('No stored PKCE verifier for this server, start the authorization again')
+    }
+    return entry.codeVerifier
+  }
+
+  /** Lets the SDK recover on its own when the server rejects the stored client or grant. */
+  async invalidateCredentials(scope: 'all' | 'client' | 'tokens' | 'verifier' | 'discovery'): Promise<void> {
+    if (scope === 'discovery') return
+    if (scope === 'all' || scope === 'client') {
+      // Tokens issued to a client the server no longer knows are dead too.
+      await clearMcpOAuthEntry(this.serverName)
+      return
+    }
+    await clearMcpOAuthTokens(this.serverName, this.serverUrl)
+  }
+}

--- a/src/server/mcp/oauth-store.test.ts
+++ b/src/server/mcp/oauth-store.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest'
+import { chmod, mkdir, mkdtemp, readdir, rm, stat, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  setMcpOAuthStorePath,
+  readMcpOAuthEntry,
+  saveMcpOAuthClientInformation,
+  saveMcpOAuthTokens,
+  saveMcpOAuthCodeVerifier,
+  saveMcpOAuthState,
+  findMcpOAuthEntryByState,
+  clearMcpOAuthAuthorizationState,
+  clearMcpOAuthTokens,
+} from './oauth-store.js'
+
+const SERVER_URL = 'https://mcp.example.com/mcp'
+
+describe('oauth-store', () => {
+  let tmpDir: string
+  let storePath: string
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'openfox-oauth-store-'))
+    storePath = join(tmpDir, 'mcp-auth.json')
+    setMcpOAuthStorePath(storePath)
+  })
+
+  afterEach(async () => {
+    setMcpOAuthStorePath(undefined)
+    await rm(tmpDir, { recursive: true, force: true })
+  })
+
+  it('round-trips saved client information and tokens through readMcpOAuthEntry', async () => {
+    await saveMcpOAuthClientInformation('srv', SERVER_URL, { client_id: 'client-abc' })
+    await saveMcpOAuthTokens('srv', SERVER_URL, { access_token: 'tok-123', token_type: 'Bearer' })
+
+    const entry = await readMcpOAuthEntry('srv', SERVER_URL)
+    expect(entry?.serverUrl).toBe(SERVER_URL)
+    expect(entry?.clientInformation).toEqual({ client_id: 'client-abc' })
+    expect(entry?.tokens).toEqual({ access_token: 'tok-123', token_type: 'Bearer' })
+  })
+
+  it.skipIf(process.platform === 'win32')(
+    'always leaves the store file at 0600, even if it pre-existed with looser permissions',
+    async () => {
+      // writeFile's mode option only applies when it creates the file, so pre-creating it at 0644
+      // is what would expose the gap if the store didn't chmod explicitly after every write.
+      await writeFile(storePath, '{}', { mode: 0o644 })
+      await chmod(storePath, 0o644)
+
+      await saveMcpOAuthClientInformation('srv', SERVER_URL, { client_id: 'client-abc' })
+
+      const mode = (await stat(storePath)).mode & 0o777
+      expect(mode).toBe(0o600)
+    },
+  )
+
+  it('saveMcpOAuthTokens clears the pending codeVerifier and state but keeps clientInformation', async () => {
+    await saveMcpOAuthClientInformation('srv', SERVER_URL, { client_id: 'client-abc' })
+    await saveMcpOAuthCodeVerifier('srv', SERVER_URL, 'verifier-xyz')
+    await saveMcpOAuthState('srv', SERVER_URL, 'state-xyz')
+
+    await saveMcpOAuthTokens('srv', SERVER_URL, { access_token: 'tok-123', token_type: 'Bearer' })
+
+    const entry = await readMcpOAuthEntry('srv', SERVER_URL)
+    expect(entry?.codeVerifier).toBeUndefined()
+    expect(entry?.state).toBeUndefined()
+    expect(entry?.clientInformation).toEqual({ client_id: 'client-abc' })
+    expect(entry?.tokens).toEqual({ access_token: 'tok-123', token_type: 'Bearer' })
+  })
+
+  it('does not return credentials saved for a different server URL', async () => {
+    await saveMcpOAuthTokens('srv', SERVER_URL, { access_token: 'tok-123', token_type: 'Bearer' })
+
+    const entry = await readMcpOAuthEntry('srv', 'https://other.example.com/mcp')
+    expect(entry).toBeUndefined()
+  })
+
+  describe('findMcpOAuthEntryByState', () => {
+    it('finds the entry a pending state belongs to, and returns null for an unknown state', async () => {
+      await saveMcpOAuthState('srv', SERVER_URL, 'state-xyz')
+
+      const found = await findMcpOAuthEntryByState('state-xyz')
+      expect(found?.name).toBe('srv')
+      expect(found?.entry.serverUrl).toBe(SERVER_URL)
+
+      expect(await findMcpOAuthEntryByState('unknown-state')).toBeNull()
+    })
+
+    it('returns null once the state has been consumed by saving tokens (single use)', async () => {
+      await saveMcpOAuthState('srv', SERVER_URL, 'state-xyz')
+      await saveMcpOAuthTokens('srv', SERVER_URL, { access_token: 'tok-123', token_type: 'Bearer' })
+
+      expect(await findMcpOAuthEntryByState('state-xyz')).toBeNull()
+    })
+  })
+
+  it('clearMcpOAuthAuthorizationState burns the state and verifier but keeps working tokens', async () => {
+    await saveMcpOAuthClientInformation('srv', SERVER_URL, { client_id: 'client-abc' })
+    await saveMcpOAuthTokens('srv', SERVER_URL, { access_token: 'tok-123', token_type: 'Bearer' })
+    await saveMcpOAuthCodeVerifier('srv', SERVER_URL, 'verifier-xyz')
+    await saveMcpOAuthState('srv', SERVER_URL, 'state-xyz')
+
+    await clearMcpOAuthAuthorizationState('srv', SERVER_URL)
+
+    const entry = await readMcpOAuthEntry('srv', SERVER_URL)
+    expect(entry?.state).toBeUndefined()
+    expect(entry?.codeVerifier).toBeUndefined()
+    expect(entry?.tokens).toEqual({ access_token: 'tok-123', token_type: 'Bearer' })
+    expect(entry?.clientInformation).toEqual({ client_id: 'client-abc' })
+  })
+
+  it('clearMcpOAuthTokens drops the tokens but keeps the registered client', async () => {
+    await saveMcpOAuthClientInformation('srv', SERVER_URL, { client_id: 'client-abc' })
+    await saveMcpOAuthTokens('srv', SERVER_URL, { access_token: 'tok-123', token_type: 'Bearer' })
+
+    await clearMcpOAuthTokens('srv', SERVER_URL)
+
+    const entry = await readMcpOAuthEntry('srv', SERVER_URL)
+    expect(entry?.tokens).toBeUndefined()
+    expect(entry?.clientInformation).toEqual({ client_id: 'client-abc' })
+  })
+
+  it('keeps every entry when several authorizations write at the same time', async () => {
+    // Each write is a read, modify and write of the whole file, so without serialization the last
+    // writer would win with a snapshot taken before its neighbours had committed.
+    const names = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h']
+
+    await Promise.all(names.map((name) => saveMcpOAuthState(name, SERVER_URL, `state-${name}`)))
+
+    for (const name of names) {
+      expect((await readMcpOAuthEntry(name, SERVER_URL))?.state).toBe(`state-${name}`)
+    }
+  })
+
+  it('leaves no temporary file behind once a write has landed', async () => {
+    await saveMcpOAuthState('srv', SERVER_URL, 'state-xyz')
+
+    expect(await readdir(tmpDir)).toEqual(['mcp-auth.json'])
+  })
+
+  describe('a corrupted store on disk', () => {
+    it('reads as undefined/null instead of throwing when the file holds invalid JSON', async () => {
+      await writeFile(storePath, 'not valid json{{{', 'utf-8')
+
+      expect(await readMcpOAuthEntry('srv', SERVER_URL)).toBeUndefined()
+      expect(await findMcpOAuthEntryByState('state-xyz')).toBeNull()
+    })
+
+    it('reads as undefined/null instead of throwing when the store path cannot be read as a file', async () => {
+      // A directory at the store path fails the read the same way a permissions error would,
+      // without depending on the test runner's uid (root bypasses chmod-based restrictions).
+      await mkdir(storePath)
+
+      expect(await readMcpOAuthEntry('srv', SERVER_URL)).toBeUndefined()
+      expect(await findMcpOAuthEntryByState('state-xyz')).toBeNull()
+    })
+  })
+})

--- a/src/server/mcp/oauth-store.test.ts
+++ b/src/server/mcp/oauth-store.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeEach, afterEach } from 'vitest'
-import { chmod, mkdir, mkdtemp, readdir, rm, stat, writeFile } from 'node:fs/promises'
+import { chmod, mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
@@ -155,6 +155,36 @@ describe('oauth-store', () => {
 
       expect(await readMcpOAuthEntry('srv', SERVER_URL)).toBeUndefined()
       expect(await findMcpOAuthEntryByState('state-xyz')).toBeNull()
+    })
+
+    it('ignores malformed entries instead of throwing, and still reads the sound ones', async () => {
+      // Valid JSON, but entries that no code path of ours could have written. Scanning by state
+      // walks every entry, so a single bad one used to take the whole callback route down.
+      const sound = { serverUrl: SERVER_URL, state: 'state-xyz' }
+      await writeFile(
+        storePath,
+        JSON.stringify({ version: 1, servers: { broken: null, alsoBroken: 'nope', srv: sound } }),
+        'utf-8',
+      )
+
+      expect(await readMcpOAuthEntry('broken', SERVER_URL)).toBeUndefined()
+      expect(await readMcpOAuthEntry('srv', SERVER_URL)).toEqual(sound)
+      expect(await findMcpOAuthEntryByState('state-xyz')).toEqual({ name: 'srv', entry: sound })
+    })
+
+    it('leaves the dropped entries out of the file as soon as anything else is written', async () => {
+      // Reading filters, and the next write persists that filtered view. Worth pinning down, because
+      // it means one bad entry disappears for good the first time an unrelated server is touched.
+      await writeFile(
+        storePath,
+        JSON.stringify({ version: 1, servers: { broken: null, srv: { serverUrl: SERVER_URL } } }),
+        'utf-8',
+      )
+
+      await saveMcpOAuthState('srv', SERVER_URL, 'state-xyz')
+
+      const onDisk = JSON.parse(await readFile(storePath, 'utf-8')) as { servers: Record<string, unknown> }
+      expect(Object.keys(onDisk.servers)).toEqual(['srv'])
     })
   })
 })

--- a/src/server/mcp/oauth-store.ts
+++ b/src/server/mcp/oauth-store.ts
@@ -55,7 +55,21 @@ async function readStore(): Promise<McpOAuthStore> {
     const parsed = JSON.parse(raw) as Partial<McpOAuthStore>
     const servers = parsed.servers
     if (!servers || typeof servers !== 'object') throw new Error('no servers object')
-    return { version: 1, servers }
+    // Valid JSON is not a valid store. A hand edited or half written entry must be dropped here,
+    // otherwise every reader has to defend itself against a shape that should never have been saved.
+    // Said out loud, because the next write persists this filtered view and the entry is then gone.
+    const kept: Record<string, McpOAuthEntry> = {}
+    for (const [name, entry] of Object.entries(servers)) {
+      if (entry && typeof entry === 'object' && typeof (entry as McpOAuthEntry).serverUrl === 'string') {
+        kept[name] = entry as McpOAuthEntry
+      } else {
+        logger.warn('Dropping an unreadable MCP OAuth entry, this server will have to authorize again', {
+          path,
+          server: name,
+        })
+      }
+    }
+    return { version: 1, servers: kept }
   } catch {
     // Worth shouting about: the next write would otherwise quietly replace everything that was there.
     logger.error('The MCP OAuth store is unreadable, stored authorizations will be ignored', { path })

--- a/src/server/mcp/oauth-store.ts
+++ b/src/server/mcp/oauth-store.ts
@@ -1,0 +1,169 @@
+import { chmod, mkdir, readFile, rename, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import type { OAuthClientInformationMixed, OAuthTokens } from '@modelcontextprotocol/sdk/shared/auth.js'
+import type { Mode } from '../../cli/main.js'
+import { getGlobalConfigDir } from '../../cli/paths.js'
+import { logger } from '../utils/logger.js'
+
+/**
+ * OAuth credentials for one MCP server. Deliberately kept out of config.json: that file is meant to
+ * be readable, diffable and shareable, while these are bearer credentials.
+ *
+ * The store file is written with 0600. That is a real guarantee on POSIX only, Windows has no
+ * equivalent mapping for those bits.
+ */
+export interface McpOAuthEntry {
+  /** The server URL the credentials were issued for. Credentials do not carry over to another URL. */
+  serverUrl: string
+  clientInformation?: OAuthClientInformationMixed
+  tokens?: OAuthTokens
+  /** PKCE verifier, only alive between the authorization request and the token exchange. */
+  codeVerifier?: string
+  /** CSRF state, only alive between the authorization request and the token exchange. */
+  state?: string
+}
+
+interface McpOAuthStore {
+  version: 1
+  servers: Record<string, McpOAuthEntry>
+}
+
+let storeMode: Mode = 'production'
+let storePathOverride: string | undefined
+
+export function setMcpOAuthStoreMode(mode: Mode): void {
+  storeMode = mode
+}
+
+export function setMcpOAuthStorePath(path: string | undefined): void {
+  storePathOverride = path
+}
+
+export function getMcpOAuthStorePath(): string {
+  return storePathOverride ?? join(getGlobalConfigDir(storeMode), 'mcp-auth.json')
+}
+
+async function readStore(): Promise<McpOAuthStore> {
+  const path = getMcpOAuthStorePath()
+  let raw: string
+  try {
+    raw = await readFile(path, 'utf-8')
+  } catch {
+    return { version: 1, servers: {} }
+  }
+  try {
+    const parsed = JSON.parse(raw) as Partial<McpOAuthStore>
+    const servers = parsed.servers
+    if (!servers || typeof servers !== 'object') throw new Error('no servers object')
+    return { version: 1, servers }
+  } catch {
+    // Worth shouting about: the next write would otherwise quietly replace everything that was there.
+    logger.error('The MCP OAuth store is unreadable, stored authorizations will be ignored', { path })
+    return { version: 1, servers: {} }
+  }
+}
+
+async function writeStore(store: McpOAuthStore): Promise<void> {
+  const path = getMcpOAuthStorePath()
+  await mkdir(dirname(path), { recursive: true })
+  // Written aside then renamed, so an interrupted write cannot leave half a file behind. The rename
+  // also carries the fresh 0600 over a pre-existing file that had looser bits.
+  const tmpPath = `${path}.tmp`
+  await writeFile(tmpPath, JSON.stringify(store, null, 2), { mode: 0o600 })
+  try {
+    await chmod(tmpPath, 0o600)
+  } catch {
+    logger.warn('Could not restrict permissions on the MCP OAuth store', { path })
+  }
+  await rename(tmpPath, path)
+}
+
+/** Read, modify and write is not atomic, so two authorizations in flight would clobber each other. */
+let writeQueue: Promise<unknown> = Promise.resolve()
+
+function serialize<T>(work: () => Promise<T>): Promise<T> {
+  const result = writeQueue.then(work, work)
+  writeQueue = result.catch(() => undefined)
+  return result
+}
+
+async function mutateEntry(
+  name: string,
+  serverUrl: string,
+  mutate: (entry: McpOAuthEntry) => McpOAuthEntry,
+): Promise<void> {
+  await serialize(async () => {
+    const store = await readStore()
+    const current = store.servers[name]
+    const base: McpOAuthEntry = current && current.serverUrl === serverUrl ? current : { serverUrl }
+    store.servers[name] = mutate(base)
+    await writeStore(store)
+  })
+}
+
+/** Keeps what outlives an authorization round trip, drops the one shot values it used. */
+function withoutAuthorizationState(entry: McpOAuthEntry): McpOAuthEntry {
+  const next: McpOAuthEntry = { serverUrl: entry.serverUrl }
+  if (entry.clientInformation) next.clientInformation = entry.clientInformation
+  if (entry.tokens) next.tokens = entry.tokens
+  return next
+}
+
+export async function readMcpOAuthEntry(name: string, serverUrl: string): Promise<McpOAuthEntry | undefined> {
+  const store = await readStore()
+  const entry = store.servers[name]
+  if (!entry || entry.serverUrl !== serverUrl) return undefined
+  return entry
+}
+
+export async function saveMcpOAuthClientInformation(
+  name: string,
+  serverUrl: string,
+  clientInformation: OAuthClientInformationMixed,
+): Promise<void> {
+  await mutateEntry(name, serverUrl, (entry) => ({ ...entry, clientInformation }))
+}
+
+export async function saveMcpOAuthTokens(name: string, serverUrl: string, tokens: OAuthTokens): Promise<void> {
+  await mutateEntry(name, serverUrl, (entry) => ({ ...withoutAuthorizationState(entry), tokens }))
+}
+
+export async function saveMcpOAuthCodeVerifier(name: string, serverUrl: string, codeVerifier: string): Promise<void> {
+  await mutateEntry(name, serverUrl, (entry) => ({ ...entry, codeVerifier }))
+}
+
+export async function saveMcpOAuthState(name: string, serverUrl: string, state: string): Promise<void> {
+  await mutateEntry(name, serverUrl, (entry) => ({ ...entry, state }))
+}
+
+/** Forgets the tokens, keeps the registered client so a new authorization need not register again. */
+export async function clearMcpOAuthTokens(name: string, serverUrl: string): Promise<void> {
+  await mutateEntry(name, serverUrl, (entry) => {
+    const next = withoutAuthorizationState(entry)
+    delete next.tokens
+    return next
+  })
+}
+
+/** Burns the state and the verifier of an attempt, whether that attempt succeeded or failed. */
+export async function clearMcpOAuthAuthorizationState(name: string, serverUrl: string): Promise<void> {
+  await mutateEntry(name, serverUrl, withoutAuthorizationState)
+}
+
+export async function clearMcpOAuthEntry(name: string): Promise<void> {
+  await serialize(async () => {
+    const store = await readStore()
+    if (!(name in store.servers)) return
+    delete store.servers[name]
+    await writeStore(store)
+  })
+}
+
+/** Resolves the pending authorization a callback belongs to. State is single use, saving tokens drops it. */
+export async function findMcpOAuthEntryByState(state: string): Promise<{ name: string; entry: McpOAuthEntry } | null> {
+  const store = await readStore()
+  for (const [name, entry] of Object.entries(store.servers)) {
+    if (entry.state && entry.state === state) return { name, entry }
+  }
+  return null
+}

--- a/src/server/mcp/types.ts
+++ b/src/server/mcp/types.ts
@@ -14,6 +14,8 @@ export interface McpServerConfig {
   env?: Record<string, string>
   url?: string
   headers?: Record<string, string>
+  /** Authorize against the server with OAuth instead of a static credential. HTTP transport only. */
+  oauth?: boolean
   disabledTools?: string[]
   cachedTools?: CachedToolInfo[]
   timeout?: number

--- a/src/server/mcp/update-server.test.ts
+++ b/src/server/mcp/update-server.test.ts
@@ -36,6 +36,15 @@ vi.mock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
   }),
 }))
 
+vi.mock('@modelcontextprotocol/sdk/client/streamableHttp.js', () => ({
+  StreamableHTTPClientTransport: vi.fn(function () {
+    return {
+      start: vi.fn().mockResolvedValue(undefined),
+      close: vi.fn().mockResolvedValue(undefined),
+    }
+  }),
+}))
+
 const defaultCfg: McpServerConfig = { transport: 'stdio', command: 'node' }
 
 describe('applyMcpServerUpdate server isolation', () => {
@@ -136,5 +145,73 @@ describe('applyMcpServerUpdate server isolation', () => {
     expect(alpha.tools).toHaveLength(2)
     expect(beta.status).toBe('connected')
     expect(beta.tools).toHaveLength(2)
+  })
+})
+
+describe('applyMcpServerUpdate oauth patch semantics', () => {
+  let manager: McpManager
+  let savedCfg: McpServerConfig | undefined
+  const save = vi.fn(async (cfg: McpServerConfig) => {
+    savedCfg = cfg
+  })
+  const oauthHttpCfg: McpServerConfig = { transport: 'http', url: 'https://mcp.example.com/mcp', oauth: true }
+
+  beforeEach(async () => {
+    savedCfg = undefined
+    manager = new McpManager()
+    await manager.addServer('srv', oauthHttpCfg)
+  })
+
+  it('keeps oauth: true when the patch does not mention oauth', async () => {
+    const existing = manager.getServer('srv')!
+
+    const { serverCfg, error } = await applyMcpServerUpdate({
+      name: 'srv',
+      patch: { timeout: 30 },
+      existing,
+      persistedCfg: oauthHttpCfg,
+      mcpManager: manager,
+      save,
+    })
+
+    expect(error).toBeUndefined()
+    expect(serverCfg.oauth).toBe(true)
+    expect(savedCfg?.oauth).toBe(true)
+  })
+
+  it('drops the oauth key entirely when the patch sets oauth: false (absent = disabled)', async () => {
+    const existing = manager.getServer('srv')!
+
+    const { serverCfg, error } = await applyMcpServerUpdate({
+      name: 'srv',
+      patch: { oauth: false },
+      existing,
+      persistedCfg: oauthHttpCfg,
+      mcpManager: manager,
+      save,
+    })
+
+    expect(error).toBeUndefined()
+    expect(serverCfg).not.toHaveProperty('oauth')
+    expect(savedCfg).not.toHaveProperty('oauth')
+  })
+
+  it('drops oauth, like url and headers, when switching transport from http to stdio', async () => {
+    const existing = manager.getServer('srv')!
+
+    const { serverCfg, error } = await applyMcpServerUpdate({
+      name: 'srv',
+      patch: { transport: 'stdio', command: 'node' },
+      existing,
+      persistedCfg: oauthHttpCfg,
+      mcpManager: manager,
+      save,
+    })
+
+    expect(error).toBeUndefined()
+    expect(serverCfg).not.toHaveProperty('oauth')
+    expect(serverCfg).not.toHaveProperty('url')
+    expect(serverCfg).not.toHaveProperty('headers')
+    expect(savedCfg).not.toHaveProperty('oauth')
   })
 })

--- a/src/server/mcp/update-server.ts
+++ b/src/server/mcp/update-server.ts
@@ -8,6 +8,7 @@ export interface McpServerPatch {
   env?: Record<string, string>
   url?: string
   headers?: Record<string, string>
+  oauth?: boolean
   timeout?: number
   disabled?: boolean
 }
@@ -37,6 +38,7 @@ export function buildUpdatedServerConfig(
   const mergedUrl = patch.url !== undefined ? patch.url : transportChanged ? undefined : existing.config.url
   const mergedHeaders =
     patch.headers !== undefined ? patch.headers : transportChanged ? undefined : existing.config.headers
+  const mergedOauth = patch.oauth !== undefined ? patch.oauth : transportChanged ? undefined : existing.config.oauth
   const mergedTimeout = patch.timeout !== undefined ? patch.timeout : existing.config.timeout
   const mergedDisabled = patch.disabled !== undefined ? patch.disabled : existing.config.disabled
 
@@ -58,6 +60,7 @@ export function buildUpdatedServerConfig(
     ...(mergedEnv && Object.keys(mergedEnv).length > 0 ? { env: mergedEnv } : {}),
     ...(mergedUrl ? { url: mergedUrl } : {}),
     ...(mergedHeaders && Object.keys(mergedHeaders).length > 0 ? { headers: mergedHeaders } : {}),
+    ...(mergedOauth ? { oauth: mergedOauth } : {}),
     ...(mergedTimeout !== undefined ? { timeout: mergedTimeout } : {}),
     ...(mergedDisabled !== undefined ? { disabled: mergedDisabled } : {}),
     ...(persistedCfg?.disabledTools && persistedCfg.disabledTools.length > 0

--- a/web/src/components/settings/McpServerCard.tsx
+++ b/web/src/components/settings/McpServerCard.tsx
@@ -22,6 +22,7 @@ interface McpServerCardProps {
   statusDot: string
   statusColor: string
   actions?: React.ReactNode
+  authPanel?: React.ReactNode
 }
 
 export function McpServerCard({
@@ -35,6 +36,7 @@ export function McpServerCard({
   statusDot,
   statusColor,
   actions,
+  authPanel,
 }: McpServerCardProps) {
   const [expandedDescs, setExpandedDescs] = useState<Set<string>>(new Set())
   const name = server.name
@@ -63,6 +65,7 @@ export function McpServerCard({
             </div>
           )}
           {server.config.url && <div className="text-xs text-text-muted font-mono">{server.config.url}</div>}
+          {authPanel}
           {tools.length === 0 ? (
             <div className="text-xs text-text-muted">No tools available</div>
           ) : (

--- a/web/src/components/settings/tabs/ToolsTab.tsx
+++ b/web/src/components/settings/tabs/ToolsTab.tsx
@@ -34,6 +34,7 @@ interface McpFormData {
   env: string
   url: string
   headers: string
+  oauth: boolean
   timeout: string
 }
 
@@ -118,6 +119,21 @@ function McpServerFormFields({ formData, onChange }: McpServerFormFieldsProps) {
               rows={3}
             />
           </div>
+          <label className="flex items-start gap-2 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={formData.oauth}
+              onChange={(e) => onChange({ ...formData, oauth: e.target.checked })}
+              className="mt-0.5"
+            />
+            <span className="text-xs text-text-secondary">
+              Authorize with OAuth
+              <span className="block text-text-muted">
+                For servers that require a sign in rather than a static credential. Expand the server afterwards to
+                authorize.
+              </span>
+            </span>
+          </label>
         </>
       )}
       <FormField
@@ -127,6 +143,106 @@ function McpServerFormFields({ formData, onChange }: McpServerFormFieldsProps) {
         placeholder="optional, e.g. 30"
       />
     </>
+  )
+}
+
+interface McpOAuthPanelProps {
+  serverName: string
+  onChanged: () => void
+}
+
+const MCP_OAUTH_BUTTON_CLASS =
+  'px-2 py-1 rounded text-xs font-medium text-text-muted hover:text-text-primary hover:bg-bg-primary transition-colors disabled:opacity-50'
+
+function McpOAuthPanel({ serverName, onChanged }: McpOAuthPanelProps) {
+  const [busy, setBusy] = useState(false)
+  const [redirectUri, setRedirectUri] = useState('')
+  const [pasted, setPasted] = useState('')
+  const [error, setError] = useState('')
+
+  const endpoint = `/api/mcp/servers/${encodeURIComponent(serverName)}/oauth`
+
+  const call = async (run: () => Promise<void>) => {
+    setBusy(true)
+    setError('')
+    try {
+      await run()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const postJson = async (path: string, body?: unknown) => {
+    const res = await authFetch(path, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+    })
+    const data = await res.json()
+    if (!res.ok) throw new Error(data.error ?? 'Request failed')
+    return data
+  }
+
+  const handleStart = () =>
+    call(async () => {
+      const data = await postJson(`${endpoint}/start`)
+      if (data.status !== 'redirect') {
+        onChanged()
+        return
+      }
+      setRedirectUri(data.redirectUri ?? '')
+      window.open(data.authorizationUrl, '_blank', 'noopener,noreferrer')
+    })
+
+  const handleComplete = () =>
+    call(async () => {
+      await postJson(`${endpoint}/complete`, { response: pasted })
+      setPasted('')
+      setRedirectUri('')
+      onChanged()
+    })
+
+  const handleForget = () =>
+    call(async () => {
+      const res = await authFetch(endpoint, { method: 'DELETE' })
+      if (!res.ok) throw new Error('Could not clear the stored credentials')
+      onChanged()
+    })
+
+  return (
+    <div className="space-y-1.5 py-1">
+      <div className="flex items-center gap-1">
+        <button onClick={handleStart} disabled={busy} className={MCP_OAUTH_BUTTON_CLASS}>
+          Authorize
+        </button>
+        <button onClick={handleForget} disabled={busy} className={MCP_OAUTH_BUTTON_CLASS}>
+          Forget credentials
+        </button>
+      </div>
+      {redirectUri && (
+        <div className="space-y-1">
+          <div className="text-xs text-text-muted">
+            A tab opened for you to sign in. If it ends up on a page that will not load, copy the whole address from it
+            and paste it below.
+          </div>
+          <div className="text-xs text-text-muted font-mono break-all">{redirectUri}</div>
+          <div className="flex items-center gap-1">
+            <input
+              value={pasted}
+              onChange={(e) => setPasted(e.target.value)}
+              placeholder="paste the callback URL"
+              className="flex-1 px-2 py-1 bg-bg-tertiary border border-border rounded text-xs font-mono focus:outline-none focus:ring-1 focus:ring-accent-primary"
+            />
+            <button onClick={handleComplete} disabled={busy || !pasted} className={MCP_OAUTH_BUTTON_CLASS}>
+              Finish
+            </button>
+          </div>
+        </div>
+      )}
+      {error && <div className="text-xs text-accent-error">{error}</div>}
+    </div>
   )
 }
 
@@ -147,6 +263,7 @@ interface McpServerState {
     env?: Record<string, string>
     url?: string
     headers?: Record<string, string>
+    oauth?: boolean
     timeout?: number
     disabled?: boolean
   }
@@ -305,6 +422,7 @@ export function ToolsTab() {
     env: '',
     url: '',
     headers: '',
+    oauth: false,
     timeout: '',
   })
   const [formError, setFormError] = useState('')
@@ -369,6 +487,7 @@ export function ToolsTab() {
     } else {
       body.url = formData.url
       body.headers = parseKeyValueLines(formData.headers)
+      body.oauth = formData.oauth
     }
     if (formData.timeout) {
       const parsed = parseFloat(formData.timeout)
@@ -387,6 +506,7 @@ export function ToolsTab() {
     env: '',
     url: '',
     headers: '',
+    oauth: false,
     timeout: '',
   }
 
@@ -440,6 +560,7 @@ export function ToolsTab() {
             .map(([k, v]) => `${k}=${v}`)
             .join('\n')
         : '',
+      oauth: server.config.oauth ?? false,
       timeout: server.config.timeout !== undefined ? String(server.config.timeout) : '',
     })
     setFormError('')
@@ -836,6 +957,9 @@ export function ToolsTab() {
                 }
                 statusDot={mcpStatusDot(server.status)}
                 statusColor={mcpStatusColor(server.status)}
+                authPanel={
+                  server.config.oauth ? <McpOAuthPanel serverName={server.name} onChanged={loadServers} /> : null
+                }
                 actions={
                   <>
                     {errorEl}


### PR DESCRIPTION
OpenFox can only authenticate to an HTTP MCP server with something static. The transport is built with headers and nothing else:

```ts
const httpOpts: StreamableHTTPClientTransportOptions = {}
if (entry.config.headers) {
  httpOpts.requestInit = { headers: entry.config.headers }
}
```

That covers a server that hands out API keys. It does not cover a server that expects a sign in, which is most of the hosted ones now, and it does not cover anything sitting behind an identity aware proxy. There is no value you can type into the headers field that gets you in, so those servers are simply unreachable today.

The SDK already carries the client side of this. `StreamableHTTPClientTransport` takes an `authProvider`, and once it has one, a 401 drives protected resource discovery, dynamic client registration, the code exchange and the refresh on its own. So this is mostly a provider implementation and the plumbing to run the browser round trip, not an OAuth implementation.

What changed:

- `oauth` is an optional boolean on http MCP servers, with a checkbox in the add and edit form. Leaving it off is exactly the current behavior, `authProvider` is never set and the headers are passed through untouched
- `McpOAuthProvider` implements `OAuthClientProvider`. It records the authorization URL rather than navigating to it, since it runs on the server, and the route hands that URL back to the UI
- credentials go to `mcp-auth.json` beside `config.json`, written 0600 through a temporary file and a rename. Nothing lands in `config.json`, which is meant to be shareable, and no token is logged or returned by an API route
- four routes to start an authorization, receive the callback, paste a callback back by hand, and forget the stored credentials

On the redirect URI. The default is the loopback address the server already listens on, so a normal install needs no configuration, and authorization servers stay happy because native apps have made loopback redirects routine. When OpenFox is reached through a tunnel, that address means nothing to the browser and the tab lands on a page that will not load. The address bar still holds the code, and pasting the whole thing back finishes the flow. `OPENFOX_PUBLIC_URL` is there for anyone who would rather register a public redirect URI and keep it automatic.

Two things worth a closer look in review:

The callback route is added to `publicPaths`. It is a redirect coming from an authorization server, so it cannot present the `x-session-token` header, and without this it answers 401 in exactly the deployment that needs it. What guards it is the `state`, which is 256 bits, single use, and required on the paste path as well.

A static `Authorization` header is dropped for servers that have OAuth on. `_commonHeaders` in the SDK merges `requestInit` headers after the ones it derives from the provider, so a leftover header would shadow the token and every request would come back unauthorized with nothing on screen to explain it.

Tests cover the transport wiring both ways, the header stripping, the patch semantics on update, the store permissions including the case where the file already existed at 0644, the single use state, concurrent writes, and a corrupted store.

Checked with `npm run typecheck`, `npm run lint` and `npm run duplicate`, all green. `npm run format` and two assertions in `src/server/routes/workspace-config.test.ts` already fail on a clean main in my environment, neither is touched here.


### AI-Enhanced Development

- **AI Models:** Claude Opus 5
