### PR TITLE
ci: move the AI-disclosure check off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -70,7 +70,7 @@ jobs:
   ai-disclosure:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v8
         with:
           script: |
             const body = context.payload.pull_request.body || '';


### PR DESCRIPTION
### Summary

Every PR run currently prints:

> Node 20 is being deprecated. This workflow is running with Node 24 by default. If you need to
> temporarily use Node 20, you can set the `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true`
> environment variable.

It comes from `actions/github-script@v7`, which is a Node 20 action. `v8` is the same action on
Node 24.

**No behaviour change.** The script body is untouched; `context.payload.pull_request` and
`core.setFailed` are unchanged across the major.

### Not in this PR, on purpose

`actions/checkout@v4` is a Node 20 action for the same reason and is **left alone**. `checkout@v5`
changes more than the runtime, so it deserves a review of its own rather than riding along with a
one-line bump.

### Verification

The change is one line in `.github/workflows/pr.yml`. The `ai-disclosure` job on this PR is the test:
if it runs and evaluates this PR's body, the action works on the new major.

### AI-Enhanced Development

Tell what models helped shape this PR:

- **AI Models:** Claude Opus 5 (1M context), through Claude Code

### Cache Impact

Does this PR affect anything cached — system prompts, tool definitions, skills, or other context?

- **No**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EhMynpFbWTNFcyUnobBGZE
