### PR TITLE
fix: handle null token usage stats without crashing sessions

### DIFF
--- a/src/server/llm/client.test.ts
+++ b/src/server/llm/client.test.ts
@@ -340,6 +340,71 @@ describe('llm client', () => {
     ])
   })
 
+  it('normalizes null usage values in streaming responses', async () => {
+    httpClientCreateStreamMock.mockReturnValueOnce(
+      (async function* () {
+        yield createChunk({
+          choices: [{ delta: { content: 'answer' }, finish_reason: 'stop' }],
+          usage: {
+            prompt_tokens: null,
+            completion_tokens: null,
+            total_tokens: null,
+          },
+        })
+      })(),
+    )
+
+    const client = createLLMClient(createConfig(), 'vllm')
+    const events = []
+
+    for await (const event of client.stream({ messages: [{ role: 'user', content: 'hello' }] })) {
+      events.push(event)
+    }
+
+    expect(events.at(-1)).toMatchObject({
+      type: 'done',
+      response: {
+        usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+      },
+    })
+  })
+
+  it('retains valid streaming usage when later fields are null or missing', async () => {
+    httpClientCreateStreamMock.mockReturnValueOnce(
+      (async function* () {
+        yield createChunk({
+          choices: [],
+          usage: {
+            prompt_tokens: 11,
+            completion_tokens: 6,
+            total_tokens: 17,
+          },
+        })
+        yield createChunk({
+          choices: [{ delta: { content: 'answer' }, finish_reason: 'stop' }],
+          usage: {
+            prompt_tokens: null,
+            total_tokens: null,
+          },
+        })
+      })(),
+    )
+
+    const client = createLLMClient(createConfig(), 'vllm')
+    const events = []
+
+    for await (const event of client.stream({ messages: [{ role: 'user', content: 'hello' }] })) {
+      events.push(event)
+    }
+
+    expect(events.at(-1)).toMatchObject({
+      type: 'done',
+      response: {
+        usage: { promptTokens: 11, completionTokens: 6, totalTokens: 17 },
+      },
+    })
+  })
+
   it('streams reasoning_content as thinking_delta', async () => {
     httpClientCreateStreamMock.mockReturnValueOnce(
       (async function* () {

--- a/src/server/llm/client.ts
+++ b/src/server/llm/client.ts
@@ -267,9 +267,9 @@ export function createLLMClient(config: Config, initialBackend: Backend = 'unkno
 
             if (chunk.usage) {
               usage = {
-                promptTokens: chunk.usage.prompt_tokens,
-                completionTokens: chunk.usage.completion_tokens,
-                totalTokens: chunk.usage.total_tokens,
+                promptTokens: chunk.usage.prompt_tokens ?? usage.promptTokens,
+                completionTokens: chunk.usage.completion_tokens ?? usage.completionTokens,
+                totalTokens: chunk.usage.total_tokens ?? usage.totalTokens,
               }
             }
 

--- a/web/src/components/plan/AssistantMessage.test.tsx
+++ b/web/src/components/plan/AssistantMessage.test.tsx
@@ -1,6 +1,8 @@
 // @vitest-environment happy-dom
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useEffect, useState } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 
 vi.mock('../../stores/session', () => ({
   useSessionStore: (selector: (state: { currentSession: { criteria: [] } }) => unknown) =>
@@ -32,7 +34,29 @@ vi.mock('../shared/CriteriaGroupDisplay', () => ({
   isCriterionTool: () => false,
 }))
 
+import type { Message } from '@shared/types.js'
+import type { TurnStats } from '../../lib/types'
 import { AssistantMessage } from './AssistantMessage'
+import { TurnStatsModal } from './TurnStatsModal'
+
+function StatsDetailHarness({ message }: { message: Message }) {
+  const [stats, setStats] = useState<TurnStats | null>(null)
+
+  useEffect(() => {
+    const handler = (event: Event) => setStats((event as CustomEvent<{ stats: TurnStats }>).detail.stats)
+    window.addEventListener('open-turn-stats', handler)
+    return () => window.removeEventListener('open-turn-stats', handler)
+  }, [])
+
+  return (
+    <>
+      <AssistantMessage message={message} />
+      {stats && <TurnStatsModal stats={stats} onClose={() => setStats(null)} />}
+    </>
+  )
+}
+
+afterEach(cleanup)
 
 describe('AssistantMessage', () => {
   it('renders an Aborted badge for partial assistant messages', () => {
@@ -84,6 +108,71 @@ describe('AssistantMessage', () => {
     expect(html).toContain('deepseek-v4-flash-dspark')
     // Should NOT truncate to first 2 hyphen-segments only
     expect(html).not.toContain('>deepseek-v4<')
+  })
+
+  it('renders persisted messages with null usage stats', () => {
+    const message = {
+      id: 'assistant-null-stats',
+      role: 'assistant',
+      content: 'Persisted answer',
+      timestamp: '2024-01-01T00:00:00.000Z',
+      tokenCount: 0,
+      isStreaming: false,
+      stats: {
+        providerId: 'openai',
+        providerName: 'OpenAI',
+        backend: 'openai',
+        model: 'MiniMax-M3',
+        mode: 'builder',
+        totalTime: 1702.319,
+        toolTime: 1681.938,
+        prefillTokens: null,
+        prefillSpeed: null,
+        generationTokens: null,
+        generationSpeed: null,
+      },
+    } as unknown as Message
+
+    const html = renderToStaticMarkup(<AssistantMessage message={message} />)
+
+    expect(html).toContain('Persisted answer')
+    expect(html).toContain('— pp')
+    expect(html).toContain('— tg')
+    expect(html).not.toContain('0 @ 0.0')
+  })
+
+  it('opens stats details for persisted messages with null usage stats', () => {
+    const message = {
+      id: 'assistant-null-stats',
+      role: 'assistant',
+      content: 'Persisted answer',
+      timestamp: '2024-01-01T00:00:00.000Z',
+      tokenCount: 0,
+      isStreaming: false,
+      stats: {
+        providerId: 'openai',
+        providerName: 'OpenAI',
+        backend: 'openai',
+        model: 'MiniMax-M3',
+        mode: 'builder',
+        totalTime: 1702.319,
+        toolTime: 1681.938,
+        prefillTokens: null,
+        prefillSpeed: null,
+        generationTokens: null,
+        generationSpeed: null,
+      },
+    } as unknown as Message
+
+    render(<StatsDetailHarness message={message} />)
+    fireEvent.click(screen.getByTitle('View detailed stats'))
+
+    const dialogText = screen.getByRole('dialog').textContent ?? ''
+    expect(dialogText).toContain('Turn Stats')
+    expect(dialogText).toContain('MiniMax-M3 · builder')
+    expect(dialogText).toContain('Prefill—')
+    expect(dialogText).toContain('Generated—')
+    expect(dialogText).not.toContain('null')
   })
 
   it('strips provider path prefix from model name', () => {

--- a/web/src/components/plan/AssistantMessage.tsx
+++ b/web/src/components/plan/AssistantMessage.tsx
@@ -266,8 +266,21 @@ export const AssistantMessage = memo(function AssistantMessage({
               const modeColor = getAgentColor(agents, stats.mode)
               const agentInfo = agents.find((a) => a.id === stats.mode)
               const modeName = agentInfo?.name ?? stats.mode
-              const formatTokens = (n: number) => (n >= 1000 ? `${(n / 1000).toFixed(1)}k` : n.toString())
-              const formatSpeed = (n: number) => (n >= 1000 ? `${(n / 1000).toFixed(1)}k` : n.toFixed(1))
+              const formatTokens = (n: number | null | undefined) => {
+                if (typeof n !== 'number' || !Number.isFinite(n)) return null
+                return n >= 1000 ? `${(n / 1000).toFixed(1)}k` : n.toString()
+              }
+              const formatSpeed = (n: number | null | undefined) => {
+                if (typeof n !== 'number' || !Number.isFinite(n)) return null
+                return n >= 1000 ? `${(n / 1000).toFixed(1)}k` : n.toFixed(1)
+              }
+              const formatUsage = (tokens: number | null | undefined, speed: number | null | undefined) => {
+                const formattedTokens = formatTokens(tokens)
+                const formattedSpeed = formatSpeed(speed)
+                return formattedTokens !== null && formattedSpeed !== null
+                  ? `${formattedTokens} @ ${formattedSpeed}`
+                  : '—'
+              }
 
               return (
                 <div key={i} className="flex items-center justify-center gap-1.5 text-[10px] text-text-muted">
@@ -284,13 +297,9 @@ export const AssistantMessage = memo(function AssistantMessage({
                     </>
                   )}
                   <span className="text-text-muted">·</span>
-                  <span>
-                    {formatTokens(stats.prefillTokens)} @ {formatSpeed(stats.prefillSpeed)} pp
-                  </span>
+                  <span>{formatUsage(stats.prefillTokens, stats.prefillSpeed)} pp</span>
                   <span className="text-text-muted">·</span>
-                  <span>
-                    {formatTokens(stats.generationTokens)} @ {formatSpeed(stats.generationSpeed)} tg
-                  </span>
+                  <span>{formatUsage(stats.generationTokens, stats.generationSpeed)} tg</span>
                   <span className="text-text-muted">·</span>
                   <button
                     type="button"

--- a/web/src/components/plan/TurnStatsModal.tsx
+++ b/web/src/components/plan/TurnStatsModal.tsx
@@ -26,16 +26,8 @@ export function TurnStatsModal({ stats: s, onClose }: TurnStatsModalProps) {
 
         <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
           <StatCard label="Total Time" value={formatTime(s.totalTime)} />
-          <StatCard
-            label="Prefill"
-            value={s.prefillTokens >= 1000 ? `${(s.prefillTokens / 1000).toFixed(1)}k` : String(s.prefillTokens)}
-          />
-          <StatCard
-            label="Generated"
-            value={
-              s.generationTokens >= 1000 ? `${(s.generationTokens / 1000).toFixed(1)}k` : String(s.generationTokens)
-            }
-          />
+          <StatCard label="Prefill" value={formatTokens(s.prefillTokens)} />
+          <StatCard label="Generated" value={formatTokens(s.generationTokens)} />
           <StatCard label="LLM Calls" value={String(s.llmCalls?.length ?? 1)} />
         </div>
 
@@ -71,6 +63,11 @@ export function TurnStatsModal({ stats: s, onClose }: TurnStatsModalProps) {
       </div>
     </Modal>
   )
+}
+
+function formatTokens(value: number | null | undefined): string {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return '—'
+  return value >= 1000 ? `${(value / 1000).toFixed(1)}k` : String(value)
 }
 
 function StatCard({ label, value }: { label: string; value: string }) {


### PR DESCRIPTION
## Summary

- normalize null or missing token usage fields at the OpenAI-compatible streaming boundary
- preserve previously reported usage values when a later streaming chunk contains partial or null usage
- render unavailable persisted token statistics safely instead of crashing the entire session
- display unavailable telemetry as an em dash rather than misleading zero measurements

## Context

Some OpenAI-compatible providers return `null` for `prompt_tokens`, `completion_tokens`, and `total_tokens` in streaming usage chunks.

Those values were copied directly into message statistics. Persisted sessions containing null token counts or speeds could then crash `AssistantMessage` when formatting the values, leaving the whole session view blank.

The non-streaming path already normalizes nullish usage values.

## Testing

- Targeted tests: 27 passed
- `npm run check`: passed
- Unit/web suite: 3799 passed, 29 skipped
- Full E2E execution remains unstable in this environment: multiple suites timed out after 10 seconds in `createTestServer()` setup, followed by cleanup errors for uninitialized server handles. One run also observed a timing-sensitive failure in `ask-user.test.ts`, where `isRunning` remained `true` after a 100 ms wait. This patch does not modify E2E infrastructure, server startup, or ask-user session state.


## AI Model

OpenAI GPT-5.6