### PR TITLE
feat(provider): allow manual model entry when auto-discovery fails

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,6 +25,7 @@ jobs:
           node-version: '24'
           cache: 'npm'
       - run: npm ci
+      - run: cd web && npm ci
       - run: npm run typecheck
 
   duplicate:
@@ -48,6 +49,7 @@ jobs:
           node-version: '24'
           cache: 'npm'
       - run: npm ci
+      - run: cd web && npm ci
       - run: npm test
 
   ai-disclosure:

--- a/web/src/components/shared/ProviderModal.test.tsx
+++ b/web/src/components/shared/ProviderModal.test.tsx
@@ -55,8 +55,9 @@ describe('ProviderModal - thinkingLevel persistence', () => {
       setTimeout(resolve, 200)
     })
 
-    // Find the reasoning effort input (shows 'max' as default)
-    const effortInput = container.querySelector('input[type="text"]') as HTMLInputElement | null
+    // Find the reasoning effort input (free-text variant; the select variant is
+    // matched via the same aria-label in other tests)
+    const effortInput = container.querySelector('input[aria-label="Reasoning effort"]') as HTMLInputElement | null
 
     if (thinkingLevel !== undefined && effortInput) {
       // React controlled components listen to 'input' event with native setter
@@ -354,6 +355,107 @@ describe('ProviderModal - thinkingLevel persistence', () => {
         selected: true,
       }),
     )
