### PR TITLE
fix(windows): unblock the pre-commit hooks and run the unit suite in CI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Check every text file out with LF, whatever core.autocrlf says. Prettier is
+# configured with the default endOfLine "lf", so on a Windows clone using the
+# git-for-windows default (core.autocrlf=true) `npm run format` would otherwise
+# flag every file in the repo and the pre-commit hook could never pass.
+* text=auto eol=lf

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -54,7 +54,7 @@ jobs:
 
   windows:
     runs-on: windows-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v7
@@ -62,8 +62,10 @@ jobs:
           node-version: '24'
           cache: 'npm'
       - run: npm ci
+      - run: cd web && npm ci
       - run: npm run typecheck
       - run: npm run build
+      - run: npm run test:unit
 
   ai-disclosure:
     runs-on: ubuntu-latest

--- a/.jscpd-server.json
+++ b/.jscpd-server.json
@@ -1,4 +1,4 @@
 {
   "threshold": 0,
-  "ignore": ["**/*.test.ts", "src/server/skills/defaults/**"]
+  "ignore": ["**/*.test.ts", "**/skills/defaults/**"]
 }

--- a/src/server/dev-server/inspect-proxy.test.ts
+++ b/src/server/dev-server/inspect-proxy.test.ts
@@ -471,6 +471,33 @@ describe('InspectProxy', () => {
     })
   })
 
