### PR TITLE
fix: Bug P1 omniroute provider compatibility issues

### DIFF
--- a/src/server/llm/client-pure.ts
+++ b/src/server/llm/client-pure.ts
@@ -257,7 +257,7 @@ async function buildChatCompletionCreateParams(
     ...(request.toolChoice ? { tool_choice: request.toolChoice as ChatCompletionToolChoiceOption } : {}),
     temperature,
     max_tokens: maxTokens,
-    top_p: topP,
+    ...(topP !== undefined && { top_p: topP }),
     stream: isStreaming,
     ...(isStreaming ? { stream_options: { include_usage: true } } : {}),
   }

--- a/src/server/llm/client.ts
+++ b/src/server/llm/client.ts
@@ -376,7 +376,7 @@ export function createLLMClient(config: Config, initialBackend: Backend = 'unkno
           },
         }
       } catch (error) {
-        logger.error('LLM stream error', { error })
+        logger.error('LLM stream error', { error: String(error) })
         yield {
           type: 'error',
           error: error instanceof Error ? error.message : 'Unknown LLM error',

--- a/src/server/tools/project-tasks.ts
+++ b/src/server/tools/project-tasks.ts
@@ -83,7 +83,11 @@ export const projectTasksTool = createTool<ProjectTasksArgs>(
           action: { type: 'string', enum: VALID_ACTIONS, description: 'The action to perform' },
           taskId: { type: 'string', description: 'Target task id (edit, move, set_gate_value, delete)' },
           prompt: { type: 'string', description: 'The prompt/instruction executed when the task launches' },
-          attachments: { type: 'array', description: 'Optional attachments (same shape as chat attachments)' },
+          attachments: {
+            type: 'array',
+            description: 'Optional attachments (same shape as chat attachments)',
+            items: {},
+          },
           agentId: { type: 'string', description: 'Selected agent id' },
           providerId: { type: 'string', description: 'Provider id used when a session is spawned' },
           model: { type: 'string', description: 'Model label used when a session is spawned' },


### PR DESCRIPTION
### Summary

Fix compatibility issues with strict OpenAI-compatible providers (Omniroute, Gemini via proxy):

1. **`top_p` sent as `null`**: When no `topP` is configured, `undefined` was serialized to `null` in the JSON body. Omniroute rejects this with `"top_p: must be a number"`. Fixed by conditionally omitting the field.
2. **`project-tasks` tool schema**: The `attachments` parameter was declared as `type: "array"` without an `items` field. Gemini (via Antigravity/Omniroute) rejects this with `INVALID_ARGUMENT: missing field`. Fixed by adding `items: {}`.
3. **LLM stream error log**: `logger.error('LLM stream error', { error })` was serializing the Error object to `{code, name}` only, hiding the actual message. Fixed by using `String(error)`.

### AI-Enhanced Development

Tell what models helped shape this PR:

- **AI Models:** gh/claude-sonnet-4.6

_No AI used? Enter 'none'_

### Cache Impact

Does this PR affect anything cached — system prompts, tool definitions, skills, or other context?

- **Yes** — `project-tasks` tool definition changed (added `items: {}` to `attachments` array schema). This affects tool definition caching for any provider that caches prompt/tool context.