### PR TITLE
# fix(windows): workspace root validation, workspace detection, and a stuck save flag

### DIFF
--- a/src/server/dev-server/manager.test.ts
+++ b/src/server/dev-server/manager.test.ts
@@ -172,6 +172,16 @@ describe('loadConfig with workspace fallback', () => {
     expect(readFile).toHaveBeenCalledTimes(2)
   })
 
+  it('falls back to project root for a backslash workspace path (Windows)', async () => {
+    vi.mocked(readFile)
+      .mockRejectedValueOnce(new Error('ENOENT'))
+      .mockResolvedValueOnce(JSON.stringify({ command: 'npm run dev', url: 'http://localhost:5173' }))
+
+    const config = await devServerManager.loadConfig('C:\\Users\\me\\AppData\\Local\\openfox\\workspaces\\my-feature')
+    expect(config).toMatchObject({ command: 'npm run dev', url: 'http://localhost:5173' })
+    expect(readFile).toHaveBeenCalledTimes(2)
+  })
+
   it('returns null when neither path has config', async () => {
     vi.mocked(readFile).mockRejectedValue(new Error('ENOENT'))
     const config = await devServerManager.loadConfig('/some/project/workspaces/my-feature')

--- a/src/server/dev-server/manager.ts
+++ b/src/server/dev-server/manager.ts
@@ -185,7 +185,7 @@ class DevServerManager {
 
   /**
    * Load dev server config from workdir.
-   * If not found and the path looks like a workspace (contains /workspaces/),
+   * If not found and the path looks like a workspace (contains a /workspaces/ segment),
    * falls back to the parent project root.
    */
   async loadConfig(workdir: string): Promise<DevServerConfig | null> {
@@ -210,7 +210,8 @@ class DevServerManager {
     if (config) return config
 
     // Auto-detect workspace paths: <global-data-dir>/workspaces/<project>/<name>
-    const wsIdx = workdir.indexOf('/workspaces/')
+    // Either separator: Windows workspace paths use backslashes.
+    const wsIdx = workdir.search(/[\\/]workspaces[\\/]/)
     if (wsIdx !== -1) {
       const projectRoot = workdir.slice(0, wsIdx)
       if (projectRoot !== workdir) {

--- a/src/server/routes/workspace-config.test.ts
+++ b/src/server/routes/workspace-config.test.ts
@@ -284,6 +284,52 @@ describe('POST /api/workspace/config/validate', () => {
       expect(body.workspaces).toEqual([])
     })
 
+    /** Saves rootDir as the project's current one, with a git workspace inside it. */
+    async function saveRootDirWithWorkspace(rootDir: string): Promise<void> {
+      await mkdir(join(rootDir, 'fix-bug', '.git'), { recursive: true })
+      const saveRes = await fetch(`${baseUrl}/api/workspace/config?workdir=${encodeURIComponent(testDir)}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ rootDir }),
+      })
+      expect(saveRes.status).toBe(200)
+    }
+
+    it('treats a trailing separator as the same rootDir', async () => {
+      const rootDir = join(testDir, 'trailing-workspaces')
+      await saveRootDirWithWorkspace(rootDir)
+
+      const res = await fetch(`${baseUrl}/api/workspace/config/validate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ rootDir: `${rootDir}/`, workdir: testDir }),
+      })
+
+      expect(res.status).toBe(200)
+      const body = (await res.json()) as ValidateResponse
+      expect(body.workspaces).toEqual([])
+    })
+
+    // Windows only: paths there are case-insensitive and separators interchangeable,
+    // so the same directory spelled differently must not read as a workspace move.
+    it.skipIf(process.platform !== 'win32')(
+      'treats case and separator differences as the same rootDir on Windows',
+      async () => {
+        const rootDir = join(testDir, 'case-workspaces')
+        await saveRootDirWithWorkspace(rootDir)
+
+        const res = await fetch(`${baseUrl}/api/workspace/config/validate`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ rootDir: rootDir.toUpperCase().replace(/\\/g, '/'), workdir: testDir }),
+        })
+
+        expect(res.status).toBe(200)
+        const body = (await res.json()) as ValidateResponse
+        expect(body.workspaces).toEqual([])
+      },
+    )
+
     it('returns empty workspaces list when config has no previous rootDir', async () => {
       const newRootDir = join(testDir, 'fresh-workspaces')
 

--- a/src/server/routes/workspace-config.ts
+++ b/src/server/routes/workspace-config.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express'
 import { stat, mkdir, readdir, access } from 'node:fs/promises'
 import { constants } from 'node:fs'
-import { resolve, isAbsolute, join } from 'node:path'
+import { resolve, isAbsolute, join, win32 } from 'node:path'
 import { loadWorkspaceConfig, saveWorkspaceConfig } from '../git/workspace-config.js'
 import { getGlobalDataDir } from '../git/workspace.js'
 import { getProjectByWorkdir, updateProject } from '../db/projects.js'
@@ -22,6 +22,18 @@ async function isWritable(path: string): Promise<boolean> {
 
 function resolveRootDir(rootDir: string, workdir: string): string {
   return isAbsolute(rootDir) ? rootDir : resolve(workdir, rootDir)
+}
+
+/**
+ * Compare two resolved directory paths. On Windows separators are interchangeable
+ * and the filesystem is case-insensitive, so `C:\Foo\` and `c:/foo` are the same
+ * directory — comparing them raw makes an unchanged rootDir look like a move and
+ * triggers a phantom orphan scan.
+ */
+function isSameDir(a: string, b: string): boolean {
+  if (process.platform !== 'win32') return a.replace(/\/+$/, '') === b.replace(/\/+$/, '')
+  const normalize = (p: string): string => win32.normalize(p).replace(/\\+$/, '').toLowerCase()
+  return normalize(a) === normalize(b)
 }
 
 async function checkDirExists(path: string): Promise<boolean> {
@@ -202,12 +214,12 @@ export function createWorkspaceConfigRoutes(sessionManager: SessionManager): Rou
       const project = getProjectByWorkdir(workdir)
       const previousRootDir = project?.workspaceRootDir ? resolveRootDir(project.workspaceRootDir, workdir) : null
 
-      if (previousRootDir && previousRootDir !== resolvedPath) {
+      if (previousRootDir && !isSameDir(previousRootDir, resolvedPath)) {
         const orphans = await findOrphanedWorkspaces(previousRootDir)
         workspaces.push(...orphans)
       } else if (!previousRootDir && projectName && typeof projectName === 'string') {
         const defaultDir = join(getGlobalDataDir(), 'workspaces', projectName)
-        if (defaultDir !== resolvedPath) {
+        if (!isSameDir(defaultDir, resolvedPath)) {
           const orphans = await findOrphanedWorkspaces(defaultDir)
           workspaces.push(...orphans)
         }

--- a/src/server/routes/workspace-config.ts
+++ b/src/server/routes/workspace-config.ts
@@ -8,7 +8,7 @@ import { getProjectByWorkdir, updateProject } from '../db/projects.js'
 import { setSessionDisabledServers } from '../mcp/session-overrides.js'
 import { logger } from '../utils/logger.js'
 import type { WorkspaceConfig } from '../../shared/workspace.js'
-import { getRootDirBlockReason } from '../../shared/workspace.js'
+import { formatRootDir, getRootDirBlockReason, suggestRootDirChild } from '../../shared/workspace.js'
 import type { SessionManager } from '../session/manager.js'
 
 async function isWritable(path: string): Promise<boolean> {
@@ -103,7 +103,7 @@ export function createWorkspaceConfigRoutes(sessionManager: SessionManager): Rou
       const trimmed = rootDir.trim()
       if (trimmed) {
         const resolvedPath = resolveRootDir(trimmed, workdir)
-        const displayPath = resolvedPath.replace(/\/+$/, '') || '/'
+        const displayPath = formatRootDir(resolvedPath)
         const blockReason = getRootDirBlockReason(resolvedPath)
         if (blockReason === 'exact') {
           return res
@@ -169,11 +169,11 @@ export function createWorkspaceConfigRoutes(sessionManager: SessionManager): Rou
     }
 
     const resolvedPath = resolveRootDir(rootDir, workdir)
-    const displayPath = resolvedPath.replace(/\/+$/, '') || '/'
+    const displayPath = formatRootDir(resolvedPath)
 
     const blockReason = getRootDirBlockReason(resolvedPath)
     if (blockReason === 'exact') {
-      const suggestion = typeof projectName === 'string' ? `${displayPath}/${projectName}` : undefined
+      const suggestion = typeof projectName === 'string' ? suggestRootDirChild(resolvedPath, projectName) : undefined
       return res.status(400).json({
         error: suggestion
           ? `Cannot use "${displayPath}" directly as workspace root. Use a subdirectory like "${suggestion}" instead.`

--- a/src/shared/workspace.test.ts
+++ b/src/shared/workspace.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest'
+import { formatRootDir, getRootDirBlockReason, isValidRootDir, suggestRootDirChild } from './workspace.js'
+
+describe('getRootDirBlockReason', () => {
+  it('blocks posix system roots exactly', () => {
+    expect(getRootDirBlockReason('/')).toBe('exact')
+    expect(getRootDirBlockReason('/etc')).toBe('exact')
+    expect(getRootDirBlockReason('/home')).toBe('exact')
+  })
+
+  it('blocks virtual filesystems by prefix', () => {
+    expect(getRootDirBlockReason('/proc/self/fd')).toBe('virtual_fs')
+    expect(getRootDirBlockReason('/sys/kernel')).toBe('virtual_fs')
+  })
+
+  it('allows regular directories', () => {
+    expect(getRootDirBlockReason('/home/me/workspaces')).toBeNull()
+    expect(getRootDirBlockReason('C:\\Users\\me\\workspaces')).toBeNull()
+    expect(isValidRootDir('C:\\Users\\me\\workspaces')).toBe(true)
+  })
+
+  it('blocks bare Windows drive roots', () => {
+    expect(getRootDirBlockReason('C:\\')).toBe('exact')
+    expect(getRootDirBlockReason('d:/')).toBe('exact')
+    expect(getRootDirBlockReason('Z:')).toBe('exact')
+    expect(isValidRootDir('C:\\')).toBe(false)
+  })
+
+  it('ignores trailing separators of either kind', () => {
+    expect(getRootDirBlockReason('/etc/')).toBe('exact')
+    expect(getRootDirBlockReason('/home//')).toBe('exact')
+    expect(getRootDirBlockReason('C:\\\\')).toBe('exact')
+    expect(getRootDirBlockReason('/home/me/ws/')).toBeNull()
+  })
+
+  it('returns null for an empty path', () => {
+    expect(getRootDirBlockReason('')).toBeNull()
+  })
+})
+
+describe('formatRootDir', () => {
+  it('drops trailing separators', () => {
+    expect(formatRootDir('/home/me/ws/')).toBe('/home/me/ws')
+    expect(formatRootDir('C:\\Users\\me\\ws\\')).toBe('C:\\Users\\me\\ws')
+  })
+
+  it('keeps drive roots readable', () => {
+    expect(formatRootDir('C:\\')).toBe('C:\\')
+    expect(formatRootDir('d:/')).toBe('d:\\')
+  })
+
+  it('keeps the posix root', () => {
+    expect(formatRootDir('/')).toBe('/')
+  })
+})
+
+describe('suggestRootDirChild', () => {
+  it('appends with a single separator', () => {
+    expect(suggestRootDirChild('/home', 'myproj')).toBe('/home/myproj')
+    expect(suggestRootDirChild('/home/', 'myproj')).toBe('/home/myproj')
+    expect(suggestRootDirChild('/', 'myproj')).toBe('/myproj')
+    expect(suggestRootDirChild('C:\\', 'myproj')).toBe('C:\\myproj')
+  })
+})

--- a/src/shared/workspace.ts
+++ b/src/shared/workspace.ts
@@ -33,18 +33,43 @@ export const BLOCKED_VIRTUAL_FS_PREFIXES = ['/proc/', '/sys/', '/dev/', '/boot/'
 
 export type RootDirBlockReason = 'exact' | 'virtual_fs'
 
+/**
+ * A bare Windows drive root (`C:\`, `d:/`, `C:`). Blocked like `/` is on posix:
+ * a whole drive as workspace root lists every top-level folder of the disk as a
+ * workspace, each one deletable from the workspace switcher.
+ * Not gated on the platform: this module also runs in the browser, which has no
+ * way to know the server's platform. The cost on posix is a relative directory
+ * literally named `c:` — the server would resolve it under the project, the
+ * client now rejects it.
+ */
+const WINDOWS_DRIVE_ROOT = /^[a-zA-Z]:$/
+
 export function getRootDirBlockReason(
   path: string,
   exactPaths: readonly string[] = BLOCKED_EXACT_PATHS,
   virtualFsPrefixes: readonly string[] = BLOCKED_VIRTUAL_FS_PREFIXES,
 ): RootDirBlockReason | null {
   if (!path) return null
-  const normalized = path.replace(/\/+$/, '') || '/'
+  const normalized = path.replace(/[\\/]+$/, '') || '/'
+  if (WINDOWS_DRIVE_ROOT.test(normalized)) return 'exact'
   if (exactPaths.includes(normalized)) return 'exact'
   for (const prefix of virtualFsPrefixes) {
     if (normalized.startsWith(prefix)) return 'virtual_fs'
   }
   return null
+}
+
+/** Root dir as shown in messages: trailing separators dropped, drive roots kept as `C:\`. */
+export function formatRootDir(path: string): string {
+  const trimmed = path.replace(/[\\/]+$/, '')
+  if (!trimmed) return '/'
+  return WINDOWS_DRIVE_ROOT.test(trimmed) ? `${trimmed}\\` : trimmed
+}
+
+/** Suggested subdirectory under a blocked root, with a single separator on both platforms. */
+export function suggestRootDirChild(path: string, child: string): string {
+  const base = formatRootDir(path)
+  return /[\\/]$/.test(base) ? `${base}${child}` : `${base}/${child}`
 }
 
 export function isValidRootDir(

--- a/web/src/components/settings/ProjectSettingsModal.test.tsx
+++ b/web/src/components/settings/ProjectSettingsModal.test.tsx
@@ -189,6 +189,26 @@ describe('ProjectSettingsModal — rootDir validation (Criterion 0 & 1)', () => 
     )
   })
 
+  it('leaves the form usable after a successful rootDir save', async () => {
+    // validate is the only authFetch call on this path — persisting goes through the stores
+    mockAuthFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({ exists: true, workspaces: [] }) })
+
+    const user = userEvent.setup()
+    mockStoreState.config = { rootDir: '/old/path', setup: [] }
+
+    render(<ProjectSettingsModal isOpen={true} onClose={vi.fn()} project={defaultProject} />)
+
+    const input = screen.getByPlaceholderText('/absolute/or/relative/path')
+    await user.clear(input)
+    await user.type(input, '/new/path')
+    await user.click(screen.getByTestId('save-btn'))
+
+    // The saving flag must be cleared on the success path too — the modal stays
+    // mounted after closing, so a stuck flag disables every field for good.
+    expect((input as HTMLInputElement).disabled).toBe(false)
+    expect((screen.getByTestId('cancel-btn') as HTMLButtonElement).disabled).toBe(false)
+  })
+
   it('shows confirmation modal when rootDir does not exist', async () => {
     mockAuthFetch.mockImplementation(async (url: string) => {
       if (url.includes('/api/workspace/config/validate')) {

--- a/web/src/components/settings/ProjectSettingsModal.tsx
+++ b/web/src/components/settings/ProjectSettingsModal.tsx
@@ -9,7 +9,7 @@ import { useMcpStore } from '../../stores/mcp'
 import { mcpStatusColor, mcpStatusDot } from '../../lib/mcp-utils'
 import { wsClient } from '../../lib/ws'
 import { authFetch } from '../../lib/api'
-import { getRootDirBlockReason } from '@shared/workspace.js'
+import { formatRootDir, getRootDirBlockReason, suggestRootDirChild } from '@shared/workspace.js'
 
 interface ProjectSettingsModalProps {
   isOpen: boolean
@@ -185,9 +185,9 @@ export function ProjectSettingsModal({ isOpen, onClose, project }: ProjectSettin
     if (trimmedRootDir) {
       const blockReason = getRootDirBlockReason(trimmedRootDir)
       if (blockReason === 'exact') {
-        const displayPath = trimmedRootDir.replace(/\/+$/, '') || '/'
+        const displayPath = formatRootDir(trimmedRootDir)
         setSaveError(
-          `Cannot use "${displayPath}" directly as workspace root. Use a subdirectory like "${displayPath}/${project.name}" instead.`,
+          `Cannot use "${displayPath}" directly as workspace root. Use a subdirectory like "${suggestRootDirChild(trimmedRootDir, project.name)}" instead.`,
         )
         return
       }

--- a/web/src/components/settings/ProjectSettingsModal.tsx
+++ b/web/src/components/settings/ProjectSettingsModal.tsx
@@ -228,7 +228,6 @@ export function ProjectSettingsModal({ isOpen, onClose, project }: ProjectSettin
       if (!res.ok) {
         const data = await res.json().catch(() => ({}))
         setSaveError(data?.error ?? 'Failed to validate workspace root directory')
-        setSaving(false)
         return
       }
 
@@ -236,14 +235,12 @@ export function ProjectSettingsModal({ isOpen, onClose, project }: ProjectSettin
 
       if (!data.exists) {
         setResolvedPath(data.resolvedPath)
-        setSaving(false)
         setShowCreateDirModal(true)
         return
       }
 
       if (data.workspaces && data.workspaces.length > 0) {
         setPendingWorkspaces(data.workspaces)
-        setSaving(false)
         setShowMigrationWarning(true)
         return
       }
@@ -252,6 +249,7 @@ export function ProjectSettingsModal({ isOpen, onClose, project }: ProjectSettin
       await persistSettings()
     } catch (err) {
       setSaveError(err instanceof Error ? err.message : 'Failed to validate settings')
+    } finally {
       setSaving(false)
     }
   }


### PR DESCRIPTION
<!-- PR title: fix(windows): workspace root validation, workspace detection, and a stuck save flag -->
<!-- Base: develop · Branch: fix/windows-workspace-roots (4 commits) -->
<!-- Copy this whole file into the PR description. HTML comments do not render on GitHub. -->

## Summary

Four Windows fixes around workspace root directories, all reproduced on Windows 11 / Node 24.

The one that matters most: `C:\` was accepted as a workspace root directory. Once set, every top-level folder of the drive is listed as a workspace of the project in the workspace switcher, and each one carries a delete button that runs `fs.rm(..., { recursive: true, force: true })` — `D:\github` was one confirmation away from being wiped. `/` and `/home` have been blocked for exactly this reason since the beginning; Windows simply had no equivalent.

The other three: dev server config was never found from a workspace, re-saving an unchanged root directory popped a phantom "workspaces will be left behind" warning, and a successful save left the settings modal permanently disabled.

## What Changed

**Modified — product**

- `src/shared/workspace.ts` — `getRootDirBlockReason` now strips trailing separators of either kind and rejects a bare drive root (`C:\`, `d:/`, `Z:`). Adds `formatRootDir` / `suggestRootDirChild` so every message about a blocked root is built the same way.
- `src/server/routes/workspace-config.ts` — new `isSameDir` for the "did the root actually change?" check: `win32.normalize` + lowercase on win32, trailing-`/` strip elsewhere. Display paths and the suggested subdirectory now come from the shared helpers.
- `src/server/dev-server/manager.ts` — the workspace→project-root config fallback matches a `workspaces` path segment with either separator instead of the literal substring `/workspaces/`.
- `web/src/components/settings/ProjectSettingsModal.tsx` — `handleSave` resets `saving` in a `finally`, like its two sibling handlers already did; uses the shared helpers for its error message.

**Added — tests**

- `src/shared/workspace.test.ts` — new file (the module had none): drive roots, posix roots, virtual filesystems, trailing separators, and both display helpers.
- `src/server/dev-server/manager.test.ts` — a backslash workspace path falls back to the project root.
- `src/server/routes/workspace-config.test.ts` — a trailing separator is not a root change (both platforms), and neither is a case/separator difference (win32 only, `it.skipIf` elsewhere).
- `web/src/components/settings/ProjectSettingsModal.test.tsx` — the form stays usable after a successful root directory save.

## Motivation & Context

Continuing the Windows review series (#196, #206, #208, #209). This is the "workspace roots and detection" batch. Each item was reproduced on a real Windows 11 machine before being fixed.

**1. A whole drive could be set as the workspace root.** `getRootDirBlockReason` normalized with `path.replace(/\/+$/, '')` — backslashes untouched — so `C:\` never matched anything in `BLOCKED_EXACT_PATHS`, and that list is posix-only anyway. Consequences downstream:

```ts
// src/server/git/workspace.ts — listWorkspaces()
const entries = await readdir(dir, { withFileTypes: true })
for (const entry of entries) if (entry.isDirectory()) workspaces.push({ path, name: entry.name, branch })

// src/server/git/workspace.ts — deleteWorkspace()
await rm(resolve(dir, name), { recursive: true, force: true, maxRetries: 3 })
```

No `.git` filter, no OpenFox marker: with `rootDir = D:\`, the workspace switcher lists `github`, `tmp`, `Program Files`, and the delete button on any of them removes the folder.

**2. Dev server config was never found from a workspace.** `loadConfig` falls back to the project root by locating `/workspaces/` in the path. Windows workspaces live under `%LOCALAPPDATA%\openfox\workspaces\<project>\<name>`, so the fallback never fired. Verified against real files, before and after:

```
D:\tmp\ofx-b3\proj\workspaces\feat  ->  null                           (develop)
D:\tmp\ofx-b3\proj\workspaces\feat  ->  {"command":"npm run dev",...}  (this branch)
D:/tmp/ofx-b3/proj/workspaces/feat  ->  {"command":"npm run dev",...}  (unchanged on posix)
```

**3. Phantom workspace migration warning.** Saving `D:\tmp\ws` then `d:/tmp/ws` — the same directory — compared unequal, so the orphan scan ran on the directory that had not moved and the UI announced a migration.

**4. Settings modal stuck on "Saving".** After a successful root directory change, reopening project settings showed every field disabled and the footer stuck. The modal stays mounted after closing (`Sidebar.tsx` renders it with `isOpen={false}`), so the flag survived into the next open; only a page reload recovered. Found while testing fix 3, whose new direct-persist path makes it easy to hit.

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing

```bash
npx vitest run src/shared/workspace.test.ts                              # 10 passed
npx vitest run src/server/dev-server/manager.test.ts                     # 24 passed
npx vitest run src/server/routes/workspace-config.test.ts                # 23 passed, 3 pre-existing failures
npx vitest run web/src/components/settings/ProjectSettingsModal.test.tsx # 16 passed
npm run typecheck                                                        # server + web + e2e clean
npm run test:unit                                                        # see counts below
```

Each new test was verified to fail without its fix (`git stash` on the source file, re-run, restore).

**Full unit suite on Windows** (`npm run test:unit`), this branch vs `develop`:

```
develop        Test Files  12 failed | 248 passed | 2 skipped (262)   Tests  3318 passed
this branch    Test Files  12 failed | 249 passed | 2 skipped (263)   Tests  3332 passed
```

The set of failing files is identical on both — `install`, `git/workspace`, `auto-update`, `workspace-config`, `manager.execution-context`, `edit-corruption`, `encoding-integration`, `file-tracking.integration`, `path-security`, `shell-streaming`, `tool-helpers`, `Markdown`. None of them except `workspace-config` belongs to this diff. The failed *test* count moves between runs (33-39 across repeated runs on both branches) — several of these suites are flaky on Windows, independently of this change. The numbers above are one representative run each; the +1 file and +14 tests on this branch are the ones added here.

**Pre-existing failures in a file this PR touches.** `workspace-config.test.ts` fails the same 3 tests on this branch and on the base commit `9ce85c16` — checked by stashing the whole branch:

- `returns 400 for non-writable existing directory` and `rejects non-writable existing directory` — `chmod` is a no-op on Windows, so the directory stays writable and no 400 is returned.
- `detects default global dir orphans when projectName provided` — the test sets `XDG_DATA_HOME`, which `getGlobalDataDir()` only reads on non-Windows platforms.

None of them touch the code changed here.

**Manual testing (Windows 11, Node 24, dev server on 10469).** Fix 2 verified against real files (output above). Fix 4 reproduced live — the settings modal locked itself after a root directory save and stayed locked across reopens — and the regression test fails without the `finally`.

**Not tested on Unix.** Every behavior change is either gated on win32 (`isSameDir`) or a strict superset of the previous posix behavior (separator stripping, `workspaces` segment matching); the posix paths in the test suite cover the no-op direction, and I am deferring to CI for the rest.

## Breaking Changes

None. `C:\` as a workspace root was never a working configuration — it produced a workspace list covering the whole drive. Posix root directories, including relative ones, behave exactly as before, with one deliberate exception noted below.

- [ ] This PR introduces breaking changes

## Related Issues

Part of the Windows compatibility series: #196 (server misc), #206 (web path display), #208 (npm scripts + Windows CI), #209 (path security). 

Two limitations left in on purpose, both mentioned in the commit messages:

- **The drive-root check is not platform-gated.** `src/shared/workspace.ts` also runs in the browser, which cannot know the server's platform. The cost on posix is that a *relative* directory literally named `c:` is now rejected by the client (the server would have resolved it under the project).
- **`isSameDir` is win32-only.** macOS on a case-insensitive APFS volume has the same class of bug, but APFS can be mounted case-sensitive — lowercasing there would trade a visible false positive (one extra dialog) for a silent false negative (orphaned workspaces never reported). That call belongs to a macOS-scoped change.

## AI-Enhanced Development

- **AI Models:** Opus 5 .

## Cache Impact

- **No** — no system prompts, tool definitions, skills, or agent context are touched. The diff is limited to path normalization, one Express route, one dev-server helper, and one React modal.

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed

**Key files to review:** `src/shared/workspace.ts` · `src/server/routes/workspace-config.ts` · `web/src/components/settings/ProjectSettingsModal.tsx` · `src/server/dev-server/manager.ts`

---

<details>
<summary><b>Technical investigation</b> — symptoms, root cause, and fix details</summary>

### Symptoms

```
1. Project settings → Workspace Root Directory → "C:\" → Save → accepted.
   Workspace switcher then lists every top-level folder of C:, each with a delete button.

2. Session opened in a workspace → Dev Server footer shows no configuration,
   although .openfox/dev.json exists at the project root.

3. Same directory re-typed as "d:/tmp/ws" instead of "D:\tmp\ws" → Save →
   "workspaces found in the previous location" dialog, listing workspaces that never moved.

4. After a successful root directory save → reopen project settings →
   every field disabled, footer stuck on "Saving" until the page is reloaded.
```

### Cause

**1 — `src/shared/workspace.ts`, `getRootDirBlockReason`**

```ts
const normalized = path.replace(/\/+$/, '') || '/'   // backslashes survive
if (exactPaths.includes(normalized)) return 'exact'  // posix-only list
```

`C:\` normalizes to `C:\`, matches nothing, and is accepted. Fixed by stripping `[\\/]+$` and testing the result against `/^[a-zA-Z]:$/`. The check is deliberately not gated on `process.platform`: this module is imported by the web client, where no server platform is known.

**2 — `src/server/dev-server/manager.ts`, `loadConfig`**

```ts
const wsIdx = workdir.indexOf('/workspaces/')   // never matches a Windows path
```

Windows workspaces live under `%LOCALAPPDATA%\openfox\workspaces\<project>\<name>`. Replaced with `workdir.search(/[\\/]workspaces[\\/]/)`.

**3 — `src/server/routes/workspace-config.ts`, `POST /config/validate`**

```ts
if (previousRootDir && previousRootDir !== resolvedPath) {  // raw string compare
  const orphans = await findOrphanedWorkspaces(previousRootDir)
```

On Windows, separators are interchangeable and the filesystem is case-insensitive, so a directory compares unequal to itself. `isSameDir` normalizes with `win32.normalize` + lowercase on win32 only. `win32.` is explicit rather than the bare `node:path` export, which resolves against the *host* platform — the exact trap that turned #209 red on the Linux runner.

**4 — `web/src/components/settings/ProjectSettingsModal.tsx`, `handleSave`**

```ts
      setSaveError(null)
      await persistSettings()      // success path exits the try without clearing `saving`
    } catch (err) {
      setSaveError(...)
      setSaving(false)             // only the failure path reset it
    }
```

`handleCreateDirectory` and `handleConfirmMigration` both already used `finally { setSaving(false) }`; `handleSave` was the odd one out. Since the modal is kept mounted after close, the stuck flag disabled the form for the rest of the session.

</details>