+  describe('Port allocation', () => {
+    it('keeps the proxy port below 65536 when devServerPort + 1000 would overflow', async () => {
+      const targetPort = await createMockTarget((_req, res) => {
+        res.writeHead(200, { 'Content-Type': 'text/plain' })
+        res.end('ok')
+      })
+
+      // 65000 + 1000 exceeds the valid port range; net.listen() beyond 65535
+      // throws a synchronous RangeError, so an unbounded scan crashes here
+      // instead of binding. Ephemeral ports land in 49152-65535 on Windows,
+      // so any listen(0)-derived devServerPort above 64535 hits this in the wild.
+      const { port, cleanup } = await startInspectProxy(
+        `http://127.0.0.1:${targetPort}`,
+        mockSessionManager as any,
+        65000,
+      )
+      try {
+        expect(port).toBeLessThanOrEqual(65535)
+        const result = await httpGet('127.0.0.1', port, '/')
+        expect(result.status).toBe(200)
+        expect(result.body).toBe('ok')
+      } finally {
+        cleanup()
+      }
+    })
+  })
+
   describe('Error handling', () => {
     it('handles target server that closes connection prematurely', async () => {
       const targetPort = await createMockTarget((_req, res) => {

--- a/src/server/dev-server/inspect-proxy.ts
+++ b/src/server/dev-server/inspect-proxy.ts
@@ -36,11 +36,17 @@ interface ProxyInstance {
 const proxyPool = new Map<string, ProxyInstance>()
 let nextOffset = 0
 
+const PORT_SCAN_RANGE = 200
+
 async function getAvailablePort(proxyBase: number): Promise<number> {
-  for (let port = proxyBase; port < proxyBase + 200; port++) {
+  // net.listen() beyond 65535 throws a synchronous RangeError that tryBind's
+  // 'error' listener cannot catch, so keep the whole scan range below the
+  // limit (the same bound findFreePort applies in manager.ts).
+  const base = Math.min(proxyBase, 65535 - PORT_SCAN_RANGE)
+  for (let port = base; port < base + PORT_SCAN_RANGE; port++) {
     if (await tryBind(port)) return port
   }
-  return proxyBase + (nextOffset++ % 200)
+  return base + (nextOffset++ % PORT_SCAN_RANGE)
 }
 
 function tryBind(port: number): Promise<boolean> {

--- a/src/server/init-llm.test.ts
+++ b/src/server/init-llm.test.ts
@@ -53,10 +53,13 @@ describe('initLLM - model auto-detect respects defaultModelSelection', () => {
     return createServerHandle(config)
   }
 
+  // Each case needs its own config, so the server boot cannot be shared the way
+  // test-params.test.ts shares it. Booting one takes ~1.5s alone but 12-15s under
+  // full-suite parallel load on Windows, which sits right on the 15s testTimeout.
   it('overrides model with auto-detected when no defaultModelSelection is set', async () => {
     const handle = await createServer(testConfig())
     expect(handle.ctx.llmClient.getModel()).toBe('auto-detected-minimax-m3')
-  })
+  }, 30_000)
 
   it('preserves configured model when defaultModelSelection is set', async () => {
     const provider = makeProvider('test-provider', 'deepseek-v4-flash')
@@ -67,5 +70,5 @@ describe('initLLM - model auto-detect respects defaultModelSelection', () => {
       }),
     )
     expect(handle.ctx.llmClient.getModel()).toBe('deepseek-v4-flash')
-  })
+  }, 30_000)
 })

--- a/src/server/providers/test-params.test.ts
+++ b/src/server/providers/test-params.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest'
+import type { ServerHandle } from '../context.js'
 import type { LlmBackend } from '../../shared/types.js'
 
 const mockCreateChatCompletion = vi.fn()
@@ -30,14 +31,28 @@ function testConfig() {
 }
 
 describe('POST /api/providers/test-params', () => {
+  let handle: ServerHandle
+  let port: number
+
+  // Booting the server is by far the expensive part here, and every case wants
+  // the same config — only the module-level HTTP client mock varies. One shared
+  // server keeps the file well inside the timeout under full-suite parallel load.
+  // The explicit hook timeout matters: hooks default to 10s, below the 15s a boot
+  // used to get from testTimeout while it still ran inside a test body.
+  beforeAll(async () => {
+    const { createServerHandle } = await import('../index.js')
+    handle = await createServerHandle(testConfig())
+    ;({ port } = await handle.start(0))
+  }, 30_000)
+
+  afterAll(async () => {
+    // A failed boot leaves handle unset; ?. avoids burying the boot error
+    await handle?.close()
+  })
+
   beforeEach(() => {
     vi.clearAllMocks()
   })
-
-  async function createServer() {
-    const { createServerHandle } = await import('../index.js')
-    return createServerHandle(testConfig())
-  }
 
   it('should build params using the same pipeline as the agentic loop for thinking mode', async () => {
     mockCreateChatCompletion.mockResolvedValue({
@@ -47,38 +62,31 @@ describe('POST /api/providers/test-params', () => {
       raw: JSON.stringify({ id: 'test-id', choices: [{ message: { content: 'Hi' } }] }),
     })
 
-    const handle = await createServer()
-    const { port } = await handle.start(0)
+    const response = await fetch(`http://127.0.0.1:${port}/api/providers/test-params`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        url: 'http://localhost:8000',
+        model: 'test-model',
+        backend: 'vllm',
+        mode: 'thinking',
+        modelConfig: {
+          thinkingEnabled: true,
+          thinkingLevel: 'high',
+          thinkingQueryParams: JSON.stringify({ reasoning_effort: 'high' }),
+        },
+      }),
+    })
 
-    try {
-      const response = await fetch(`http://127.0.0.1:${port}/api/providers/test-params`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          url: 'http://localhost:8000',
-          model: 'test-model',
-          backend: 'vllm',
-          mode: 'thinking',
-          modelConfig: {
-            thinkingEnabled: true,
-            thinkingLevel: 'high',
-            thinkingQueryParams: JSON.stringify({ reasoning_effort: 'high' }),
-          },
-        }),
-      })
+    expect(response.ok).toBe(true)
+    const data: any = await response.json()
+    expect(data.success).toBe(true)
+    expect(data.message).toBeDefined()
+    expect(data.raw).toBeDefined()
 
-      expect(response.ok).toBe(true)
-      const data: any = await response.json()
-      expect(data.success).toBe(true)
-      expect(data.message).toBeDefined()
-      expect(data.raw).toBeDefined()
-
-      // Verify the params passed to createChatCompletion include reasoning_effort
-      const params = mockCreateChatCompletion.mock.calls[0]![0] as Record<string, unknown>
-      expect(params['reasoning_effort']).toBe('high')
-    } finally {
-      await handle.close()
-    }
+    // Verify the params passed to createChatCompletion include reasoning_effort
+    const params = mockCreateChatCompletion.mock.calls[0]![0] as Record<string, unknown>
+    expect(params['reasoning_effort']).toBe('high')
   })
 
   it('should build params for non-thinking mode with chatTemplateKwargs', async () => {
@@ -89,75 +97,57 @@ describe('POST /api/providers/test-params', () => {
       raw: JSON.stringify({ id: 'test-id', choices: [{ message: { content: 'Hi' } }] }),
     })
 
-    const handle = await createServer()
-    const { port } = await handle.start(0)
+    const response = await fetch(`http://127.0.0.1:${port}/api/providers/test-params`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        url: 'http://localhost:8000',
+        model: 'test-model',
+        backend: 'vllm',
+        mode: 'non-thinking',
+        modelConfig: {
+          nonThinkingEnabled: true,
+          nonThinkingQueryParams: JSON.stringify({ reasoning_effort: 'none' }),
+        },
+      }),
+    })
 
