### PR TITLE
test(context): harden cache-safe workspace switching

### DIFF
--- a/src/server/chat/prompts.test.ts
+++ b/src/server/chat/prompts.test.ts
@@ -206,3 +206,65 @@ describe('buildSubAgentsSection', () => {
     expect(buildSubAgentsSection([])).toBe('')
   })
 })
+
+// ============================================================================
+// Static-prompt contract that keeps the cached system prompt reusable across
+// workspace/branch mutations: the prompt may carry a stale "Working directory"
+// line, so it must (a) acknowledge the directory can change, (b) defer to a
+// later <system-reminder>, and (c) qualify <system-reminder> as authoritative.
+// ============================================================================
+
+describe('buildBasePrompt: working-directory change acknowledgement and <system-reminder> override', () => {
+  it('acknowledges the working directory may change during a session', () => {
+    const prompt = buildBasePrompt('/old/workdir')
+    // Phrase must clearly talk about the working directory AND its ability to change.
+    expect(prompt).toMatch(/working directory[^.\n]*\b(may|can)\b[^.\n]*change/i)
+  })
+
+  it('instructs the model to trust a later <system-reminder> over the static Working directory line', () => {
+    const prompt = buildBasePrompt('/old/workdir')
+    // Must not just mention <system-reminder> — must tell the model to trust it.
+    // Use a strict regex that captures the override semantics.
+    expect(prompt).toMatch(/<system-reminder>[^]*?trust[^]*?(workspace|that value|over this)/i)
+  })
+
+  it('qualifies <system-reminder> as authoritative operational constraints', () => {
+    const prompt = buildBasePrompt('/old/workdir')
+    expect(prompt).toContain('authoritative')
+    expect(prompt).toContain('operational constraints')
+  })
+
+  it('preserves the static "Working directory:" line so the cache key is stable', () => {
+    const prompt = buildBasePrompt('/old/workdir')
+    expect(prompt).toContain('Working directory: /old/workdir')
+  })
+})
+
+describe('static-prompt contract is preserved across top-level and sub-agent builders', () => {
+  it('buildTopLevelSystemPrompt preserves the full contract', () => {
+    const prompt = buildTopLevelSystemPrompt('/old/workdir', undefined, undefined, [mockVerifier])
+    expect(prompt).toContain('Working directory: /old/workdir')
+    expect(prompt).toMatch(/working directory[^.\n]*\b(may|can)\b[^.\n]*change/i)
+    expect(prompt).toMatch(/<system-reminder>[^]*?trust[^]*?(workspace|that value|over this)/i)
+    expect(prompt).toContain('authoritative')
+    expect(prompt).toContain('operational constraints')
+  })
+
+  it('buildSubAgentSystemPrompt preserves the full contract', () => {
+    const prompt = buildSubAgentSystemPrompt('/old/workdir', mockVerifier)
+    expect(prompt).toContain('Working directory: /old/workdir')
+    expect(prompt).toMatch(/working directory[^.\n]*\b(may|can)\b[^.\n]*change/i)
+    expect(prompt).toMatch(/<system-reminder>[^]*?trust[^]*?(workspace|that value|over this)/i)
+    expect(prompt).toContain('authoritative')
+    expect(prompt).toContain('operational constraints')
+    // Sub-agent body is appended on top — the base contract must remain.
+    expect(prompt).toContain('Verify each criterion carefully.')
+  })
+
+  it('buildAgentReminder wraps the agent body in <system-reminder>…</system-reminder>', () => {
+    const reminder = buildAgentReminder(mockPlanner)
+    expect(reminder.startsWith('<system-reminder>')).toBe(true)
+    expect(reminder.endsWith('</system-reminder>')).toBe(true)
+    expect(reminder).toContain('Plan mode ACTIVE')
+  })
+})

--- a/src/server/chat/prompts.ts
+++ b/src/server/chat/prompts.ts
@@ -12,6 +12,13 @@ import { getPlatformShell } from '../utils/platform.js'
  * Core system prompt shared by ALL agents (top-level and sub-agents).
  * Contains: environment, core behavior, tone, guardrails, skills.
  * Does NOT contain: agent-specific instructions, sub-agents list.
