### PR TITLE
fix(test): retry recursive rm on Windows to stop suite flakiness

### DIFF
--- a/src/server/tools/edit-corruption.test.ts
+++ b/src/server/tools/edit-corruption.test.ts
@@ -60,7 +60,9 @@ describe('edit_file corruption bug reproduction', () => {
 
   afterEach(async () => {
     closeDatabase()
-    await rm(testDir, { recursive: true, force: true })
+    // Windows keeps the directory in "pending delete" after the files are
+    // unlinked, so rmdir returns EBUSY; fs.rm does not retry unless asked.
+    await rm(testDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 })
   })
 
   it('reproduces the exact edit sequence from session f5b04e33 that caused silent corruption', async () => {

--- a/src/server/tools/encoding-integration.test.ts
+++ b/src/server/tools/encoding-integration.test.ts
@@ -59,7 +59,9 @@ describe('encoding integration', () => {
 
   afterEach(async () => {
     closeDatabase()
-    await rm(testDir, { recursive: true, force: true })
+    // Windows keeps the directory in "pending delete" after the files are
+    // unlinked, so rmdir returns EBUSY; fs.rm does not retry unless asked.
+    await rm(testDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 })
   })
 
   describe('read_file encoding detection', () => {

--- a/src/server/tools/file-tracking.integration.test.ts
+++ b/src/server/tools/file-tracking.integration.test.ts
@@ -64,7 +64,9 @@ describe('file tracking integration', () => {
 
   afterEach(async () => {
     closeDatabase()
-    await rm(testDir, { recursive: true, force: true })
+    // Windows keeps the directory in "pending delete" after the files are
+    // unlinked, so rmdir returns EBUSY; fs.rm does not retry unless asked.
+    await rm(testDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 })
   })
 
   describe('write_file requires read first', () => {


### PR DESCRIPTION
## Summary

On Windows the unit suite is not just red, it is *non-deterministic*: three consecutive `npm run test:unit` runs produce a different set of failing tests every time, which makes it impossible to tell a real regression from noise. 

The whole of that instability comes from a single mechanism — `fs.rm` defaults to `maxRetries: 0`, and on Windows a directory stays in "pending delete" after its files are unlinked, so `rmdir` returns `EBUSY` inside `afterEach`. Vitest attributes a hook failure to the test that just finished, so a random subset of tests goes red on each run. 

This PR adds retries to the three integration suites that create and tear down a temp workdir.

```
before   36 / 37 / 38 failures across 12 files   (list varies run to run)
after    14 / 14 / 14 failures across  9 files   (byte-identical every run)
```

The 14 remaining failures are pre-existing, deterministic Windows-isms; none of them live in the files this PR touches. 
They will be addressed in a follow-up PR.

## What Changed

**Modified (tests only, no production code):**

- `src/server/tools/encoding-integration.test.ts` — the `afterEach` teardown `rm(testDir, …)` now passes `maxRetries: 10, retryDelay: 50`.
- `src/server/tools/file-tracking.integration.test.ts` — same.
- `src/server/tools/edit-corruption.test.ts` — same.

Three lines changed, one per suite. Each carries a two-line comment explaining the Windows behaviour, so the options do not read as cargo cult to the next reader.

Two of these suites also call `rm` in `beforeEach`, and those are deliberately left alone: `testDir` is named `openfox-…-${Date.now()}` on the line above, so the directory cannot exist and `force: true` makes the call a no-op. Adding retries there would be unreachable code.

## Motivation & Context

Every one of these suites tears down its temp workdir the same way, and on Windows the teardown throws:

```
Error: EBUSY: resource busy or locked, rmdir 'C:\Users\...\AppData\Local\Temp\openfox-encoding-test-1785937232547'
Serialized Error: { errno: -4082, code: 'EBUSY', syscall: 'rmdir', path: '...' }
```

Because the throw happens in the hook rather than the test body, the failure is charged to whichever test just completed — so the red set shifts on every run, and the failure message points at encoding or file-tracking assertions that are in fact passing. That is what made this look like several independent flaky suites for weeks; it is one mechanism.

This is not a new remedy for this codebase: `src/server/git/workspace.ts:338` already ships `rm(wsPath, { recursive: true, force: true, maxRetries: 3 })` in production code for exactly this reason. This PR applies the same treatment to the test teardowns that need it.

On Linux and macOS the change is a strict no-op: Node only retries on `EBUSY`, `ENOTEMPTY`, `EPERM` and `ENOTDIR`, none of which occur on those platforms for this teardown.

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing

Machine: Windows 11 Pro (26200), Node 24.18.0.

Targeted — the three modified files, three consecutive runs:

```
npx vitest run src/server/tools/encoding-integration.test.ts \
               src/server/tools/file-tracking.integration.test.ts \
               src/server/tools/edit-corruption.test.ts

before   14 / 14 failed in encoding-integration alone (100% reproducible in isolation)
after    28 / 28 passed, 3 runs out of 3
```

Full suite — `npm run test:unit`, three consecutive runs, compared assertion by assertion via `--reporter=json` rather than by failure count:

```
before   36 / 37 / 38 failures, 12 files, set differs between runs
after    14 / 14 / 14 failures,  9 files, set identical between runs
```

`npx tsc --noEmit` and `npx eslint` on the three files: clean.

Linux and macOS: not run locally. The change is a no-op there by construction (see above) and CI covers it.

Honest note on the remaining 14: `cli/install` (asserts a Unix launcher), `git/workspace` ×4 (expects POSIX quoting), `routes/auto-update`, `routes/workspace-config` ×3 (`chmod` is a no-op on win32, `XDG_DATA_HOME` is not the win32 branch), `session/manager.execution-context` (hardcoded `/tmp/...` path), `tools/path-security` (a `describe` block missing its platform pin), `tools/shell-streaming` (`tail -2` obsolete syntax), `tools/tool-helpers` (`resolve()` prepends a drive letter), `web Markdown` (30s timeout under parallel load). All pre-existing on `develop`, none in the files this PR touches, all deterministic now that the `EBUSY` noise is gone.

## Breaking Changes

None. Test-only change; the added options are ignored on platforms that never raise the retried error codes.

- [ ] This PR introduces breaking changes

## Related Issues

None open that I am aware of. 

This is the first of three planned changes to make the suite trustworthy on Windows: 
(1) this PR, removing the non-determinism; 
(2) the 12 remaining deterministic test-only Windows-isms listed above; 
(3) adding `npm run test:unit` to the existing `windows-latest` job in `.github/workflows/pr.yml`, which today runs only `typecheck` and `build` — deliberately, because the suite was red. (3) only makes sense once (1) and (2) land.

Side benefit worth flagging: the `pre-commit` hook runs `npm test`, so Windows contributors currently have to commit with `--no-verify`. After (1) and (2) the hook works again.

## AI-Enhanced Development

- **AI Models:** Opus 5 .

_No AI used? Enter 'none'_

## Cache Impact

- **No** — the diff touches three `*.test.ts` teardown hooks only. No system prompt, tool definition, skill, or context-building code is involved.

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed

No new test is added: this PR repairs existing tests rather than covering new behaviour, and the proof is the reproducible before/after above. A test that asserts "the teardown does not throw on Windows" would only restate the fix.

**Key files to review:** `src/server/tools/encoding-integration.test.ts`, `src/server/tools/file-tracking.integration.test.ts`, `src/server/tools/edit-corruption.test.ts`

---

<details>
<summary><b>Technical investigation</b> — symptoms, root cause, and fix details</summary>

### Symptoms

Three `npm run test:unit` runs on `develop` @ `ce80eaab`, diffed assertion by assertion. The failing *file* list was stable at 12; the failing *test* list was not. All of the variance was confined to two files:

```
in run1 not in run2:
  encoding-integration  ::  write_file encoding support writes ISO-8859-1 when encoding is specified
  encoding-integration  ::  write_file encoding support writes UTF-8 by default
  encoding-integration  ::  write_file encoding support writes windows-1252 when encoding is specified

in run2 not in run1:
  encoding-integration      ::  read_file encoding detection detects UTF-16 with BOM
  encoding-integration      ::  write_file encoding support writes UTF-16 LE when encoding is specified
  file-tracking.integration ::  edit_file requires read first rejects editing file that was not read
  file-tracking.integration ::  write_file requires read first allows multiple writes after single read
```

Every one of those failures carried the same message, and none of them related to the assertion named in the test:

```
Error: EBUSY: resource busy or locked, rmdir 'C:\Users\...\AppData\Local\Temp\openfox-encoding-test-1785937232547'
```

### Cause

1. **`fs.rm` does not retry by default.** `maxRetries` is `0` unless set. Node documents `EBUSY`/`ENOTEMPTY`/`EPERM`/`ENOTDIR` as retryable precisely because Windows raises them transiently.
2. **Windows defers directory deletion.** Once the files inside `testDir` are unlinked, the directory remains in a pending-delete state until the last handle is released — antivirus and the search indexer routinely hold one for a few dozen milliseconds. `rmdir` in that window returns `EBUSY`.
3. **The throw lands in `afterEach`, not in a test.** Vitest charges a failing teardown hook to the test that just finished. Which test that is depends on scheduling, so the red set is effectively random per run — while the underlying condition is 100% reproducible (running `encoding-integration.test.ts` alone fails 14/14).
4. **Fix.** `maxRetries: 10, retryDelay: 50` gives the OS up to 500 ms to release the handle. Measured cost: roughly +0.8 s on `encoding-integration.test.ts`, and only on Windows — on other platforms the first attempt always succeeds and no delay is incurred.

</details>