-    try {
-      const response = await fetch(`http://127.0.0.1:${port}/api/providers/test-params`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          url: 'http://localhost:8000',
-          model: 'test-model',
-          backend: 'vllm',
-          mode: 'non-thinking',
-          modelConfig: {
-            nonThinkingEnabled: true,
-            nonThinkingQueryParams: JSON.stringify({ reasoning_effort: 'none' }),
-          },
-        }),
-      })
-
-      expect(response.ok).toBe(true)
-      const data: any = await response.json()
-      expect(data.success).toBe(true)
-    } finally {
-      await handle.close()
-    }
+    expect(response.ok).toBe(true)
+    const data: any = await response.json()
+    expect(data.success).toBe(true)
   })
 
   it('should return 400 for missing required fields', async () => {
-    const handle = await createServer()
-    const { port } = await handle.start(0)
+    const response = await fetch(`http://127.0.0.1:${port}/api/providers/test-params`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ url: 'http://localhost:8000' }),
+    })
 
-    try {
-      const response = await fetch(`http://127.0.0.1:${port}/api/providers/test-params`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ url: 'http://localhost:8000' }),
-      })
-
-      expect(response.ok).toBe(false)
-      expect(response.status).toBe(400)
-    } finally {
-      await handle.close()
-    }
+    expect(response.ok).toBe(false)
+    expect(response.status).toBe(400)
+    // The error path answers 400 too, so assert which guard rejected the body
+    const data: any = await response.json()
+    expect(data.error).toBe('model is required')
   })
 
   it('should handle API errors gracefully', async () => {
     mockCreateChatCompletion.mockRejectedValue(new Error('Connection refused'))
 
-    const handle = await createServer()
-    const { port } = await handle.start(0)
+    const response = await fetch(`http://127.0.0.1:${port}/api/providers/test-params`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        url: 'http://localhost:9999',
+        model: 'test-model',
+        backend: 'vllm',
+        mode: 'thinking',
+      }),
+    })
 
-    try {
-      const response = await fetch(`http://127.0.0.1:${port}/api/providers/test-params`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          url: 'http://localhost:9999',
-          model: 'test-model',
-          backend: 'vllm',
-          mode: 'thinking',
-        }),
-      })
-
-      expect(response.ok).toBe(false)
-      expect(response.status).toBe(400)
-      const data: any = await response.json()
-      expect(data.error).toBeDefined()
-    } finally {
-      await handle.close()
-    }
+    expect(response.ok).toBe(false)
+    expect(response.status).toBe(400)
+    const data: any = await response.json()
+    expect(data.error).toBeDefined()
   })
 })

