### PR TITLE
fix: fetch OpenCode Go models from /zen/go/v1 instead of Zen API

### DIFF
--- a/src/server/provider-manager.test.ts
+++ b/src/server/provider-manager.test.ts
@@ -433,7 +433,7 @@ describe('ProviderManager - Model Selection', () => {
       expect(result).toEqual({ success: false, error: 'No models returned from backend' })
     })
 
-    it('uses alternate endpoint for OpenCode Go', async () => {
+    it('fetches OpenCode Go models from /zen/go/v1/models', async () => {
       const opencodeProvider: Provider = {
         id: 'provider-opencode',
         name: 'OpenCode Go',
@@ -460,7 +460,7 @@ describe('ProviderManager - Model Selection', () => {
 
       expect(result.success).toBe(true)
       expect(mockFetch).toHaveBeenCalledWith(
-        'https://opencode.ai/zen/v1/models',
+        'https://opencode.ai/zen/go/v1/models',
         expect.objectContaining({
           headers: expect.objectContaining({ Authorization: 'Bearer test-key' }),
         }),

--- a/src/server/provider-manager.ts
+++ b/src/server/provider-manager.ts
@@ -105,9 +105,10 @@ export async function fetchModelsWithContext(
     logger.info('LM Studio native endpoint unavailable, falling back to /v1/models')
   }
 
-  // OpenCode Go has models at /zen/v1/models not /zen/go/v1/models
-  const isOpenCodeGo = baseUrl.includes('opencode.ai/zen/go')
-  const url = isOpenCodeGo ? buildModelsUrl(baseUrl.replace('/zen/go', '/zen')) : buildModelsUrl(baseUrl)
+  // OpenCode Go exposes its models at https://opencode.ai/zen/go/v1/models
+  // (see https://opencode.ai/docs/go/) — the standard buildModelsUrl already
+  // produces the correct URL, so no rewrite to the Zen API (/zen/v1) is needed.
+  const url = buildModelsUrl(baseUrl)
 
   logger.info('Fetching models via /v1/models', { url })
   const models = await fetchModelsFromBackend(url, apiKey)


### PR DESCRIPTION
The `opencode-go` backend was rewriting its base URL from `https://opencode.ai/zen/go/v1` to the Zen API (`/zen/v1`) when fetching the model list, returning the Zen catalog instead of the OpenCode Go catalog.

Per https://opencode.ai/docs/go/, OpenCode Go serves its models at `https://opencode.ai/zen/go/v1/models` — the standard `buildModelsUrl()` already produces the correct URL, so the rewrite is removed.

- Remove the `/zen/go` → `/zen` rewrite in `fetchModelsWithContext`
- Add a comment documenting the correct endpoint
- Update the provider-manager test to expect `/zen/go/v1/models`

## AI Models
AI Models: DeepSeek V4 Flash (via OpenFox)
