### PR TITLE
fix(e2e): run server tests sequentially

### DIFF
--- a/e2e/timeouts.test.ts
+++ b/e2e/timeouts.test.ts
@@ -11,6 +11,10 @@ describe('E2E timeouts', () => {
     expect(config.test?.testTimeout).toBe(15_000 * CI_MULTIPLIER)
   })
 
+  it('runs server-backed test files sequentially', () => {
+    expect(config.test?.maxWorkers).toBe(1)
+  })
+
   it('keeps websocket waits within the per-test budget', () => {
     const budget = 8_000 * CI_MULTIPLIER
     expect(DEFAULT_WAIT_TIMEOUT_MS).toBeLessThanOrEqual(budget)

--- a/e2e/vitest.config.ts
+++ b/e2e/vitest.config.ts
@@ -14,10 +14,10 @@ export default defineConfig({
     testTimeout: 15_000 * CI_MULTIPLIER,
     hookTimeout: 10_000 * CI_MULTIPLIER,
 
-    // Run tests in parallel with fork pool
-    // Each test file gets its own in-process server on a dynamic port
+    // Each test file starts a full server. Parallel startups contend for enough
+    // CPU and memory to exceed the hook timeout on supported developer machines.
     pool: 'forks',
-    maxWorkers: process.env['CI'] === 'true' ? 1 : 12, // CI runners are resource-constrained
+    maxWorkers: 1,
 
     // No global setup - each test file manages its own server
     // globalSetup: './setup.ts',  // REMOVED - using in-process servers


### PR DESCRIPTION
### Summary

Closes #225.

Each E2E test file starts a full OpenFox server. Starting up to 12 of these servers concurrently can exhaust local CPU and memory long enough for `createTestServer()` to exceed the existing 10-second hook timeout.

Run server-backed E2E files sequentially, matching the already reliable CI worker policy. This addresses the resource contention directly without increasing test or hook timeouts.

A regression assertion now protects the worker policy.

Validation:

- Reproduced the default-worker startup timeout cascade
- Confirmed four workers still fail with the same hook timeouts
- `e2e/timeouts.test.ts`: 4 tests passed
- E2E TypeScript check passed
- Prettier passed for both changed files
- Full sequential E2E run was capped after approximately eight minutes under concurrent batch load and did not produce a final result

### AI-Enhanced Development

- **AI Models:** GPT-5.6 (Codex)

### Cache Impact

- **No**