+  })
+
+  it('adds a manually-entered model to the save payload when discovery returns no models', async () => {
+    // Simulate a provider (e.g. Cline) that does not expose a /models endpoint.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input)
+        if (url.includes('/api/providers/models')) {
+          return new Response(JSON.stringify({ error: 'No models found at http://localhost:8000/v1/models' }), {
+            status: 404,
+          })
+        }
+        return new Response(JSON.stringify({}), { status: 200 })
+      }),
+    )
+
+    await new Promise<void>((resolve) => {
+      root.render(
+        <ProviderModal
+          isOpen={true}
+          onClose={vi.fn()}
+          onSave={onSaveMock as (provider: ProviderFormData) => void}
+          initialStep={2}
+          editProvider={{
+            id: 'no-models-provider',
+            name: 'No Models Provider',
+            url: 'http://localhost:8000/v1',
+            backend: 'openai',
+            models: [],
+          }}
+        />,
+      )
+      setTimeout(resolve, 300)
+    })
+
+    // The manual model input is available even though discovery failed.
+    const manualInput = container.querySelector('[data-testid="provider-modal-manual-model-input"]') as HTMLInputElement
+    expect(manualInput).toBeTruthy()
+
+    const nativeInputValueSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')?.set
+    nativeInputValueSetter?.call(manualInput, 'my-cline-model')
+    manualInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const addButton = container.querySelector(
+      '[data-testid="provider-modal-manual-model-add"]',
+    ) as HTMLButtonElement | null
+    addButton?.click()
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    const saveButton = container.querySelector('[data-testid="provider-modal-save"]') as HTMLButtonElement | null
+    saveButton?.click()
+
+    expect(onSaveMock).toHaveBeenCalledTimes(1)
+    const savedData: ProviderFormData = onSaveMock.mock.calls[0]![0]!
+    const savedModel = savedData.models.find((m) => m.id === 'my-cline-model')
+    expect(savedModel).toBeDefined()
+    expect(savedModel?.selected).toBe(true)
+    expect(savedModel?.contextWindow).toBe(200000)
+  })
+
+  it('rejects a duplicate manual model id and selects the existing one', async () => {
+    await new Promise<void>((resolve) => {
+      root.render(
+        <ProviderModal
+          isOpen={true}
+          onClose={vi.fn()}
+          onSave={onSaveMock as (provider: ProviderFormData) => void}
+          initialStep={2}
+          editProvider={{
+            id: 'dup-provider',
+            name: 'Dup Provider',
+            url: 'http://localhost:8000/v1',
+            backend: 'vllm',
+            models: [{ id: 'existing-model', contextWindow: 200000 }],
+          }}
+        />,
+      )
+      setTimeout(resolve, 200)
+    })
+
+    const manualInput = container.querySelector('[data-testid="provider-modal-manual-model-input"]') as HTMLInputElement
+    const nativeInputValueSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')?.set
+    nativeInputValueSetter?.call(manualInput, 'existing-model')
+    manualInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const addButton = container.querySelector(
+      '[data-testid="provider-modal-manual-model-add"]',
+    ) as HTMLButtonElement | null
+    addButton?.click()
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    // An error message is shown and the duplicate was not added.
+    expect(container.textContent).toContain('already in the list')
+
+    const saveButton = container.querySelector('[data-testid="provider-modal-save"]') as HTMLButtonElement | null
+    saveButton?.click()
+
+    const savedData: ProviderFormData = onSaveMock.mock.calls[0]![0]!
+    // Only the original model is present — no duplicate.
+    expect(savedData.models.filter((m) => m.id === 'existing-model')).toHaveLength(1)
   })
 
   it.each([

--- a/web/src/components/shared/ProviderModal.tsx
+++ b/web/src/components/shared/ProviderModal.tsx
@@ -484,9 +484,12 @@ export function ProviderModal({
   const [providerPresets, setProviderPresets] = useState<ProviderPreset[]>([])
   const [devicePageOpened, setDevicePageOpened] = useState(false)
   const [codeCopied, setCodeCopied] = useState(false)
+  const [manualModelId, setManualModelId] = useState('')
+  const [manualModelError, setManualModelError] = useState<string | null>(null)
   const codeCopiedTimerRef = useRef<number | null>(null)
   const draftProviderSaved = useRef(false)
   const urlInputRef = useRef<HTMLInputElement>(null)
+  const manualModelInputRef = useRef<HTMLInputElement>(null)
 
   useEffect(() => {
     if (formStep === 1 && isOpen) {
@@ -534,6 +537,50 @@ export function ProviderModal({
     return models.filter((m) => terms.every((t) => m.id.toLowerCase().includes(t)))
   }
 
+  function addManualModel() {
+    const trimmed = manualModelId.trim()
+    if (!trimmed) {
+      setManualModelError('Enter a model name')
+      return
+    }
+
+    // Detect duplicates against existing models, normalizing the same way the
+    // server does (lowercase, ignore -_:. and whitespace) so "my-model" and
+    // "my_model" are treated as the same model.
+    const normalize = (s: string) => s.toLowerCase().replace(/[-_\s:.]+/g, '')
+    const normalized = normalize(trimmed)
+    const existing = models.find((m) => normalize(m.id) === normalized)
+    if (existing) {
+      // Already present: just select it instead of duplicating.
+      selectModel(existing)
+      setManualModelError(`"${existing.id}" is already in the list`)
+      setManualModelId('')
+      if (!formAuthAdapter && autoConfigState.progress[existing.id] !== 'probing') {
+        runAutoConfig(existing.id)
+      }
+      return
+    }
+
+    const newModel: ModelInfo = {
+      id: trimmed,
+      contextWindow: 200000,
+    }
+    setModels((prev) => [...prev, newModel])
+    setSelectedModelIds((current) => new Set(current).add(newModel.id))
+    setModelConfigs((current) => ({
+      ...current,
+      [newModel.id]: {
+        contextWindow: newModel.contextWindow,
+        thinkingEnabled: true,
+      },
+    }))
+    setExpandedModelId(newModel.id)
+    setManualModelId('')
+    setManualModelError(null)
+    // The user has resolved the discovery failure on their own.
+    setFetchError(null)
+  }
+
   // Reset state when modal opens
   useEffect(() => {
     if (isOpen) {
@@ -555,6 +602,8 @@ export function ProviderModal({
       setDeviceChallenge(null)
       setDevicePageOpened(false)
       setCodeCopied(false)
+      setManualModelId('')
+      setManualModelError(null)
 
       if (editProvider?.models?.length) {
         const configs: Record<string, ModelConfig> = {}
@@ -882,6 +931,8 @@ export function ProviderModal({
     setRawModalData(null)
     setSelectedModelIds(new Set())
     setSearchQuery('')
+    setManualModelId('')
+    setManualModelError(null)
   }
 
   function handleClose() {
@@ -1220,7 +1271,57 @@ export function ProviderModal({
                   >
                     Edit URL
                   </button>
+                  {!formAuthAdapter && (
+                    <button
+                      onClick={() => manualModelInputRef.current?.focus()}
+                      className="text-xs text-accent-primary hover:underline"
+                    >
+                      Add model manually
+                    </button>
+                  )}
                 </div>
+              </div>
+            )}
+
+            {/* Add model manually — always available in step 2 so providers that
+                don't expose a /models endpoint (e.g. Cline) can be configured. */}
+            {formBackend && (!formAuthAdapter || providerAuthState === 'connected') && (
+              <div>
+                <h4 className="text-sm font-medium text-text-primary mb-1">Add model manually</h4>
+                <p className="text-xs text-text-muted mb-2">
+                  {fetchError
+                    ? "Can't discover models automatically? Enter the model name to use:"
+                    : 'Enter a model name manually if it does not appear in the list above:'}
+                </p>
+                <div className="flex gap-2">
+                  <input
+                    ref={manualModelInputRef}
+                    type="text"
+                    value={manualModelId}
+                    onChange={(e) => {
+                      setManualModelId(e.target.value)
+                      if (manualModelError) setManualModelError(null)
+                    }}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') {
+                        e.preventDefault()
+                        addManualModel()
+                      }
+                    }}
+                    placeholder="model-name"
+                    data-testid="provider-modal-manual-model-input"
+                    className="flex-1 px-3 py-1.5 bg-bg-primary border border-border rounded-lg text-sm text-text-primary placeholder-text-muted focus:outline-none focus:border-accent-primary"
+                  />
+                  <button
+                    type="button"
+                    onClick={addManualModel}
+                    data-testid="provider-modal-manual-model-add"
+                    className="px-3 py-1.5 bg-accent-primary text-text-primary rounded-lg text-sm font-medium hover:bg-accent-primary/90 transition-colors"
+                  >
+                    Add
+                  </button>
+                </div>
+                {manualModelError && <p className="text-xs text-red-500 mt-1">{manualModelError}</p>}
               </div>
             )}
 


### PR DESCRIPTION
## Problem

Some providers (e.g. **Cline**) do not expose a `/models` endpoint. When adding such a provider, the auto-discovery returns `404 No models found` and the user is **blocked** — the error block only offers **Retry** and **Edit URL**, with no way to specify the model name manually.

## Solution

Add a **manual model entry field** to the provider modal (step 2), always visible so a model name can be typed in regardless of discovery outcome. The server already handles user-supplied models (`buildModelConfigs` assigns `source: user`), so the feature change is **frontend-only**.

Also fixes a pre-existing CI issue: the `pr.yml` workflow never installed web dependencies (`cd web && npm ci`), causing all web typecheck and test jobs to fail with `Cannot find module 'overlayscrollbars-react'`.

### Changes

**`web/src/components/shared/ProviderModal.tsx`**
- New `addManualModel()` function with:
  - Empty-input validation
  - Duplicate detection using the same normalization as the server (lowercase, ignore `-_:. ` and whitespace)
  - Auto-selects the model and expands its config panel
  - Clears `fetchError` once a model is added
- New UI section "Add model manually" in step 2 (field + Add button, Enter to submit)
- "Add model manually" link added to the error block (focuses the input)
- State reset on modal open and `resetStep2()`

**`web/src/components/shared/ProviderModal.test.tsx`**
- New test: adds a manually-entered model to the save payload when discovery returns 404
- New test: rejects a duplicate manual model id and selects the existing one
- Fix: pre-existing test used a fragile `input[type=text]` selector that now matches the new input — switched to `input[aria-label="Reasoning effort"]`

**`.github/workflows/pr.yml`**
- Add `cd web && npm ci` to `typecheck` and `test` jobs so web dependencies are installed (fixes pre-existing CI failure)

### Validation
- All precommit hooks passed (duplicate, lint, typecheck, full test suite)
- `ProviderModal.test.tsx`: 12/12
- Full web test suite: 85 files, 832 tests passed
- Typecheck + ESLint clean

### No server changes required
The `POST/PUT /api/providers` endpoints already accept user-supplied models via `buildModelConfigs()` (sets `source: user`), and the singular `model` field already creates a user model. This change simply exposes that capability in the UI.

---

### AI-Enhanced Development

- **AI Models:** GLM-5.2

### Cache Impact

- **No**
