### PR TITLE
fix(test): recognize the win32 npm invocation in the auto-update mock

### DIFF
--- a/src/server/routes/auto-update.test.ts
+++ b/src/server/routes/auto-update.test.ts
@@ -33,7 +33,9 @@ describe('Auto Update Routes', () => {
     mockSpawn.mockReset()
     // Default: npm view returns a version, openfox update succeeds
     mockSpawn.mockImplementation((cmd: unknown, args: unknown) => {
-      if (cmd === 'npm' && Array.isArray(args) && args[0] === 'view') {
+      // auto-update.ts spawns npm as a shell string on win32 (npm.cmd there,
+      // CVE-2024-27980) and as argv elsewhere — match both.
+      if (cmd === 'npm view openfox version' || (cmd === 'npm' && Array.isArray(args) && args[0] === 'view')) {
         return makeMockChild({ stdout: '1.2.3\n' })
       }
       // git fetch returns nothing


### PR DESCRIPTION
## Summary

`auto-update.ts:162` spawns npm two ways — a shell string on Windows (npm is npm.cmd there, CVE-2024-27980), argv everywhere else. 

The test's spawn mock only matched the argv form, so on Windows it fell through to its catch-all and returned `Updated: 1.2.3` — the stdout meant for `openfox update` — as the version.

One condition widened. Production code unchanged.

```diff
-      if (cmd === 'npm' && Array.isArray(args) && args[0] === 'view') {
+      if (cmd === 'npm view openfox version' || (cmd === 'npm' && Array.isArray(args) && args[0] === 'view')) {
```

```
AssertionError: expected 'Updated: 1.2.3' to be '1.2.3'
    at src/server/routes/auto-update.test.ts:119
```

Worth knowing: only `force=true` compares that value. The other three `/check` tests assert `typeof latest === 'string'` or compare the response to itself, so they passed on Windows the whole time on a value that was never a version.

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing

Windows 11 Pro, Node 24.18.0 — `1 failed | 8 passed` before, `9 passed` after, three consecutive runs. `tsc`, `eslint`, prettier clean.

Verified by mutation: changing the win32 command string in `auto-update.ts` turns the test red again, so the mock is coupled to the command actually issued rather than absorbing any change.

Linux/macOS not run locally — the added `||` branch matches a string those platforms never spawn, so their path through the mock is unchanged.

## Breaking Changes

None.

- [ ] This PR introduces breaking changes

## Related Issues

Last of three test-only fixes for the Windows unit suite, after #216 (`fs.rm` retries) and #217 (POSIX-only assertions). 

With all three in, `npm run test:unit` is green on Windows across repeated runs — which would let `npm run test:unit` join the existing `windows-latest` job in `pr.yml`, currently limited to `typecheck` and `build` because the suite was red.

Still open, unrelated to that job: `e2e/provider-plugins.test.ts` fails on Windows (`expected undefined to be 'disconnected'`). Not investigated.

## AI-Enhanced Development

- **AI Models:** Claude Opus 5.

## Cache Impact

- **No** — one test file.

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed

No new test — this repairs an existing mock. The two-line comment says why both spawn forms must be matched, so the next edit does not drop one.

**Key files to review:** `src/server/routes/auto-update.test.ts`
