### PR TITLE
feat(web): resizable railbars with max width and reset-on-refresh

### DIFF
--- a/web/src/components/layout/SessionLayout.tsx
+++ b/web/src/components/layout/SessionLayout.tsx
@@ -1,6 +1,8 @@
 import { ScrollArea } from '../shared/ScrollArea'
+import { ResizeHandle } from '../shared/ResizeHandle'
 import type { ReactNode } from 'react'
 import { useSessionStore } from '../../stores/session'
+import { useResizable } from '../../hooks/useResizable'
 import { SessionSidebar } from '../plan/SessionSidebar'
 import type { Message } from '@shared/types.js'
 
@@ -19,6 +21,13 @@ export function SessionLayout({
 }: SessionLayoutProps) {
   const session = useSessionStore((state) => state.currentSession)
 
+  const { width: rightSidebarWidth, handleMouseDown: handleResizeMouseDown } = useResizable({
+    initialWidth: 320,
+    minWidth: 240,
+    maxWidth: 600,
+    direction: 'right',
+  })
+
   return (
     <div className="relative h-full overflow-hidden">
       {/* Backdrop - mobile only, when sidebar is open */}
@@ -32,7 +41,11 @@ export function SessionLayout({
 
         {/* Session Sidebar - mobile: fixed overlay, desktop: flex item */}
         {criteriaSidebarOpen ? (
-          <aside className="hidden md:block w-[320px] shrink-0 border-l border-border bg-secondary">
+          <aside
+            className="hidden md:block shrink-0 border-l border-border bg-secondary relative"
+            style={{ width: rightSidebarWidth }}
+          >
+            <ResizeHandle side="left" onMouseDown={handleResizeMouseDown} />
             <ScrollArea className="h-full p-4">
               <SessionSidebar messages={messages} workdir={session?.workspace ?? session?.workdir} />
             </ScrollArea>

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -15,6 +15,8 @@ import { EllipsisIcon, SpinIcon, StopIcon, SearchIcon, XCloseIcon } from '../sha
 import { groupSessionsByDate, formatDateHeader, formatTime } from '../../lib/format-date.js'
 import { fuzzyMatch, highlightMatches } from '../../lib/modal-utils.js'
 import { useBinding, useKeybindings } from '../../hooks/useKeybindings.js'
+import { useResizable } from '../../hooks/useResizable'
+import { ResizeHandle } from '../shared/ResizeHandle'
 
 interface SidebarProps {
   projectId: string
@@ -47,6 +49,13 @@ export function Sidebar({ projectId, isOpen = true, onClose }: SidebarProps) {
   const [focusedIndex, setFocusedIndex] = useState(-1)
   const searchRef = useRef<HTMLInputElement>(null)
   const sessionListRef = useRef<HTMLDivElement>(null)
+
+  const { width: sidebarWidth, handleMouseDown: handleResizeMouseDown } = useResizable({
+    initialWidth: 300,
+    minWidth: 200,
+    maxWidth: 600,
+    direction: 'left',
+  })
 
   const wasAutoOpenedRef = useRef(false)
 
@@ -368,7 +377,7 @@ export function Sidebar({ projectId, isOpen = true, onClose }: SidebarProps) {
         return (
           <aside
             className={`
-            ${isOpen ? 'md:w-[300px] md:shrink-0' : 'md:w-0 md:shrink-0 md:overflow-hidden md:border-r-0'}
+            ${isOpen ? 'md:w-[var(--sidebar-w)] md:shrink-0' : 'md:w-0 md:shrink-0 md:overflow-hidden md:border-r-0'}
             md:relative md:h-auto md:translate-x-0
 
             fixed z-50 h-[calc(100vh-32px)]
@@ -376,8 +385,10 @@ export function Sidebar({ projectId, isOpen = true, onClose }: SidebarProps) {
             transition-transform duration-300 ease-in-out
             ${isOpen ? 'translate-x-0' : '-translate-x-full'}
           `}
+            style={{ '--sidebar-w': `${sidebarWidth}px` } as React.CSSProperties}
           >
             {sidebarContent}
+            {isOpen && <ResizeHandle side="right" onMouseDown={handleResizeMouseDown} className="hidden md:block" />}
           </aside>
         )
       })()}

--- a/web/src/components/shared/ResizeHandle.tsx
+++ b/web/src/components/shared/ResizeHandle.tsx
@@ -1,0 +1,24 @@
+interface ResizeHandleProps {
+  /** Which edge of the parent sidebar this handle sits on. */
+  side: 'left' | 'right'
+  onMouseDown: (e: React.MouseEvent) => void
+  /** Extra classes (e.g. 'hidden md:block' to restrict to desktop). */
+  className?: string
+}
+
+/**
+ * Thin vertical drag handle for resizing sidebar/railbar widths.
+ * Must be placed inside a `position: relative` parent.
+ */
+export function ResizeHandle({ side, onMouseDown, className = '' }: ResizeHandleProps) {
+  return (
+    <div
+      role="separator"
+      aria-orientation="vertical"
+      onMouseDown={onMouseDown}
+      className={`absolute top-0 bottom-0 w-1 z-20 cursor-col-resize hover:bg-accent-primary/30 transition-colors ${
+        side === 'left' ? 'left-0 -ml-0.5' : 'right-0 -mr-0.5'
+      } ${className}`}
+    />
+  )
+}

--- a/web/src/hooks/useResizable.test.ts
+++ b/web/src/hooks/useResizable.test.ts
@@ -1,0 +1,129 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { act } from 'react'
+import { renderHook } from '@testing-library/react'
+import { useResizable } from './useResizable'
+;(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+function setup(options: Parameters<typeof useResizable>[0]) {
+  const utils = renderHook(() => useResizable(options))
+  const { result } = utils
+  return { result, utils }
+}
+
+describe('useResizable', () => {
+  beforeEach(() => {
+    vi.spyOn(document, 'addEventListener')
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    document.body.style.userSelect = ''
+    document.body.style.cursor = ''
+  })
+
+  it('returns the initial width', () => {
+    const { result } = setup({ initialWidth: 300, minWidth: 200, maxWidth: 600, direction: 'left' })
+    expect(result.current.width).toBe(300)
+    expect(result.current.isResizing).toBe(false)
+  })
+
+  it('activates resizing on mousedown', () => {
+    const { result } = setup({ initialWidth: 300, minWidth: 200, maxWidth: 600, direction: 'left' })
+    const fakeEvent = {
+      clientX: 100,
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+    } as unknown as React.MouseEvent
+    act(() => {
+      result.current.handleMouseDown(fakeEvent)
+    })
+    expect(result.current.isResizing).toBe(true)
+    expect(document.body.style.cursor).toBe('col-resize')
+    expect(document.body.style.userSelect).toBe('none')
+  })
+
+  it('increases width when dragging right on a left-anchored sidebar', () => {
+    const { result } = setup({ initialWidth: 300, minWidth: 200, maxWidth: 600, direction: 'left' })
+    const downEvent = {
+      clientX: 100,
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+    } as unknown as React.MouseEvent
+    act(() => result.current.handleMouseDown(downEvent))
+
+    // simulate mousemove: +50px to the right
+    const moveEvent = new MouseEvent('mousemove', { clientX: 150 })
+    act(() => {
+      document.dispatchEvent(moveEvent)
+    })
+    expect(result.current.width).toBe(350)
+  })
+
+  it('decreases width when dragging left on a right-anchored sidebar', () => {
+    const { result } = setup({ initialWidth: 320, minWidth: 240, maxWidth: 600, direction: 'right' })
+    const downEvent = {
+      clientX: 500,
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+    } as unknown as React.MouseEvent
+    act(() => result.current.handleMouseDown(downEvent))
+
+    // simulate mousemove: -80px (drag left) → width increases for right sidebar
+    const moveEvent = new MouseEvent('mousemove', { clientX: 420 })
+    act(() => {
+      document.dispatchEvent(moveEvent)
+    })
+    expect(result.current.width).toBe(400)
+  })
+
+  it('clamps to maxWidth', () => {
+    const { result } = setup({ initialWidth: 300, minWidth: 200, maxWidth: 600, direction: 'left' })
+    act(() =>
+      result.current.handleMouseDown({
+        clientX: 0,
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+      } as unknown as React.MouseEvent),
+    )
+    act(() => {
+      document.dispatchEvent(new MouseEvent('mousemove', { clientX: 500 }))
+    })
+    expect(result.current.width).toBe(600)
+  })
+
+  it('clamps to minWidth', () => {
+    const { result } = setup({ initialWidth: 300, minWidth: 200, maxWidth: 600, direction: 'left' })
+    act(() =>
+      result.current.handleMouseDown({
+        clientX: 200,
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+      } as unknown as React.MouseEvent),
+    )
+    // drag far left
+    act(() => {
+      document.dispatchEvent(new MouseEvent('mousemove', { clientX: -500 }))
+    })
+    expect(result.current.width).toBe(200)
+  })
+
+  it('stops resizing on mouseup and restores body styles', () => {
+    const { result } = setup({ initialWidth: 300, minWidth: 200, maxWidth: 600, direction: 'left' })
+    act(() =>
+      result.current.handleMouseDown({
+        clientX: 100,
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+      } as unknown as React.MouseEvent),
+    )
+    expect(result.current.isResizing).toBe(true)
+
+    act(() => {
+      document.dispatchEvent(new MouseEvent('mouseup'))
+    })
+    expect(result.current.isResizing).toBe(false)
+    expect(document.body.style.cursor).toBe('')
+    expect(document.body.style.userSelect).toBe('')
+  })
+})

--- a/web/src/hooks/useResizable.ts
+++ b/web/src/hooks/useResizable.ts
@@ -1,0 +1,69 @@
+import { useState, useEffect, useRef, useCallback } from 'react'
+
+export interface UseResizableOptions {
+  initialWidth: number
+  minWidth: number
+  maxWidth: number
+  /** 'left' = sidebar anchored on the left edge (drag right = wider); 'right' = sidebar anchored on the right edge (drag left = wider) */
+  direction: 'left' | 'right'
+}
+
+export interface UseResizableResult {
+  width: number
+  isResizing: boolean
+  handleMouseDown: (e: React.MouseEvent) => void
+}
+
+/**
+ * Mouse-driven resize hook for sidebar/railbar widths.
+ *
+ * Width is stored in React state — it resets to `initialWidth` on page refresh
+ * (no localStorage persistence).
+ */
+export function useResizable({ initialWidth, minWidth, maxWidth, direction }: UseResizableOptions): UseResizableResult {
+  const [width, setWidth] = useState(initialWidth)
+  const [isResizing, setIsResizing] = useState(false)
+  const resizeStateRef = useRef({ startX: 0, startWidth: initialWidth })
+
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault()
+      e.stopPropagation()
+      resizeStateRef.current = { startX: e.clientX, startWidth: width }
+      setIsResizing(true)
+    },
+    [width],
+  )
+
+  useEffect(() => {
+    if (!isResizing) return
+
+    const handleMouseMove = (e: MouseEvent) => {
+      const { startX, startWidth } = resizeStateRef.current
+      const delta = e.clientX - startX
+      const raw = direction === 'left' ? startWidth + delta : startWidth - delta
+      setWidth(Math.max(minWidth, Math.min(maxWidth, raw)))
+    }
+
+    const handleMouseUp = () => {
+      setIsResizing(false)
+    }
+
+    document.addEventListener('mousemove', handleMouseMove)
+    document.addEventListener('mouseup', handleMouseUp)
+
+    const prevUserSelect = document.body.style.userSelect
+    const prevCursor = document.body.style.cursor
+    document.body.style.userSelect = 'none'
+    document.body.style.cursor = 'col-resize'
+
+    return () => {
+      document.removeEventListener('mousemove', handleMouseMove)
+      document.removeEventListener('mouseup', handleMouseUp)
+      document.body.style.userSelect = prevUserSelect
+      document.body.style.cursor = prevCursor
+    }
+  }, [isResizing, direction, minWidth, maxWidth])
+
+  return { width, isResizing, handleMouseDown }
+}


### PR DESCRIPTION
### Summary

Add mouse-draggable resize handles to the left and right railbars (sidebars). Users can now drag the sidebar edges to resize them, subject to minimum/maximum width constraints. Width resets to default on page refresh (no localStorage persistence).

**Why:** The sidebars had fixed widths (300px left, 320px right). Users needed the ability to widen them for more content visibility, or narrow them for more center space, with a sensible maximum to prevent collapsing the main content area.

**What changed:**

- New `useResizable` hook (`web/src/hooks/useResizable.ts`) — handles mousedown/mousemove/mouseup drag logic, clamps width to `[min, max]`, sets `body { cursor: col-resize; userSelect: none }` during active drag, cleans up on mouseup. Width stored in `useState` (resets on refresh, no localStorage).
- New `ResizeHandle` component (`web/src/components/shared/ResizeHandle.tsx`) — thin 4px vertical bar, `cursor-col-resize`, `hover:bg-accent-primary/30`, `role=separator` for a11y. Absolute-positioned at the sidebar edge.
- `Sidebar.tsx` (left railbar) — uses CSS variable `--sidebar-w` consumed only by the desktop class `md:w-[var(--sidebar-w)]`; mobile `w-[300px]` remains untouched. Handle placed at right edge, `hidden md:block`.
- `SessionLayout.tsx` (right railbar) — inline `style={{ width }}` on desktop aside (which is `hidden md:block`; mobile has a separate aside). Handle placed at left edge.

**Constraints:**

| Sidebar | Initial | Min | Max |
|---------|---------|-----|-----|
| Left    | 300px   | 200px | 600px |
| Right   | 320px   | 240px | 600px |

**Testing:**

- 7 new unit tests for `useResizable` hook (initial width, drag direction left/right, clamp min/max, mouseup cleanup, body style restoration)
- All 3096 existing unit tests pass
- `npm run typecheck` — pass
- ESLint — clean
- Manual visual testing on dev server pending (drag requires real DOM, not covered by happy-dom)

### AI-Enhanced Development

Tell what models helped shape this PR:

- **AI Models:** GLM-5.2

### Cache Impact

Does this PR affect anything cached — system prompts, tool definitions, skills, or other context?

- **No**