--- a/src/server/tools/path-security.test.ts
+++ b/src/server/tools/path-security.test.ts
@@ -278,15 +278,21 @@ describe('path-security', () => {
       })
 
       it('denies chain of symlinks eventually escaping sandbox', async () => {
-        // Create chain: workdir/link1 -> workdir/link2 -> /etc/passwd
+        // Chain: workdir/link1 -> workdir/link2 -> the node binary. The final
+        // target must exist on every platform: a Unix literal like /etc/passwd
+        // leaves the whole chain dangling on Windows, and the broken-symlink
+        // fallback in isPathWithinSandbox follows only one readlink hop — the
+        // resolution stops at link2, inside the sandbox, and the verdict flips
+        // to allowed.
+        const escapeTarget = process.execPath
         const link2Path = join(WORKDIR, 'link2')
-        await symlink('/etc/passwd', link2Path)
+        await symlink(escapeTarget, link2Path)
         const link1Path = join(WORKDIR, 'link1')
         await symlink(link2Path, link1Path)
 
         const result = await isPathWithinSandbox(link1Path, WORKDIR)
         expect(result.allowed).toBe(false)
-        expect(result.resolvedPath).toBe(CANONICAL_PASSWD)
+        expect(result.resolvedPath).toBe(normalize(await realpath(escapeTarget)))
       })
 
       it('handles broken symlinks gracefully', async () => {

--- a/src/server/tools/shell-streaming.test.ts
+++ b/src/server/tools/shell-streaming.test.ts
@@ -28,7 +28,9 @@ describe('shell tool streaming', () => {
   })
 
   afterEach(async () => {
-    await rm(tempDir, { recursive: true, force: true })
+    // Windows keeps the directory in "pending delete" after the files are
+    // unlinked, so rmdir returns EBUSY; fs.rm does not retry unless asked.
+    await rm(tempDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 })
   })
 
   it('calls onProgress for each stdout chunk', async () => {

--- a/src/server/utils/process-tree.test.ts
+++ b/src/server/utils/process-tree.test.ts
@@ -12,6 +12,22 @@ function isAlive(pid: number): boolean {
   }
 }
 
+/**
+ * Termination is not synchronous — `taskkill /f /t` in particular returns before
+ * Windows has finished reaping the tree, and the close event trails the exit — so
+ * a fixed sleep before asserting is a race that loses under parallel test load.
+ * Poll instead; on timeout we fall through and let the assertion do the reporting.
+ */
+async function waitFor(condition: () => boolean, timeoutMs = 10_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline && !condition()) await sleep(50)
+}
+
+const allDead =
+  (...pids: number[]) =>
+  () =>
+    !pids.some(isAlive)
+
 /** Collect all descendant PIDs via ps (Unix) or CIM (Windows, where ps does not exist) */
 async function getDescendants(rootPid: number): Promise<number[]> {
   const [cmd, args] =
@@ -74,7 +90,7 @@ describe('terminateProcessTree', () => {
     expect(isAlive(proc.pid!)).toBe(true)
 
     await terminateProcessTree(proc)
-    await sleep(100)
+    await waitFor(allDead(proc.pid!))
 
     expect(isAlive(proc.pid!)).toBe(false)
   })
@@ -95,7 +111,7 @@ describe('terminateProcessTree', () => {
 
     // Terminate the tree
     await terminateProcessTree(proc)
-    await sleep(300)
+    await waitFor(allDead(proc.pid!, ...descendants))
 
     // All should be dead now
     expect(isAlive(proc.pid!)).toBe(false)
@@ -137,7 +153,7 @@ describe('terminateProcessTree', () => {
     })
 
     await terminateProcessTree(proc)
-    await sleep(300)
+    await waitFor(() => closed && !isAlive(proc.pid!))
 
     expect(closed).toBe(true)
     expect(isAlive(proc.pid!)).toBe(false)
@@ -156,7 +172,7 @@ describe('terminateProcessTree', () => {
     expect(descendants.length).toBeGreaterThanOrEqual(1)
 
     await terminateProcessTree(proc, { immediate: true })
-    await sleep(300)
+    await waitFor(allDead(proc.pid!, ...descendants))
 
     expect(isAlive(proc.pid!)).toBe(false)
     for (const pid of descendants) {
@@ -186,7 +202,7 @@ describe('terminateProcessTree', () => {
     })
 
     await terminateProcessTree(proc)
-    await sleep(300)
+    await waitFor(() => closed && allDead(proc.pid!, ...descendants)())
 
     expect(closed).toBe(true)
     expect(isAlive(proc.pid!)).toBe(false)

--- a/src/server/utils/process-tree.test.ts
+++ b/src/server/utils/process-tree.test.ts
@@ -18,9 +18,24 @@ function isAlive(pid: number): boolean {
  * a fixed sleep before asserting is a race that loses under parallel test load.
  * Poll instead; on timeout we fall through and let the assertion do the reporting.
  */
-async function waitFor(condition: () => boolean, timeoutMs = 10_000): Promise<void> {
+async function waitFor(condition: () => boolean | Promise<boolean>, timeoutMs = 10_000): Promise<void> {
   const deadline = Date.now() + timeoutMs
-  while (Date.now() < deadline && !condition()) await sleep(50)
+  while (Date.now() < deadline && !(await condition())) await sleep(50)
+}
+
+/**
+ * Poll until the tree under rootPid has at least `min` descendants. A fixed
+ * settle sleep after spawn loses on slow runners: the children may not have
+ * been forked yet, and a tree kill issued before they exist lets them escape
+ * the taskkill snapshot on Windows and hold inherited pipes open forever.
+ */
+async function waitForDescendants(rootPid: number, min: number): Promise<number[]> {
+  let descendants: number[] = []
+  await waitFor(async () => {
+    descendants = await getDescendants(rootPid)
+    return descendants.length >= min
+  })
+  return descendants
 }
 
 const allDead =
@@ -99,9 +114,7 @@ describe('terminateProcessTree', () => {
     const proc = spawn(process.execPath, ['-e', TREE_SCRIPT], { stdio: 'ignore', detached: true })
 
     expect(proc.pid).toBeTruthy()
-    await sleep(400)
-
-    const descendants = await getDescendants(proc.pid!)
+    const descendants = await waitForDescendants(proc.pid!, 2)
     expect(descendants.length).toBeGreaterThanOrEqual(2)
 
     // All should be alive before termination
@@ -152,6 +165,14 @@ describe('terminateProcessTree', () => {
       closed = true
     })
 
+    // On Windows, MSYS bash cannot exec-replace itself the way Unix bash does
+    // with a single command: 'sleep 300' runs as a child sleep.exe holding the
+    // inherited pipes. Terminating before that child exists lets it escape the
+    // taskkill tree snapshot and keep the pipes open — 'close' then never
+    // fires (flaked exactly this way on the CI runner). On Unix bash execs
+    // into sleep, so there is no child to wait for.
+    if (process.platform === 'win32') await waitForDescendants(proc.pid!, 1)
+
     await terminateProcessTree(proc)
     await waitFor(() => closed && !isAlive(proc.pid!))
 
@@ -166,9 +187,10 @@ describe('terminateProcessTree', () => {
     })
 
     expect(proc.pid).toBeTruthy()
-    await sleep(300)
-
-    const descendants = await getDescendants(proc.pid!)
+    // TREE_SCRIPT always spawns two children — wait for both, or the kill can
+    // race the second one's launch (its inherited pipe closes mid-start, which
+    // surfaces as an ERROR_NO_DATA dialog on Windows and a possible orphan).
+    const descendants = await waitForDescendants(proc.pid!, 2)
     expect(descendants.length).toBeGreaterThanOrEqual(1)
 
     await terminateProcessTree(proc, { immediate: true })
@@ -190,10 +212,10 @@ describe('terminateProcessTree', () => {
     })
 
     expect(proc.pid).toBeTruthy()
-    await sleep(400)
 
-    // Confirm children are alive
-    const descendants = await getDescendants(proc.pid!)
+    // Confirm children are alive (TREE_SCRIPT spawns two — wait for both so
+    // the kill cannot race the second child's launch)
+    const descendants = await waitForDescendants(proc.pid!, 2)
     expect(descendants.length).toBeGreaterThanOrEqual(1)
 
     let closed = false


### PR DESCRIPTION
## Summary

With #216, #217 and #218 merged, the unit suite passes on Windows — but nothing keeps it that way, because the `windows-latest` job still only runs `typecheck` and `build`. 

This PR closes that loop: it fixes six test defects and one product bug — the inspect proxy's port scan runs past 65535 and crashes on a synchronous `RangeError` — plus the two pre-commit gates no Windows clone can currently satisfy (`format` and `duplicate`), and then turns `npm run test:unit` on in the Windows CI job.

```
npm run format      917 of 917 files flagged       ->   All matched files use Prettier code style!
npm run duplicate   1 clone in unmodified files    ->   0 clones, exit 0
unit suite (local)  flaky: red on 4 of 5 runs      ->   0 failures over 5 consecutive runs
windows CI job      typecheck + build              ->   + test:unit, green on the runner
```

**One production code change**: a three-line clamp in `inspect-proxy.ts`, mirroring the bound `manager.ts` already applies to its own port scan. 

Everything else is tests, config and CI. 
The findings came in three waves — five under local full-suite load across twenty-one runs, then the new job's own first two runs each caught one more that a dev machine cannot reproduce (details below) — which is the best argument for the job this PR adds.

## Motivation & Context

Each failure, its cause, and the fix — mechanisms and verbatim logs in the collapsed section at the bottom:

| Failure | Cause | Fix |
| --- | --- | --- |
| `test-params` times out at 15s under load | 4 cases × full server boot, all with the same config | one shared boot in `beforeAll` (4 boots → 1) |
| `init-llm` times out (measured 15053ms vs 15000) | full boots too, but each case needs its own config | explicit 30s budget on the two cases |
| `shell-streaming` `EBUSY` on teardown | Windows pending-delete; `fs.rm` won't retry unasked | `maxRetries: 10, retryDelay: 50` (same as #216) |
| `process-tree` asserts death after a flat sleep | `taskkill /f /t` returns before the tree is reaped | `waitFor()` poll with a 10s deadline |
| `inspect-proxy` loses all tests at once, 1 run in 16 | unbounded port scan walks past 65535 → sync `RangeError` | clamp the scan range (mirrors `manager.ts`) |
| `npm run format` flags all 917 files | no `.gitattributes` + `autocrlf=true` = CRLF checkout | `* text=auto eol=lf` |
| `npm run duplicate` red on unmodified files | jscpd mangles config-file ignore globs on Windows | `**/`-prefixed glob, which jscpd leaves untouched |
| symlink-chain escape not denied — **CI run 1** | chain ends at `/etc/passwd`, absent on Windows → dangling | end the chain at `process.execPath`, which exists everywhere |
| `close` event never fires in `process-tree` — **CI run 2** | tests kill the tree while their own children are still forking | `waitForDescendants()` settles the tree before the kill |

Three things deserve a word here rather than in the collapsed section.

**The port clamp is the one production change, and it has to ride in this PR**: the tests derive the proxy base from a `listen(0)` ephemeral port, Windows allocates ephemerals sequentially from 49152–65535, and about 6% of that range overflows the scan — so without the clamp, the CI job this PR adds would be intermittently red from day one. It is also a real (if narrow) product bug: a dev server configured above port 64535 crashes the proxy startup the same way. Two more Windows dev-server bugs are diagnosed and coming in a separate PR (the Start button failing under cmd.exe, and an `EADDRINUSE` crash on the second click); they touch the same file but change behavior, so they get their own review.

**The last two findings only exist on the runner, which is the point of the job.** Symlink creation needs a privilege the GitHub runner has (admin) and a default dev box does not, so the seven symlink tests had never executed on Windows before this job ran them — run 1 caught a fixture that only worked where `/etc/passwd` exists. Run 2 caught a spawn/kill race that needs a machine slow enough for `taskkill`'s tree snapshot to beat a `fork`. Neither was reachable by any number of local runs; both are now fixed at the mechanism, and run 3 is green.

**This PR does not make the pre-commit hook fully green on Windows yet.** The hook runs `npm test`, which includes the e2e suite, and `e2e/provider-plugins.test.ts` still fails there (`expected undefined to be 'disconnected'`) — uninvestigated so far. That is also why the CI job runs `test:unit` rather than `npm test`.

## What Changed

**Added:**

- `.gitattributes` — pin checkout to LF whatever `core.autocrlf` says. No content change: the index blobs are already LF (proofs below).

**Modified:**

- `src/server/dev-server/inspect-proxy.ts` — `getAvailablePort` clamps its scan (and its fallback) below 65536, via a `PORT_SCAN_RANGE` constant matching `MAX_PORT_SCAN` in `manager.ts`.
- `src/server/dev-server/inspect-proxy.test.ts` — new test: proxy started with `devServerPort = 65000` binds a valid port and proxies traffic; fails on the exact `RangeError` without the clamp.
- `src/server/providers/test-params.test.ts` — one shared server in `beforeAll`/`afterAll` instead of four boots; also hardens the 400 case to assert `data.error`, which was passing for the wrong reason (details below).
- `src/server/init-llm.test.ts` — explicit 30s budget on the two cases.
- `src/server/tools/shell-streaming.test.ts` — teardown `rm` gets the #216 retry treatment.
- `src/server/utils/process-tree.test.ts` — the five flat `sleep()`s before liveness assertions become `waitFor()` polls, and the fixed settle sleeps after spawn become `waitForDescendants()` polls so the tests stop racing their own children (the CI run 2 failure); the passing cases get faster too.
- `src/server/tools/path-security.test.ts` — the symlink-chain escape test ends at `process.execPath` instead of `/etc/passwd`, so the chain resolves on every platform (the CI run 1 failure).
- `.jscpd-server.json` — ignore glob `src/server/skills/defaults/**` → `**/skills/defaults/**`, same files ignored on every platform.
- `.github/workflows/pr.yml` — the `windows` job installs the web workspace (test:unit includes the web tests), runs `npm run test:unit`, timeout 20 → 30 minutes.

Worth flagging: roughly 35 other test files tear down temp directories with `rm(dir, { recursive: true, force: true })` and no retries — same latent `EBUSY`. Left alone here (none observed failing, and a sweep would bury this PR); happy to send it as a follow-up if you want it in one pass.

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing

Machine: Windows 11 Pro (26200), Node 24, git-for-windows with `core.autocrlf=true` — plus the `windows-latest` runner itself, which executes seven symlink tests the dev box cannot (privilege-gated skip) and is the only place the two runner findings reproduce.

- Full suite locally, **five consecutive runs**, compared file-list by file-list rather than by count — zero failures. On the runner: run 1 and 2 each caught one runner-only defect, **run 3 is fully green**:

```
local   Test Files  273 passed | 2 skipped     Tests  3458 passed | 39 skipped
CI      Test Files  273 passed | 2 skipped     Tests  3465 passed | 34 skipped
```

- **Three fixes verified by mutation**: removing the clamp turns the new port test red on the exact `RangeError`; a wrong `reasoningEffort` in the route turns the thinking-mode case red (proving `clearAllMocks` still isolates calls across the shared server); deleting the `!model` guard turns the hardened 400 case red — it stayed green before this PR.
- **`.gitattributes` measured on a throwaway clone** (`--no-hardlinks`, `autocrlf=true`): 917 files flagged before, all clean after; binary sha256s identical to their blobs; no phantom modifications in an existing CRLF working tree.
- **jscpd isolated by experiment**: original pattern fails from the config file but passes as CLI `--ignore`; the `**/`-prefixed form passes from the config file (0 clones, exit 0), matching the `resolveIgnorePattern` code path described below.
- `npm run typecheck`, `npm run lint`, `npm run duplicate` and `prettier --check` on the touched files: clean.
- Linux/macOS not run locally: the test changes are timeouts, `fs.rm` retries Node only honours for `EBUSY`/`ENOTEMPTY`/`EPERM`, polls replacing sleeps, and a symlink target that exists everywhere; the clamp only changes behavior for scan bases that previously crashed; the jscpd glob takes the resolution-free code path on every platform; `.gitattributes` is a no-op where checkout is already LF; the CI change touches only the `windows` job.

## Breaking Changes

None. `.gitattributes` changes how files are checked out, not what is stored, and the stored blobs are already LF — existing CRLF working trees see no diff churn. The inspect-proxy clamp only affects configurations that previously crashed.

- [ ] This PR introduces breaking changes

## Related Issues

Completes the series started by #216 (`fs.rm` retries), #217 (POSIX-only assertions) and #218 (the auto-update spawn mock): those made the Windows unit suite green, this one makes it stay green. Also repairs the Windows half of the `format` gate added in `ee259786`, and unblocks the `duplicate` gate from the same hook.

Two follow-ups I would like to send separately: a `format` job in `pr.yml` (green from day one now, and it closes the `--no-verify` drift that caused the reformat in `fa993ff8`), and a product fix for dangling symlink *chains* — the broken-symlink fallback in `isPathWithinSandbox` follows only one `readlink` hop, so a dangling chain of two or more links resolves to the intermediate link and is allowed on every platform (writing through one creates the final target outside the sandbox). The fixture fix in this PR surfaced it; the product fix deserves its own review.

## AI-Enhanced Development

- **AI Models:** Fable 5

## Cache Impact

- **No** 

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed

One test added (the port clamp); otherwise this strengthens existing assertions and replaces sleeps and redundant setup with polls rather than adding cases.

**Key files to review:** `src/server/dev-server/inspect-proxy.ts`, `.gitattributes`, `.jscpd-server.json`, `src/server/utils/process-tree.test.ts`, `.github/workflows/pr.yml`

---

<details>
<summary><b>Technical investigation</b> — symptoms, root causes, and proofs</summary>

### Symptoms

Server-boot timeouts, always on the last cases of the file as parallel load builds up over the run (`test-params`, and the same shape in `init-llm`):

```
Error: Test timed out in 15000ms.
 ❯ src/server/providers/test-params.test.ts:119:3
    120|     const handle = await createServer()
    121|     const { port } = await handle.start(0)
```

Teardown failure in `shell-streaming` under load:

```
Error: EBUSY: resource busy or locked, rmdir 'C:\Users\...\AppData\Local\Temp\shell-test-HE4c6F'
```

Post-termination assertion failure in `process-tree` (the descendant liveness check):

```
AssertionError: expected true to be false
```

All tests of `inspect-proxy.test.ts` failing as a block, one full-suite run in sixteen:

```
RangeError: options.port should be >= 0 and < 65536.
 ❯ getAvailablePort src/server/dev-server/inspect-proxy.ts:40
 ❯ Module.startInspectProxy src/server/dev-server/inspect-proxy.ts:118
```

Pre-commit `format` gate on any fresh Windows clone:

```
[warn] Code style issues found in 917 files. Run Prettier with --write to fix.
```

Pre-commit `duplicate` gate on any Windows clone, over files no one modified:

```
Clone found (json): src/server/workflows/defaults/default.workflow.json [60:76]
                    src/server/skills/defaults/workflows/SKILL.md [433:449]
ERROR: jscpd found too many duplicates (0.05%) over threshold (0%)
```

CI run 1 of the new windows job — a symlink test's first-ever execution on Windows:

```
FAIL  src/server/tools/path-security.test.ts > denies chain of symlinks eventually escaping sandbox
AssertionError: expected true to be false
 ❯ src/server/tools/path-security.test.ts:288
```

CI run 2 — intermittent (this test was green on run 1):

```
FAIL  src/server/utils/process-tree.test.ts > fires close event after killing process group
AssertionError: expected false to be true
 ❯ src/server/utils/process-tree.test.ts:158
```

### Causes

1. **Server boots under load** — `test-params.test.ts` booted four complete servers (`createServerHandle`: database, event store, provider plugin discovery) for four cases sharing one config; a boot measured at 12–15s under full-suite load against the 15s `testTimeout` (`vitest.config.ts` already names both files in the comment on that value, so raising it again would just move the threshold). `init-llm.test.ts` has the same boot cost but genuinely different configs per case, so its budget was the only lever. The shared `beforeAll` carries an explicit 30s timeout because hooks default to 10s — *below* the 15s a boot used to get from `testTimeout` while it still ran inside a test body; without it the refactor would have quietly shrunk the budget it set out to widen.
2. **The weak 400 assertion** — while verifying the refactor by mutation, `should return 400 for missing required fields` stayed green after deleting all three guards (`!url`, `!model`, `!mode`) from the route: the error path answers 400 too, so the status alone proved nothing. It now asserts `data.error === 'model is required'`.
3. **EBUSY on rmdir** — Windows keeps a directory in pending-delete after its files are unlinked; an immediate `rmdir` gets `EBUSY` and `fs.rm` does not retry unless given `maxRetries`. Identical to the #216 diagnosis; this file just wasn't red that day.
4. **Fixed sleep vs process reaping** — `taskkill /f /t` returns before Windows finishes reaping the tree, and the `close` event trails the exit, so `sleep(300)` then asserting death is a race. `waitFor()` polls the same condition every 50ms with a 10s deadline; on timeout it falls through and lets the existing assertions report.
5. **Unbounded port scan** — `getAvailablePort` (`inspect-proxy.ts`) scans `proxyBase..proxyBase+200` with no upper bound; the tests derive `proxyBase` from a `listen(0)` ephemeral port + 1000, and Windows allocates ephemeral ports sequentially from 49152–65535, so once the allocator passes 64535 the whole scan range is invalid — which is why the file flips red or green as a block, following the allocator rather than the code. `net.listen()` rejects out-of-range ports with a synchronous throw rather than an `'error'` event, so the guard inside `tryBind` never fires. `findFreePort` in `manager.ts` already clamps its own scan with `MAX_PORT_SCAN`; this brings `getAvailablePort` in line, fallback included.
6. **CRLF checkout vs prettier** — no `.gitattributes` + default `endOfLine: "lf"` + `core.autocrlf=true` (the git-for-windows default) = every text file checked out CRLF, every file non-conformant. And since there is no `format` job in `pr.yml`, the pre-commit hook is the only place the gate applies — and the only place it cannot be satisfied.
7. **jscpd ignore mangled** — jscpd's `resolveIgnorePattern` runs config-file ignore globs through `path.resolve`/`path.relative`, which on Windows returns `src\server\skills\defaults\**` — backslashes, no longer a valid glob, so the entry silently stops matching. `**/`-prefixed patterns bypass that resolution on every platform, and CLI `--ignore` bypasses the function entirely — exactly the observed matrix (config fails, CLI works, the `**/*.test.ts` entry next to it works). Arguably a jscpd bug worth reporting upstream; the rewritten pattern is the form that is robust regardless.
8. **Dangling symlink chain (CI run 1)** — the chain test ended at `/etc/passwd`, which does not exist on Windows, so the whole chain dangles there: `realpath()` throws, and the broken-symlink fallback in `isPathWithinSandbox` follows exactly one `readlink` hop — resolution stops at `link2`, inside the sandbox, and the verdict flips to allowed. The test had never run on Windows before: symlink creation needs a privilege the runner has (admin) and a default dev box does not (the `CAN_SYMLINK` probe gets `EPERM`), which the skip counts confirm — 34 skipped on CI vs 39 locally. Ending the chain at `process.execPath` makes it resolvable everywhere. The one-hop limit itself is the cross-platform product gap flagged in Related Issues.
9. **Tests racing their own spawns (CI run 2)** — the close-event test runs `bash -c 'sleep 300'` and terminates the tree immediately; under MSYS bash, `sleep` runs as a child `sleep.exe` that inherits the stdout/stderr pipes, and on a slow runner the `taskkill /f /t` tree snapshot can be taken before bash has forked it — the child escapes the kill, keeps the pipe write ends open, and `'close'` never fires. Three sibling tests carried the same race latently (fixed 300–400ms settle sleeps, then asserting the children exist); killing while a child is still launching also closes its inherited stdio mid-start, which surfaced on the dev machine as an `ERROR_NO_DATA` (0x800700E8) dialog. `waitForDescendants(pid, min)` polls the tree until populated (min = 2 for the two-child fixture, so the kill can never race the second launch), and the bash-child wait is win32-only — Unix bash execs into `sleep`, so there is no child to wait for.

### Proofs and measurements

- Twenty-one local full-suite runs plus three runs of the new CI job. Locally, before the fixes: red on 4 of 5 runs, never the same files; after: five consecutive runs with zero failures, file-lists compared, not counts. On the runner: run 1 caught the symlink fixture, run 2 the spawn race, run 3 green. The findings came in waves — three green runs after the first fix looked like "done", then two more local runs surfaced two new flakes, then the runner surfaced two more that no local run could reach — hence the run-count discipline throughout.
- `.gitattributes` measured on a throwaway `--no-hardlinks` clone with `autocrlf=true`: 917 files flagged before, `All matched files use Prettier code style!` after; sha256 of a PNG, an MP3 and a screenshot identical to their blobs; `git status` on an existing CRLF working tree shows only the untracked `.gitattributes`. The repo contains no `.bat`/`.cmd`/`.ps1` that would want CRLF.
- jscpd: original pattern red from config, green as `--ignore`; `**/skills/defaults/**` green from config (1 clone → 0 clones, exit 0). On Linux the resolution it now bypasses was an identity transformation, so the ubuntu `duplicate` job sees the same ignore set as before.
- The process-tree rework was run five consecutive times locally after the fix (8/8 green each time); the win32 settle path exercises the real CIM-based `getDescendants` polling on every local run, since Git Bash does fork a `sleep.exe` child there.

</details>
