### PR TITLE
fix(test): make the unit suite platform-agnostic on Windows

### DIFF
--- a/src/cli/install.test.ts
+++ b/src/cli/install.test.ts
@@ -34,7 +34,12 @@ describe('persistent CLI installation', () => {
 
     const result = await checkInstall(env)
     expect(result.launcherPersistent).toBe(true)
-    expect(result.directoryInPath).toBe(true)
+    // The POSIX PATH delimiter is ":", which also appears in the drive letter of
+    // the Windows temp directory this test writes to, so the entry never matches
+    // there. The launcher itself is still installed and verified above.
+    if (process.platform !== 'win32') {
+      expect(result.directoryInPath).toBe(true)
+    }
   })
 
   it('prints the exact PATH instruction without editing shell files', async () => {

--- a/src/server/git/workspace.test.ts
+++ b/src/server/git/workspace.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { resolve } from 'node:path'
+import { resolve, sep } from 'node:path'
 
 import {
   getGitBranch,
@@ -414,8 +414,11 @@ describe('deleteWorkspace', () => {
     // fs.rm takes the path as plain data — shell metacharacters are inert
     await deleteWorkspace(PROJECT_NAME, maliciousName, CWD)
 
+    // deleteWorkspace runs the name through resolve(), which rewrites "/" to the
+    // native separator; the metacharacters themselves must survive untouched.
+    const inertName = maliciousName.split('/').join(sep)
     expect(rm).toHaveBeenCalledTimes(1)
-    expect(rm).toHaveBeenCalledWith(expect.stringContaining(maliciousName), {
+    expect(rm).toHaveBeenCalledWith(expect.stringContaining(inertName), {
       recursive: true,
       force: true,
       maxRetries: 3,

--- a/src/server/routes/workspace-config.test.ts
+++ b/src/server/routes/workspace-config.test.ts
@@ -57,6 +57,9 @@ beforeEach(() => {
   mockProjectRecords.clear()
 })
 
+const IS_WIN32 = process.platform === 'win32'
+const IS_DARWIN = process.platform === 'darwin'
+
 interface ValidateResponse {
   exists: boolean
   resolvedPath: string
@@ -209,7 +212,9 @@ describe('POST /api/workspace/config/validate', () => {
     expect(body.error).toMatch(/Cannot use paths under/i)
   })
 
-  it('returns 400 for non-writable existing directory', async () => {
+  // POSIX-only: chmod is a no-op on directories under win32, so the non-writable
+  // state this asserts cannot be produced there.
+  it.skipIf(IS_WIN32)('returns 400 for non-writable existing directory', async () => {
     const restrictedPath = join(testDir, 'restricted')
     await mkdir(restrictedPath, { recursive: true })
     // Remove write permissions to simulate non-writable directory
@@ -344,9 +349,13 @@ describe('POST /api/workspace/config/validate', () => {
       expect(body.workspaces).toEqual([])
     })
 
-    it('detects default global dir orphans when projectName provided', async () => {
-      const origXdg = process.env['XDG_DATA_HOME']
-      process.env['XDG_DATA_HOME'] = testDir
+    // getGlobalDataDir() reads a different env var per platform (src/cli/paths.ts):
+    // XDG_DATA_HOME on Linux, LOCALAPPDATA on Windows. macOS derives the path from
+    // the home directory with no env override, so it cannot be redirected here.
+    it.skipIf(IS_DARWIN)('detects default global dir orphans when projectName provided', async () => {
+      const dataDirEnv = IS_WIN32 ? 'LOCALAPPDATA' : 'XDG_DATA_HOME'
+      const origXdg = process.env[dataDirEnv]
+      process.env[dataDirEnv] = testDir
       try {
         const defaultDir = join(testDir, 'openfox', 'workspaces', 'my-project')
         const ws1 = join(defaultDir, 'fix-bug')
@@ -371,8 +380,8 @@ describe('POST /api/workspace/config/validate', () => {
         expect(body.workspaces!.length).toBe(1)
         expect(body.workspaces![0]!.name).toBe('fix-bug')
       } finally {
-        if (origXdg !== undefined) process.env['XDG_DATA_HOME'] = origXdg
-        else delete process.env['XDG_DATA_HOME']
+        if (origXdg !== undefined) process.env[dataDirEnv] = origXdg
+        else delete process.env[dataDirEnv]
       }
     })
 
@@ -480,7 +489,8 @@ describe('POST /api/workspace/config (existing endpoint)', () => {
     expect(body.error).toMatch(/Cannot use paths under/i)
   })
 
-  it('rejects non-writable existing directory', async () => {
+  // POSIX-only: see the matching /validate test above.
+  it.skipIf(IS_WIN32)('rejects non-writable existing directory', async () => {
     const restrictedPath = join(testDir, 'restricted-save')
     await mkdir(restrictedPath, { recursive: true })
     const { chmod } = await import('node:fs/promises')

--- a/src/server/session/manager.execution-context.test.ts
+++ b/src/server/session/manager.execution-context.test.ts
@@ -15,7 +15,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { mkdtemp, rm } from 'node:fs/promises'
-import { join } from 'node:path'
+import { join, resolve } from 'node:path'
 import { tmpdir } from 'node:os'
 
 const {
@@ -693,7 +693,9 @@ describe('SessionManager.switchWorkspace – execution context integrity (issue 
         expect(workspaceReminders.length).toBeGreaterThan(0)
         const reminder = workspaceReminders[workspaceReminders.length - 1]!
         expect(reminder.content).toContain('feature-x')
-        expect(reminder.content).toContain('/tmp/openfox-workspaces/feature-x')
+        // switchWorkspace resolves the path (manager.ts), so the reminder carries
+        // the native form — on Windows that is a backslash path with a drive.
+        expect(reminder.content).toContain(resolve('/tmp/openfox-workspaces', 'feature-x'))
         expect(reminder.content).toMatch(/branch\s+"feat-x"/)
         expect(reminder.content).not.toContain('requested-branch')
 

--- a/src/server/tools/path-security.test.ts
+++ b/src/server/tools/path-security.test.ts
@@ -1971,6 +1971,13 @@ describe('extractDangerousPatterns — Windows equivalents', () => {
 })
 
 describe('extractDangerousPatterns — Unix scope', () => {
+  // Without this pin the block runs on the host platform, so it only asserts
+  // "Unix scope" when the host happens to be Unix. The module-level afterEach
+  // restores the real platform.
+  beforeEach(() => {
+    mockPlatform('linux')
+  })
+
   it('does not flag Windows commands on Unix', () => {
     expect(extractDangerousPatterns('rd /s /q C:\\projet')).toEqual([])
     expect(extractDangerousPatterns('format D:')).toEqual([])

--- a/src/server/tools/shell-streaming.test.ts
+++ b/src/server/tools/shell-streaming.test.ts
@@ -5,6 +5,8 @@ import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
+const IS_WIN32 = process.platform === 'win32'
+
 describe('shell tool streaming', () => {
   let tempDir: string
   let context: ToolContext
@@ -330,7 +332,11 @@ for i in a b c d e f g h i j; do echo "$i"; done
       expect(result.output).toContain('second')
     })
 
-    it('keeps every section when multiple ;-separated commands have their own tails', async () => {
+    // POSIX-only: `;` is not a statement separator in cmd.exe, so tail receives
+    // a literal "-2;" argument and rejects it ("option used in invalid context").
+    // The behaviour under test is stripTailPipe's handling of `;`, which is a
+    // POSIX shell construct.
+    it.skipIf(IS_WIN32)('keeps every section when multiple ;-separated commands have their own tails', async () => {
       const result = await runCommandTool.execute(
         {
           command: 'printf "a1\\na2\\na3\\na4\\na5\\n" | tail -2; echo "===MID==="; printf "b1\\nb2\\nb3\\n" | tail -1',

--- a/src/server/tools/tool-helpers.test.ts
+++ b/src/server/tools/tool-helpers.test.ts
@@ -80,9 +80,10 @@ describe('createTool', () => {
     await tool.execute({ path: 'src/file.ts' }, mockContext)
     expect(resolvedPath).toBe(resolve('/test/workdir', 'src/file.ts'))
 
-    // Absolute path
+    // Absolute path: bypasses the workdir. Resolved rather than compared
+    // literally because on Windows an absolute POSIX path gains the cwd drive.
     await tool.execute({ path: '/absolute/path.ts' }, mockContext)
-    expect(resolvedPath).toBe('/absolute/path.ts')
+    expect(resolvedPath).toBe(resolve('/absolute/path.ts'))
   })
 
   it('provides success helper', async () => {

--- a/web/src/components/shared/Markdown.test.tsx
+++ b/web/src/components/shared/Markdown.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 import { describe, it, expect } from 'vitest'
-import { Markdown, getMarkdownCacheBytesForTest } from './Markdown'
+import { Markdown, getMarkdownCacheBytesForTest, setMarkdownCacheMaxBytesForTest } from './Markdown'
 import { renderToString } from 'react-dom/server'
 
 describe('Markdown', () => {
@@ -170,20 +170,28 @@ describe('Markdown', () => {
     })
 
     it('evicts large cached entries so the byte budget is not exceeded', () => {
-      // ~30 entries of ~800KB each would blow past the 20MB budget — the
-      // byte-bounded eviction must kick in. Keep the payloads small enough
-      // that the parse itself stays fast for CI.
-      const big = `# Heading\n\n${'x'.repeat(800_000)}`
-      for (let i = 0; i < 30; i++) {
-        renderToString(<Markdown content={`${big} ${i}`} />)
+      // Shrink the budget instead of feeding it 24MB: eviction behaves the same
+      // at any threshold, and the content must stay markdown (the plain-text
+      // fast path never reaches the cache, so plain filler would prove nothing).
+      const budget = 200_000
+      setMarkdownCacheMaxBytesForTest(budget)
+      try {
+        // 30 x ~20KB = ~600KB of keys, well past the shrunk budget.
+        const big = `# Heading\n\n${'x'.repeat(20_000)}`
+        for (let i = 0; i < 30; i++) {
+          renderToString(<Markdown content={`${big} ${i}`} />)
+        }
+        // Bounded, and actually filled — a zero here would mean the renders
+        // bypassed the cache and the assertion above proved nothing.
+        expect(getMarkdownCacheBytesForTest()).toBeGreaterThan(0)
+        expect(getMarkdownCacheBytesForTest()).toBeLessThanOrEqual(budget)
+        // And the cache still works for fresh content
+        const html = renderToString(<Markdown content={`${big} fresh`} />)
+        expect(html).toContain('Heading')
+      } finally {
+        setMarkdownCacheMaxBytesForTest()
       }
-      // The byte budget caps total key bytes — verify it stayed bounded
-      // (30 × ~800KB = 24MB would exceed 20MB without eviction).
-      expect(getMarkdownCacheBytesForTest()).toBeLessThanOrEqual(20 * 1024 * 1024)
-      // And the cache still works for fresh content
-      const html = renderToString(<Markdown content={`${big} fresh`} />)
-      expect(html).toContain('Heading')
-    }, 30_000)
+    })
   })
 
   describe('markdown edge cases (full parser routing)', () => {

--- a/web/src/components/shared/Markdown.tsx
+++ b/web/src/components/shared/Markdown.tsx
@@ -26,6 +26,7 @@ const SKIP_HIGHLIGHT_THRESHOLD = 5000
 const markdownRenderCache = new Map<string, React.ReactNode>()
 const MARKDOWN_CACHE_MAX = 100
 const MARKDOWN_CACHE_MAX_BYTES = 20 * 1024 * 1024
+let markdownCacheMaxBytes = MARKDOWN_CACHE_MAX_BYTES
 let markdownCacheBytes = 0
 
 // Exposed for tests: verifies the byte-bounded eviction without parsing tens
@@ -34,10 +35,17 @@ export function getMarkdownCacheBytesForTest(): number {
   return markdownCacheBytes
 }
 
+// Exposed for tests: shrinking the budget is what lets the eviction be proven
+// with a few hundred KB instead of the 24MB the real budget would demand.
+// Call with no argument to restore the production value.
+export function setMarkdownCacheMaxBytesForTest(bytes = MARKDOWN_CACHE_MAX_BYTES): void {
+  markdownCacheMaxBytes = bytes
+}
+
 function cacheMarkdown(key: string, node: React.ReactNode): React.ReactNode {
   markdownRenderCache.set(key, node)
   markdownCacheBytes += key.length
-  while (markdownRenderCache.size > MARKDOWN_CACHE_MAX || markdownCacheBytes > MARKDOWN_CACHE_MAX_BYTES) {
+  while (markdownRenderCache.size > MARKDOWN_CACHE_MAX || markdownCacheBytes > markdownCacheMaxBytes) {
     const firstKey = markdownRenderCache.keys().next().value
     if (firstKey === undefined) break
     markdownRenderCache.delete(firstKey)


### PR DESCRIPTION
## Summary

Thirteen unit tests asserted POSIX-only behaviour and failed on Windows even though the production code they cover is correct. 
Ten are fixed so they run everywhere; three are skipped on win32 because the state they need cannot exist there.

```
before   14 failures across 9 files   (with #216  merged, which removes 25 EBUSY flakes)
after     1 failure  in  1 file       (routes/auto-update — left out on purpose, see Related Issues)
```

Combined with #216  (the `fs.rm` retry fix), three consecutive `npm run test:unit` runs on Windows now produce a single, identical failure.

## What Changed

| File | What was wrong | Treatment |
|---|---|---|
| `tools/tool-helpers.test.ts` | expected `/absolute/path.ts`, got `D:\absolute\path.ts` | compare against `resolve()` |
| `session/manager.execution-context.test.ts` | expected a hardcoded `/tmp/...` workspace path | compare against `resolve()` |
| `git/workspace.test.ts` (×4) | `resolve()` rewrites `/` in the workspace name to `\` | allow for `sep`, still assert the metacharacters survive |
| `routes/workspace-config.test.ts` | set `XDG_DATA_HOME`, one of the three branches in `getGlobalDataDir()` | use the host platform's variable — **now runs on Windows**, `skipIf(darwin)` where there is no override |
| `tools/path-security.test.ts` | `— Unix scope` block had no platform pin | pin `linux`, like its `— Windows equivalents` sibling |
| `cli/install.test.ts` | POSIX `PATH` delimiter `:` also appears in `C:\...` | gate only the PATH lookup, keep the launcher assertions |
| `routes/workspace-config.test.ts` (×2) | `chmod` cannot make a directory non-writable on win32 | `skipIf(win32)` |
| `tools/shell-streaming.test.ts` | `;` is not a statement separator in cmd.exe | `skipIf(win32)` |
| `shared/Markdown.test.tsx` | pushed 24MB through the parser, timed out under load | shrink the cache budget instead — 15.5s → 0.4s |

The only production change is six lines in `web/src/components/shared/Markdown.tsx`: a `setMarkdownCacheMaxBytesForTest()` next to the `getMarkdownCacheBytesForTest()` already exported there. Runtime behaviour and the 20MB budget are unchanged.

## Motivation & Context

Sorting these was the prerequisite for trusting the suite on Windows at all. Three are worth calling out because the test was weak on Linux too, not merely Windows-hostile:

- `path-security` — the `— Unix scope` block never pinned a platform, so on a Linux runner it passed for the wrong reason: it asserted the host's behaviour, not Unix behaviour.
- `workspace-config` — the orphan test only ever exercised the `XDG_DATA_HOME` branch of `getGlobalDataDir()` (`src/cli/paths.ts:35`). It now runs on Windows instead of failing there.
- `Markdown` — proving a 20MB eviction budget by feeding it 24MB was always going to be slow; the module's own comment says the test hook exists to avoid exactly that.

Where a skip was unavoidable the comment says what cannot be reproduced, not just which platform: `chmod` is a no-op on win32 directories, so the "non-writable directory" state those two tests need cannot be created at all.

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing

Windows 11 Pro (26200), Node 24.18.0.

```
the 8 modified test files      335 passed | 9 skipped (344)
full suite, 3 runs, with #<PR1> merged in    1 failure, identical each run
```

`tsc --noEmit` (server + web), `eslint src/ web/src/`, `npm run duplicate`: clean.

The Markdown fix is verified by mutation — disabling the eviction condition in `cacheMarkdown` turns the test red (`expected 600980 to be less than or equal to 200000`).

**Linux/macOS: not run locally.** Every change either compares against `resolve()`/`sep` (identity on POSIX), pins a platform the test already assumed, or gates on `win32`. The one I cannot verify by construction is the new `darwin` gate on the orphan test — on macOS `getGlobalDataDir()` returns `~/Library/Application Support/openfox` with no env override, so that test could not have passed there before this PR either.

**`npm run format` is unusable to check this PR on Windows.** With `core.autocrlf=true` prettier sees CRLF on disk and reports every file in the repo as non-conforming, untouched ones included. Verified instead against the content as git stores it (`tr -d '\r' | prettier --check --stdin-filepath`): all nine files conform.

## Breaking Changes

None.

- [ ] This PR introduces breaking changes

## Related Issues

Second of three steps toward a trustworthy Windows suite: #216 removed the non-determinism, this one removes the platform assumptions, and a third would add `npm run test:unit` to the existing `windows-latest` job in `pr.yml` (which today runs only `typecheck` and `build`).

Deliberately excluded — candidate product bugs, not test issues, each deserving its own investigation:

- `routes/auto-update.test.ts` — `?force=true` returns `Updated: 1.2.3` where `1.2.3` is expected. The last unit failure on Windows.
- `e2e/provider-plugins.test.ts` — auth flow returns `undefined` instead of `disconnected`. Stable across runs.
- `tools/shell-tail.ts` — `hasTopLevelStatementSeparator` only knows `;` and newline. Under cmd.exe the separator is `&`, so `a & b | tail -5` would have its tail stripped and re-applied over the combined output. Found while diagnosing the shell-streaming test.

## AI-Enhanced Development

- **AI Models:** Claude Opus 5.

## Cache Impact

- **No** — eight test files plus a test-only export. 

The markdown render cache is a client-side parse cache for already-rendered message content; its 20MB production budget is untouched.

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed

No new test is added — this PR repairs existing ones. 
Three end up stronger: `path-security` now pins the platform it claims to assert, `workspace-config` runs on Windows instead of failing, and `Markdown` now fails when eviction breaks.

**Key files to review:** `web/src/components/shared/Markdown.tsx` (the only production change), `src/server/routes/workspace-config.test.ts`, `src/server/tools/path-security.test.ts`

---

<details>
<summary><b>Why the obvious Markdown fix is wrong</b> — worth 60 seconds, it looks correct</summary>

The eviction test rendered 30 × 800KB of markdown to overflow a 20MB cache budget: 15.5s in isolation, and past its 30s timeout once the suite ran files in parallel. The shrunk-budget version takes 0.4s.

The tempting fix is to make the filler plain text so it skips the parser. It does not work: the plain-text fast path in `Markdown` returns its paragraph directly and never reaches `cacheMarkdown`, so nothing enters the cache. `getMarkdownCacheBytesForTest()` then returns 0, `toBeLessThanOrEqual(20MB)` passes vacuously, and the test is green while proving nothing. Measured, 30 × 800KB of filler:

```
plain-text filler  ->  cache bytes = 0
markdown filler    ->  cache bytes = 20,800,462     (24,000,000 without eviction)
```

I shipped that version before catching it, which is why the test now also asserts the byte count is greater than zero — that assertion is what makes the vacuous pass impossible to reintroduce silently.

The budget is the only other lever, hence the test-only setter. Eviction behaves identically at any threshold, so 30 × 20KB against a 200KB budget proves the same property for 1/40th of the parse cost.

</details>

<details>
<summary><b>Path normalization details</b> — the six failing assertions in three files</summary>

`resolve()` and `join()` return native paths, so production code that resolves before storing or logging yields backslashes on Windows, and an absolute POSIX input additionally gains the cwd drive:

```
resolve('/absolute/path.ts')                     ->  D:\absolute\path.ts
resolve('/tmp/openfox-workspaces', 'feature-x')  ->  D:\tmp\openfox-workspaces\feature-x
resolve(dir, '$HOME/test')                       ->  …\$HOME\test
```

All three tests compared against POSIX literals. The expectations now run through the same normalization, so each keeps asserting the property it cares about — that the workspace name travels as inert data, that the reminder carries the switched-to path — on every platform.

For the cmd.exe case, `;` is an ordinary character rather than a separator, so the whole line reaches `tail` as arguments:

```
> cmd /d /s /c "printf a1\na2\n | tail -2; echo MID"
tail: option used in invalid context -- 2
```

`stripTailPipe` correctly declines to strip a tail from a `;`-separated command, which is what the test verifies — but verifying it needs a shell where `;` means what the function assumes.

</details>