+ *
+ * Contract (pinned by src/server/chat/prompts.test.ts — buildBasePrompt +
+ * preserved-across-builders): the cached system prompt is sacred. Workspace
+ * and branch mutations do NOT invalidate it. The static "Working directory"
+ * line below may be stale; the model is told to trust a later <system-reminder>
+ * over it. The MODE CONTROL <system-reminder> qualifier below is also pinned.
+ * Do not inject additional documentary text into the returned string.
  */
 export function buildBasePrompt(
   workdir: string,

--- a/src/server/session/manager.execution-context.test.ts
+++ b/src/server/session/manager.execution-context.test.ts
@@ -18,12 +18,28 @@ import { mkdtemp, rm } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 
-const { mockGetGitBranch, mockGetWorkspacesDir, mockRunGit, mockGetCommitsBehind } = vi.hoisted(() => {
+const {
+  mockGetGitBranch,
+  mockGetWorkspacesDir,
+  mockRunGit,
+  mockGetCommitsBehind,
+  mockEnsureWorkspace,
+  mockWorkspaceExists,
+} = vi.hoisted(() => {
   const mockGetGitBranch = vi.fn(async (_cwd: string) => 'feat-x' as string | null)
   const mockGetWorkspacesDir = vi.fn(async (_projectName: string, _projectDir: string) => '/tmp/openfox-workspaces')
   const mockRunGit = vi.fn(async (_cwd: string, _args: string[]) => undefined as void)
   const mockGetCommitsBehind = vi.fn(async (_cwd: string, _branch: string) => 0 as number | null)
-  return { mockGetGitBranch, mockGetWorkspacesDir, mockRunGit, mockGetCommitsBehind }
+  const mockEnsureWorkspace = vi.fn(async () => undefined)
+  const mockWorkspaceExists = vi.fn(async () => true)
+  return {
+    mockGetGitBranch,
+    mockGetWorkspacesDir,
+    mockRunGit,
+    mockGetCommitsBehind,
+    mockEnsureWorkspace,
+    mockWorkspaceExists,
+  }
 })
 
 vi.mock('../lsp/index.js', () => ({
@@ -39,8 +55,8 @@ vi.mock('../git/workspace.js', async (importOriginal) => {
     getWorkspacesDir: mockGetWorkspacesDir as any,
     runGit: mockRunGit as any,
     getCommitsBehind: mockGetCommitsBehind as any,
-    ensureWorkspace: vi.fn(async () => undefined),
-    workspaceExists: vi.fn(async () => true),
+    ensureWorkspace: mockEnsureWorkspace as any,
+    workspaceExists: mockWorkspaceExists as any,
     validateRef: vi.fn(async () => undefined),
     resolveAndValidateSourceBranch: vi.fn(async () => 'origin/HEAD'),
   }
@@ -56,6 +72,17 @@ const mockProviderManager = {
   createClient: vi.fn(() => undefined),
   getActiveProviderId: vi.fn(() => 'test-provider'),
   getCurrentModel: vi.fn(() => 'global-model'),
+  getModelSettings: vi.fn(() => undefined),
+  getProviders: vi.fn(() => []),
+  createClientForAgent: vi.fn(() => ({
+    getModel: () => 'mock-test-model',
+    setModel: vi.fn(),
+    getProfile: vi.fn(() => ({})),
+    getBackend: () => 'ollama',
+    setBackend: vi.fn(),
+    complete: vi.fn(),
+    stream: vi.fn(),
+  })),
 }
 
 import { loadConfig } from '../config.js'
@@ -64,6 +91,136 @@ import { createProject } from '../db/projects.js'
 import { updateSessionBranch } from '../db/sessions.js'
 import { initEventStore } from '../events/index.js'
 import { SessionManager } from './manager.js'
+import type { ToolCall, ToolResult } from '../../shared/types.js'
+import type { TurnEvent } from '../events/types.js'
+
+// ============================================================================
+// Orchestrator/agent-loop mocks — used only by the runAgentTurn integration
+// describe at the bottom. Kept here so the test file is self-contained.
+// ============================================================================
+
+const { orchestratorCapturedStreamCalls, orchestratorStreamResults, orchestratorStreamCallIndex } = vi.hoisted(() => {
+  const captured: Array<{ systemPrompt: string; messages: unknown[]; tools: unknown[] }> = []
+  const results: Array<{
+    content: string
+    toolCalls: Array<{ id: string; name: string; arguments: Record<string, unknown> }>
+    segments: Array<{ type: string; content: string }>
+    usage: { promptTokens: number; completionTokens: number }
+    timing: { ttft: number; completionTime: number; tps: number; prefillTps: number }
+    aborted: boolean
+    finishReason: 'stop' | 'tool_calls' | 'length'
+    modelParams: Record<string, unknown>
+  }> = []
+  return {
+    orchestratorCapturedStreamCalls: captured,
+    orchestratorStreamResults: results,
+    orchestratorStreamCallIndex: { value: 0 },
+  }
+})
+
+vi.mock('../skills/registry.js', () => ({
+  getEnabledSkillMetadata: vi.fn(async () => []),
+}))
+
+vi.mock('../context/instructions.js', () => ({
+  getAllInstructions: vi.fn(async () => ({ content: '', files: [] })),
+}))
+
+vi.mock('../runtime-config.js', () => ({
+  getRuntimeConfig: vi.fn(() => ({
+    mode: 'test',
+    workdir: '/tmp/project',
+    agent: { toolTimeout: 30000, maxIterations: 25, maxConsecutiveFailures: 3 },
+    context: { maxTokens: 200000, compactionThreshold: 0.8, compactionTarget: 0.5 },
+    llm: {
+      baseUrl: 'http://localhost:11434',
+      model: 'mock-test-model',
+      timeout: 30000,
+      idleTimeout: 30000,
+      backend: 'ollama',
+    },
+    database: { path: ':memory:' },
+    server: { port: 0, host: '127.0.0.1' },
+  })),
+}))
+
+vi.mock('../../cli/paths.js', () => ({
+  getGlobalConfigDir: vi.fn(() => '/tmp/openfox-test-config'),
+}))
+
+vi.mock('../db/settings.js', () => ({
+  getSetting: vi.fn(() => null),
+  SETTINGS_KEYS: {
+    RETRY_PATTERNS: 'agent.retryPatterns',
+    CONFIRM_ON_WORKSPACE_ACTIONS: 'tools.confirmOnWorkspaceActions',
+  },
+}))
+
+vi.mock('../agents/registry.js', () => ({
+  loadAllAgentsDefault: vi.fn(async () => [
+    {
+      metadata: {
+        id: 'planner',
+        name: 'Planner',
+        description: 'Plans work',
+        subagent: false,
+        allowedTools: ['read_file', 'workspace'],
+        color: '#a855f7',
+      },
+      prompt: '# Plan Mode\nCRITICAL: Plan mode ACTIVE.',
+    },
+  ]),
+  findAgentById: vi.fn((id: string, list: Array<{ metadata: { id: string } }>) =>
+    list.find((a) => a.metadata.id === id),
+  ),
+  resolveDefaultAgentId: vi.fn(() => 'planner'),
+  getSubAgents: vi.fn(() => []),
+  getTopLevelAgents: vi.fn(() => []),
+}))
+
+vi.mock('../chat/stream-pure.js', () => ({
+  streamLLMPure: vi.fn((opts: { systemPrompt: string; messages: unknown[]; tools: unknown[] }) => {
+    orchestratorCapturedStreamCalls.push({
+      systemPrompt: opts.systemPrompt,
+      messages: opts.messages,
+      tools: opts.tools,
+    })
+    const idx = (orchestratorStreamCallIndex as unknown as { value: number }).value++
+    const result = orchestratorStreamResults[idx]
+    if (!result) {
+      throw new Error(
+        `streamLLMPure called ${idx + 1} times, only ${orchestratorStreamResults.length} results prepared`,
+      )
+    }
+    return result
+  }),
+  consumeStreamGenerator: vi.fn(async <T>(gen: T | Promise<T>) => gen),
+  TurnMetrics: class {
+    addToolTime = vi.fn()
+    addLLMCall = vi.fn()
+    buildStats = vi.fn(() => ({}))
+  },
+  createMessageStartEvent: vi.fn((messageId: string, role: string, content?: string, options?: unknown) => ({
+    type: 'message.start',
+    data: { messageId, role, content, ...(options as object) },
+  })),
+  createMessageDoneEvent: vi.fn((messageId: string, options?: unknown) => ({
+    type: 'message.done',
+    data: { messageId, ...(options as object) },
+  })),
+  createChatDoneEvent: vi.fn((messageId: string, reason: string, _stats?: unknown, agentType?: string) => ({
+    type: 'chat.done',
+    data: { messageId, reason, ...(agentType ? { agentType } : {}) },
+  })),
+  createToolCallEvent: vi.fn((messageId: string, toolCall: unknown) => ({
+    type: 'tool.call',
+    data: { messageId, toolCall },
+  })),
+  createToolResultEvent: vi.fn((messageId: string, toolCallId: string, result: unknown) => ({
+    type: 'tool.result',
+    data: { messageId, toolCallId, result },
+  })),
+}))
 
 async function setSessionBranch(manager: SessionManager, sessionId: string, branch: string) {
   updateSessionBranch(sessionId, branch)
@@ -96,6 +253,10 @@ describe('SessionManager.switchWorkspace – execution context integrity (issue 
     mockRunGit.mockResolvedValue(undefined)
     mockGetCommitsBehind.mockClear()
     mockGetCommitsBehind.mockResolvedValue(0)
+    mockEnsureWorkspace.mockReset()
+    mockEnsureWorkspace.mockResolvedValue(undefined)
+    mockWorkspaceExists.mockReset()
+    mockWorkspaceExists.mockResolvedValue(true)
   })
 
   afterEach(async () => {
@@ -246,6 +407,347 @@ describe('SessionManager.switchWorkspace – execution context integrity (issue 
       if (result.ok === false) {
         expect(result.expectedBranch).toBe('feat-x')
         expect(result.actualBranch).toBe('main')
+      }
+    })
+  })
+
+  // ==========================================================================
+  // A failed workspace creation must NOT manufacture a fake refreshed context:
+  // cache stays intact, no workspace reminder, no session_updated emitted.
+  // ==========================================================================
+
+  describe('mutation failure does not leak a fake refreshed context', () => {
+    it('keeps cache untouched and emits no workspace reminder when ensureWorkspace rejects', async () => {
+      // Prevent createSession's async getGitBranch() from racing our branch write
+      mockGetGitBranch.mockResolvedValue(null)
+
+      const session = manager.createSession(projectId, 'Fail-1')
+
+      await setSessionBranch(manager, session.id, 'initial-branch')
+
+      // Stabilize any pending async writes from createSession before capturing state
+      await new Promise<void>((resolve) => setImmediate(resolve))
+
+      const before = manager.requireSession(session.id)
+      const beforeWorkspace = before.workspace
+      const beforeWorkdir = before.workdir
+      const beforeBranch = before.branch
+
+      manager.setCachedPrompt(session.id, 'System prompt with Working directory: /tmp/project', [], 'old-hash')
+
+      // Install spies AFTER stabilization so creation-time side effects are not counted
+      const setCachedSpy = vi.spyOn(manager, 'setCachedPrompt')
+      const resetWarmupSpy = vi.spyOn(manager, 'resetWarmup')
+      const addMessageSpy = vi.spyOn(manager, 'addMessage')
+      setCachedSpy.mockClear()
+      resetWarmupSpy.mockClear()
+      addMessageSpy.mockClear()
+
+      const sessionUpdatedEvents: unknown[] = []
+      const unsubscribe = manager.subscribe((event) => {
+        if (event.type === 'session_updated') sessionUpdatedEvents.push(event)
+      })
+
+      try {
+        // Force the failure: workspace does not exist AND ensureWorkspace throws
+        mockWorkspaceExists.mockResolvedValue(false)
+        mockEnsureWorkspace.mockRejectedValueOnce(new Error('checkout failed: branch not found'))
+
+        // Capture the rejection explicitly to prevent an unhandled-rejection warning
+        // triggered by the .finally() chain on the internal lock promise.
+        const rejection = await manager.switchWorkspace(session.id, 'bad-ws', 'bad-branch').then(
+          () => null,
+          (err: Error) => err,
+        )
+        expect(rejection).not.toBeNull()
+        expect(rejection?.message ?? '').toMatch(/checkout|branch/i)
+
+        // Let any in-flight .finally() settle so unhandled-rejection tracking is clean
+        await new Promise<void>((resolve) => setImmediate(resolve))
+
+        const after = manager.requireSession(session.id)
+        expect(after.workspace).toBe(beforeWorkspace)
+        expect(after.workdir).toBe(beforeWorkdir)
+        expect(after.branch).toBe(beforeBranch)
+
+        const cachedAfter = manager.getCachedPrompt(session.id)
+        expect(cachedAfter).toBeDefined()
+        expect(cachedAfter?.hash).toBe('old-hash')
+        expect(cachedAfter?.systemPrompt).toBe('System prompt with Working directory: /tmp/project')
+
+        expect(setCachedSpy).not.toHaveBeenCalled()
+        expect(resetWarmupSpy).not.toHaveBeenCalled()
+        expect(addMessageSpy.mock.calls.filter(([, msg]) => msg?.messageKind === 'auto-prompt')).toHaveLength(0)
+
+        // No session_updated events were emitted post-failure (the listener was installed
+        // AFTER createSession stabilization, so any later session_updated reflects only
+        // post-stabilization activity — and there should be none from the failed switch).
+        expect(sessionUpdatedEvents).toHaveLength(0)
+      } finally {
+        unsubscribe()
+      }
+    })
+  })
+
+  // ==========================================================================
+  // Switching to the current workspace+branch is a no-op and must not consume
+  // cache, reset warmup, or emit any workspace reminder / session_updated event.
+  // ==========================================================================
+
+  describe('no-op switchWorkspace leaves cache, warmup, and event log untouched', () => {
+    it('does not invalidate cache, does not reset warmup, and does not emit any message or session_updated', async () => {
+      // Prevent createSession's async getGitBranch() from racing our branch write
+      mockGetGitBranch.mockResolvedValue('feat-x')
+
+      const session = manager.createSession(projectId, 'Noop-1', undefined, undefined, '/ws/openfox/feat-x')
+
+      await setSessionBranch(manager, session.id, 'feat-x')
+
+      await new Promise<void>((resolve) => setImmediate(resolve))
+
+      manager.setCachedPrompt(
+        session.id,
+        'Stable system prompt with Working directory: /ws/openfox/feat-x',
+        [],
+        'stable-hash',
+      )
+
+      const cachedBefore = manager.getCachedPrompt(session.id)
+      expect(cachedBefore).toBeDefined()
+      expect(cachedBefore?.hash).toBe('stable-hash')
+
+      const resetWarmupSpy = vi.spyOn(manager, 'resetWarmup')
+      const addMessageSpy = vi.spyOn(manager, 'addMessage')
+      const setCachedSpy = vi.spyOn(manager, 'setCachedPrompt')
+      resetWarmupSpy.mockClear()
+      addMessageSpy.mockClear()
+      setCachedSpy.mockClear()
+
+      const messagesBefore = manager.getSession(session.id)!.messages.slice()
+
+      const sessionUpdatedEvents: unknown[] = []
+      const unsubscribe = manager.subscribe((event) => {
+        if (event.type === 'session_updated') sessionUpdatedEvents.push(event)
+      })
+
+      try {
+        await manager.switchWorkspace(session.id, 'feat-x')
+
+        const cachedAfter = manager.getCachedPrompt(session.id)
+        expect(cachedAfter).toBeDefined()
+        expect(cachedAfter?.hash).toBe('stable-hash')
+        expect(cachedAfter?.systemPrompt).toBe('Stable system prompt with Working directory: /ws/openfox/feat-x')
+
+        expect(setCachedSpy).not.toHaveBeenCalled()
+        expect(resetWarmupSpy).not.toHaveBeenCalled()
+
+        expect(addMessageSpy.mock.calls.filter(([, msg]) => msg?.messageKind === 'auto-prompt')).toHaveLength(0)
+
+        const messagesAfter = manager.getSession(session.id)!.messages
+        expect(messagesAfter.length).toBe(messagesBefore.length)
+
+        expect(sessionUpdatedEvents).toHaveLength(0)
+      } finally {
+        unsubscribe()
+      }
+    })
+  })
+
+  // ==========================================================================
+  // End-to-end runAgentTurn integration: prove that the cached system prompt is
+  // strictly identical across the two LLM calls of the same turn when a workspace
+  // switch happens between them, while the new workspace/branch/path reaches the
+  // second LLM call via a dynamic <system-reminder> auto-prompt.
+  // ==========================================================================
+
+  describe('runAgentTurn: cached system prompt preserved across same-turn workspace switch', () => {
+    it('keeps the cached system prompt strictly identical and surfaces the new context via a workspace <system-reminder>', async () => {
+      const session = manager.createSession(projectId, 'CacheSacred-SameTurn')
+
+      const oldSystemPrompt =
+        'System prompt with Working directory: /tmp/project\nThis prompt was warmed up with the old workdir.'
+      const cachedTools = [
+        {
+          type: 'function' as const,
+          function: { name: 'workspace', description: 'Workspace tool', parameters: {} },
+        },
+        {
+          type: 'function' as const,
+          function: { name: 'read_file', description: 'Read', parameters: {} },
+        },
+      ]
+      const oldHash = 'stable-hash-from-prior-turn'
+
+      manager.setCachedPrompt(session.id, oldSystemPrompt, cachedTools, oldHash)
+
+      const cachedBefore = manager.getCachedPrompt(session.id)
+      expect(cachedBefore).toBeDefined()
+      expect(cachedBefore?.hash).toBe(oldHash)
+      expect(cachedBefore?.systemPrompt).toBe(oldSystemPrompt)
+
+      const setCachedSpy = vi.spyOn(manager, 'setCachedPrompt')
+      const resetWarmupSpy = vi.spyOn(manager, 'resetWarmup')
+      setCachedSpy.mockClear()
+      resetWarmupSpy.mockClear()
+
+      orchestratorCapturedStreamCalls.length = 0
+      orchestratorStreamResults.length = 0
+      orchestratorStreamCallIndex.value = 0
+
+      const workspaceToolCallId = 'call-ws-1'
+      orchestratorStreamResults.push({
+        content: '',
+        toolCalls: [
+          {
+            id: workspaceToolCallId,
+            name: 'workspace',
+            arguments: { action: 'switch', target: 'feature-x', branch: 'requested-branch' },
+          },
+        ],
+        segments: [],
+        usage: { promptTokens: 100, completionTokens: 5 },
+        timing: { ttft: 10, completionTime: 100, tps: 50, prefillTps: 100 },
+        aborted: false,
+        finishReason: 'tool_calls',
+        modelParams: { temperature: 0 },
+      })
+      // The session in this file has no workspace yet, so the early-return
+      // branch check (currentBranch === requestedBranch) uses the default mock
+      // getGitBranch value 'feat-x' for the pre-mutation check, then 'feat-x'
+      // for the post-mutation authoritative read. The reminder will therefore
+      // carry branch="feat-x", distinct from the requested branch.
+      mockGetGitBranch.mockResolvedValue('feat-x')
+      orchestratorStreamResults.push({
+        content: 'Acknowledged the workspace switch.',
+        toolCalls: [],
+        segments: [{ type: 'text', content: 'Acknowledged the workspace switch.' }],
+        usage: { promptTokens: 200, completionTokens: 10 },
+        timing: { ttft: 10, completionTime: 50, tps: 200, prefillTps: 100 },
+        aborted: false,
+        finishReason: 'stop',
+        modelParams: { temperature: 0 },
+      })
+
+      // Stub executeTools to perform the real manager.switchWorkspace (the only
+      // mutation under test) and emit the matching tool.call / tool.result events.
+      // Everything else — session state, conversation history, event log — runs
+      // through real production code paths.
+      const executeToolsModule = await import('../chat/execute-tools.js')
+      const executeToolsSpy = vi
+        .spyOn(executeToolsModule, 'executeTools')
+        .mockImplementation(
+          async (assistantMsgId: string, toolCalls: ToolCall[], _ctx: unknown, append: (event: TurnEvent) => void) => {
+            for (const toolCall of toolCalls) {
+              append({
+                type: 'tool.call',
+                data: {
+                  messageId: assistantMsgId,
+                  toolCall: {
+                    id: toolCall.id,
+                    name: toolCall.name,
+                    arguments: toolCall.arguments,
+                  },
+                },
+              })
+            }
+            await manager.switchWorkspace(session.id, 'feature-x', 'requested-branch')
+            const toolResult: ToolResult = {
+              success: true,
+              output: JSON.stringify({
+                workspace: 'feature-x',
+                path: '/tmp/openfox-workspaces/feature-x',
+                branch: 'feature-x',
+                message: 'Switched to workspace "feature-x" on branch "feature-x"',
+              }),
+              durationMs: 5,
+              truncated: false,
+            }
+            for (const toolCall of toolCalls) {
+              append({
+                type: 'tool.result',
+                data: { messageId: assistantMsgId, toolCallId: toolCall.id, result: toolResult },
+              })
+            }
+            return {
+              toolMessages: [
+                {
+                  role: 'tool' as const,
+                  content: toolResult.output ?? '',
+                  source: 'history' as const,
+                  toolCallId: workspaceToolCallId,
+                },
+              ],
+              criteriaChanged: false,
+            }
+          },
+        )
+
+      manager.setActiveSession(session.id)
+
+      const { runAgentTurn } = await import('../chat/orchestrator.js')
+      try {
+        await runAgentTurn(
+          {
+            sessionManager: manager,
+            sessionId: session.id,
+            llmClient: {
+              getModel: () => 'mock-test-model',
+              setModel: vi.fn(),
+              getProfile: () => ({}) as never,
+              getBackend: () => 'ollama',
+              setBackend: vi.fn(),
+              complete: vi.fn(),
+              stream: vi.fn(),
+            } as never,
+          },
+          {
+            addToolTime: vi.fn(),
+            addLLMCall: vi.fn(),
+            buildStats: vi.fn(() => ({})),
+          } as never,
+          'planner',
+          vi.fn(),
+        )
+
+        expect(orchestratorCapturedStreamCalls).toHaveLength(2)
+        const firstCall = orchestratorCapturedStreamCalls[0]!
+        const secondCall = orchestratorCapturedStreamCalls[1]!
+
+        // Identity of the system prompt across the two calls (character-by-character).
+        expect(firstCall.systemPrompt).toBe(oldSystemPrompt)
+        expect(secondCall.systemPrompt).toBe(oldSystemPrompt)
+        expect(secondCall.systemPrompt).toBe(firstCall.systemPrompt)
+
+        // Tool list reuse (deep equality).
+        expect(secondCall.tools).toEqual(firstCall.tools)
+        expect(firstCall.tools).toEqual(cachedTools)
+
+        // Cache state after both calls — hash, system prompt, no rebuild helpers.
+        const cachedAfter = manager.getCachedPrompt(session.id)
+        expect(cachedAfter).toBeDefined()
+        expect(cachedAfter?.hash).toBe(oldHash)
+        expect(cachedAfter?.systemPrompt).toBe(oldSystemPrompt)
+        expect(setCachedSpy).not.toHaveBeenCalled()
+        expect(resetWarmupSpy).not.toHaveBeenCalled()
+
+        // The workspace reminder reaches the second LLM call with the
+        // authoritatively-read workspace, path, and branch — not the requested one.
+        const secondMessages = secondCall.messages as Array<{ content: string }>
+        const workspaceReminders = secondMessages.filter(
+          (m) =>
+            typeof m.content === 'string' && m.content.includes('<system-reminder>') && m.content.includes('workspace'),
+        )
+        expect(workspaceReminders.length).toBeGreaterThan(0)
+        const reminder = workspaceReminders[workspaceReminders.length - 1]!
+        expect(reminder.content).toContain('feature-x')
+        expect(reminder.content).toContain('/tmp/openfox-workspaces/feature-x')
+        expect(reminder.content).toMatch(/branch\s+"feat-x"/)
+        expect(reminder.content).not.toContain('requested-branch')
+
+        // Position: the reminder arrives after at least one prior context element.
+        expect(secondMessages.findIndex((m) => m === reminder)).toBeGreaterThan(0)
+      } finally {
+        executeToolsSpy.mockRestore()
       }
     })
   })

--- a/src/server/session/manager.ts
+++ b/src/server/session/manager.ts
@@ -1638,9 +1638,15 @@ export class SessionManager {
     })()
 
     this.switchLocks.set(sessionId, lockPromise)
-    lockPromise.finally(() => {
-      if (this.switchLocks.get(sessionId) === lockPromise) this.switchLocks.delete(sessionId)
-    })
+    // The .finally() chain returns a new promise that propagates the original
+    // rejection. Attach .catch() so the cleanup never surfaces as an unhandled
+    // rejection when lockPromise rejects — the caller already observes the
+    // rejection via the returned promise.
+    lockPromise
+      .finally(() => {
+        if (this.switchLocks.get(sessionId) === lockPromise) this.switchLocks.delete(sessionId)
+      })
+      .catch(() => {})
 
     return lockPromise
   }


### PR DESCRIPTION
## Summary

Follow-up to #191 that hardens the cache-safe workspace-switching contract.

- preserves the cached system prompt and tool definitions across a workspace/branch switch within the same agent turn;
- verifies the authoritative workspace, path, and actual branch reach the second LLM call through a dynamic `<system-reminder>`;
- verifies failed and no-op switches do not invalidate the cache, reset warmup state, emit a misleading reminder, or publish a false `session_updated` event;
- pins the static prompt contract for top-level and sub-agent builders;
- prevents the cleanup promise created by `lockPromise.finally(...)` from surfacing an unhandled rejection while preserving the original rejection for the caller.

## Validation

- `git diff --check`
- `npm run lint`
- `npx tsc --noEmit`
- full unit suite: **3099 passed, 28 skipped, 0 failed**
- full pre-commit test suite, including E2E, passed locally with `VITEST_MAX_WORKERS=1`

## Invariants

- cached system prompt remains byte-for-byte identical between the two LLM calls;
- cached hash remains unchanged;
- no `setCachedPrompt()` or `resetWarmup()` call occurs during the switch;
- the later `<system-reminder>` contains the authoritative workspace, resolved path, and actual branch.

`THE CACHE IS SACRED.`


### AI-Enhanced Development

Tell what models helped shape this PR:

- **AI Models:** MiniMax M3 for implementation and test execution; GPT-5.6 Thinking for planning, review, and PR preparation.

### Cache Impact

Does this PR affect anything cached — system prompts, tool definitions, skills, or other context?

- **Yes — cache preservation contract only.** This PR does not invalidate, rebuild, replace, or mutate the cached system prompt, cached tool definitions, or cached hash during workspace or branch switches. Updated execution context is delivered through a dynamic `<system-reminder>` before the next LLM call.
