### PR TITLE
fix: include symlinked directories in project discovery listings

### DIFF
--- a/src/server/git/workspace.test.ts
+++ b/src/server/git/workspace.test.ts
@@ -156,9 +156,9 @@ describe('getWorkspacesDir', () => {
 describe('listWorkspaces', () => {
   it('returns sorted workspace directories', async () => {
     vi.mocked(readdir).mockResolvedValue([
-      { name: 'fix-bug', isDirectory: () => true },
-      { name: 'add-feature', isDirectory: () => true },
-      { name: 'readme.md', isDirectory: () => false },
+      { name: 'fix-bug', isDirectory: () => true, isSymbolicLink: () => false },
+      { name: 'add-feature', isDirectory: () => true, isSymbolicLink: () => false },
+      { name: 'readme.md', isDirectory: () => false, isSymbolicLink: () => false },
     ] as any)
 
     vi.mocked(spawn).mockReturnValue(makeMockProc('main\n') as any)
@@ -167,6 +167,30 @@ describe('listWorkspaces', () => {
     expect(result[0]?.name).toBe('add-feature')
     expect(result[1]?.name).toBe('fix-bug')
     expect(result[0]?.branch).toBe('main')
+  })
+
+  it('includes symlinked workspace directories', async () => {
+    vi.mocked(readdir).mockResolvedValue([
+      { name: 'fix-bug', isDirectory: () => true, isSymbolicLink: () => false },
+      { name: 'linked-ws', isDirectory: () => false, isSymbolicLink: () => true },
+      { name: 'readme.md', isDirectory: () => false, isSymbolicLink: () => false },
+    ] as any)
+
+    vi.mocked(stat).mockResolvedValue({ isDirectory: () => true } as any)
+    vi.mocked(spawn).mockReturnValue(makeMockProc('main\n') as any)
+    const result = await listWorkspaces(PROJECT_NAME, CWD)
+    expect(result).toHaveLength(2)
+    expect(result.map((w) => w.name)).toContain('linked-ws')
+  })
+
+  it('excludes broken symlinked workspace directories', async () => {
+    vi.mocked(readdir).mockResolvedValue([
+      { name: 'broken-ws', isDirectory: () => false, isSymbolicLink: () => true },
+    ] as any)
+
+    vi.mocked(stat).mockRejectedValue({ code: 'ENOENT' })
+    const result = await listWorkspaces(PROJECT_NAME, CWD)
+    expect(result).toEqual([])
   })
 
   it('returns empty on error', async () => {

--- a/src/server/git/workspace.ts
+++ b/src/server/git/workspace.ts
@@ -3,6 +3,7 @@ import { mkdir, rm } from 'node:fs/promises'
 import { resolve, join, isAbsolute } from 'node:path'
 import { homedir, platform } from 'node:os'
 import { logger } from '../utils/logger.js'
+import { isDirectoryEntry } from '../utils/fs.js'
 import { gitSpawnEnv } from './env.js'
 import { loadWorkspaceConfig } from './workspace-config.js'
 import { getProjectByWorkdir } from '../db/projects.js'
@@ -248,7 +249,7 @@ export async function listWorkspaces(projectName: string, projectDir: string): P
     const entries = await readdir(dir, { withFileTypes: true })
     const workspaces: WorkspaceInfo[] = []
     for (const entry of entries) {
-      if (entry.isDirectory()) {
+      if (await isDirectoryEntry(dir, entry)) {
         const wsPath = resolve(dir, entry.name)
         const branch = await getGitBranch(wsPath)
         workspaces.push({ path: wsPath, name: entry.name, branch })

--- a/src/server/routes/directories.test.ts
+++ b/src/server/routes/directories.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import express from 'express'
-import { mkdir, rm, writeFile } from 'node:fs/promises'
+import { mkdir, rm, symlink, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { createDirectoryRoutes } from './directories.js'
@@ -49,5 +49,27 @@ describe('GET /api/directories', () => {
     const body = (await res.json()) as { directories: Array<{ name: string }> }
     const names = body.directories.map((d) => d.name)
     expect(names).toContain('.hidden')
+  })
+
+  it('returns symlinked directories', async () => {
+    const linkType = process.platform === 'win32' ? 'junction' : 'dir'
+    await symlink(join(testDir, 'visible'), join(testDir, 'linked'), linkType)
+    const res = await fetch(`${baseUrl}/api/directories?path=${encodeURIComponent(testDir)}`)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { directories: Array<{ name: string; path: string }> }
+    const linked = body.directories.find((d) => d.name === 'linked')
+    expect(linked).toBeDefined()
+    expect(linked!.path).toBe(join(testDir, 'linked'))
+  })
+
+  describe.skipIf(process.platform === 'win32')('broken symlinks', () => {
+    it('excludes broken symlinks', async () => {
+      await symlink(join(testDir, 'nonexistent'), join(testDir, 'broken'), 'dir')
+      const res = await fetch(`${baseUrl}/api/directories?path=${encodeURIComponent(testDir)}`)
+      expect(res.status).toBe(200)
+      const body = (await res.json()) as { directories: Array<{ name: string }> }
+      const names = body.directories.map((d) => d.name)
+      expect(names).not.toContain('broken')
+    })
   })
 })

--- a/src/server/routes/directories.ts
+++ b/src/server/routes/directories.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express'
 import { readdir } from 'node:fs/promises'
 import { resolve, join, dirname, basename } from 'node:path'
+import { isDirectoryEntry } from '../utils/fs.js'
 
 export function createDirectoryRoutes(): Router {
   const router = Router()
@@ -13,12 +14,15 @@ export function createDirectoryRoutes(): Router {
     try {
       const resolvedPath = resolve(path)
       const entries = await readdir(resolvedPath, { withFileTypes: true })
-      const directories = entries
-        .filter((entry) => entry.isDirectory())
-        .map((entry) => ({
-          name: entry.name,
-          path: join(resolvedPath, entry.name),
-        }))
+      const dirs = await Promise.all(
+        entries.map(async (entry) =>
+          (await isDirectoryEntry(resolvedPath, entry))
+            ? { name: entry.name, path: join(resolvedPath, entry.name) }
+            : null,
+        ),
+      )
+      const directories = dirs
+        .filter((d): d is { name: string; path: string } => d !== null)
         .sort((a, b) => a.name.localeCompare(b.name))
 
       const parent = dirname(resolvedPath)

--- a/src/server/routes/plugins.ts
+++ b/src/server/routes/plugins.ts
@@ -8,6 +8,7 @@ import { promisify } from 'node:util'
 import type { ProviderPluginRegistry } from '../../provider/index.js'
 import type { ProviderPluginDiagnostic } from '../providers/plugins/index.js'
 import { getGlobalConfigDir } from '../../cli/paths.js'
+import { isDirectoryEntry } from '../utils/fs.js'
 import type { ProviderRegistry } from '../providers/plugins/registry.js'
 import type { Config } from '../../shared/types.js'
 
@@ -189,7 +190,7 @@ export function createPluginRoutes(options: {
       const entries = await readdir(pluginsDir, { withFileTypes: true })
       const installed: { name: string; version: string | null }[] = []
       for (const entry of entries) {
-        if (!entry.isDirectory()) continue
+        if (!(await isDirectoryEntry(pluginsDir, entry))) continue
         const pkgPath = join(pluginsDir, entry.name, 'package.json')
         let version: string | null = null
         try {

--- a/src/server/routes/workspace-config.ts
+++ b/src/server/routes/workspace-config.ts
@@ -4,6 +4,7 @@ import { constants } from 'node:fs'
 import { resolve, isAbsolute, join, win32 } from 'node:path'
 import { loadWorkspaceConfig, saveWorkspaceConfig } from '../git/workspace-config.js'
 import { getGlobalDataDir } from '../git/workspace.js'
+import { isDirectoryEntry } from '../utils/fs.js'
 import { getProjectByWorkdir, updateProject } from '../db/projects.js'
 import { setSessionDisabledServers } from '../mcp/session-overrides.js'
 import { logger } from '../utils/logger.js'
@@ -55,7 +56,7 @@ async function findOrphanedWorkspaces(dir: string): Promise<{ name: string }[]> 
   try {
     const entries = await readdir(dir, { withFileTypes: true })
     for (const entry of entries) {
-      if (entry.isDirectory()) {
+      if (await isDirectoryEntry(dir, entry)) {
         try {
           const gitStat = await stat(join(dir, entry.name, '.git'))
           if (gitStat.isDirectory()) {

--- a/src/server/utils/fs.ts
+++ b/src/server/utils/fs.ts
@@ -1,0 +1,19 @@
+import { stat } from 'node:fs/promises'
+import { join } from 'node:path'
+import type { Dirent } from 'node:fs'
+
+/**
+ * Whether a readdir entry is a directory, following symlinks. Dirent.isDirectory()
+ * reflects the entry's own file type and never follows symlinks, so symlinked
+ * directories are otherwise invisible in listings. Broken and cyclic symlinks
+ * (stat throws ENOENT/ELOOP) are excluded.
+ */
+export async function isDirectoryEntry(parent: string, entry: Dirent): Promise<boolean> {
+  if (entry.isDirectory()) return true
+  if (!entry.isSymbolicLink()) return false
+  try {
+    return (await stat(join(parent, entry.name))).isDirectory()
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
### Summary

The bug: Openfox ignores projects that are symlinks to directories  #243

The fix: checking that a directory exists does now perform two checks:

1. either it is a real directory
2. or it is a symlink pointing to a real directry

### AI-Enhanced Development

- **AI Models:** DeepSeek V4 Flash

### Cache Impact

Does this PR affect anything cached — system prompts, tool definitions, skills, or other context?

- **No**

### Tests

Tests performed and passed
All automated checks were run against the rebased branch (c6442241 = symlink fix on ae26b30b / v2.0.120), clean worktree.

1. New unit tests (added in this PR)

src/server/git/workspace.test.ts — listWorkspaces:
- includes symlinked workspace directories — a symlinked dir is returned as a workspace
- excludes broken symlinked workspace directories — a symlink whose target is missing (stat → ENOENT) is excluded

src/server/routes/directories.test.ts — GET /api/directories (real filesystem symlinks via node:fs symlink):
- returns symlinked directories — a symlinked folder appears in the listing with its resolved path
- excludes broken symlinks (skipped on Windows via describe.skipIf) — a broken link is not listed

2. Targeted run — passed

npx vitest run src/server/git/workspace.test.ts src/server/routes/directories.test.ts

  Test Files  2 passed (2)
  Tests      43 passed (43)

3. Full unit suite — passed

npm run test:unit

  Test Files  319 passed | 2 skipped (321)
  Tests      4057 passed | 33 skipped (4097)

4. Static checks — passed

npm run check   # exit 0
Includes: typecheck (server + web + e2e), ESLint, Prettier, and duplicate-code detection (jscpd) — 0 clones.

Not run
- npm test full suite (includes slow e2e suite) and Playwright e2e — not run; recommend before merge.

Manual test plan (recommended)

Covers the four call sites the fix touches (isDirectoryEntry in src/server/utils/fs.ts:16):

1. Directory browser (routes/directories.ts): launch the app, browse to a dir containing ln -s <real-dir> linked — the linked folder appears and is navigable; a broken link (ln -s <missing> broken) does not appear.

2. Workspace listing (git/workspace.ts listWorkspaces): a symlinked worktree dir appears in the workspaces panel with its git branch.

3. Orphaned workspace scan (routes/workspace-config.ts findOrphanedWorkspaces, used at lines 219/224): a symlinked git repo is offered for re-attach.

4. Plugins listing (routes/plugins.ts): a symlinked plugin dir shows in installed plugins.

Precondition for a manual test: revert to the stock build and confirm symlinked dirs are absent (repro), then run the modified build and confirm they appear.