### PR TITLE
fix(web): remove fake hardcoded fields from the provider defaults modal 

### DIFF
--- a/web/src/components/shared/ProviderModal.test.tsx
+++ b/web/src/components/shared/ProviderModal.test.tsx
@@ -1,14 +1,16 @@
 // @vitest-environment happy-dom
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import type { ComponentProps } from 'react'
 import { createRoot } from 'react-dom/client'
 import { ProviderModal } from './ProviderModal'
 import type { ProviderFormData } from './ProviderModal'
 
-describe('ProviderModal - thinkingLevel persistence', () => {
-  let container: HTMLElement
-  let root: ReturnType<typeof createRoot>
-  let onSaveMock: ReturnType<typeof vi.fn>
+let container: HTMLElement
+let root: ReturnType<typeof createRoot>
+let onSaveMock: ReturnType<typeof vi.fn>
 
+/** Mounts a fresh React root before each test in the calling suite and tears it down after. */
+function setupRoot() {
   beforeEach(() => {
     container = document.createElement('div')
     document.body.appendChild(container)
@@ -21,54 +23,69 @@ describe('ProviderModal - thinkingLevel persistence', () => {
     document.body.removeChild(container)
     vi.unstubAllGlobals()
   })
+}
 
-  function makeEditProvider() {
-    return {
-      id: 'test-provider',
-      name: 'Test Provider',
-      url: 'http://localhost:8000/v1',
-      backend: 'vllm' as const,
-      models: [
-        {
-          id: 'test-model',
-          contextWindow: 200000,
-          thinkingEnabled: true,
-        },
-      ],
-    }
+const tick = (ms = 50) => new Promise((resolve) => setTimeout(resolve, ms))
+
+/** Renders the modal on step 2 with the shared onSave mock, then waits for its effects to settle. */
+async function renderProviderModal(props: Partial<ComponentProps<typeof ProviderModal>> = {}, waitMs = 200) {
+  root.render(
+    <ProviderModal
+      isOpen={true}
+      onClose={vi.fn()}
+      onSave={onSaveMock as (provider: ProviderFormData) => void}
+      initialStep={2}
+      {...props}
+    />,
+  )
+  await tick(waitMs)
+}
+
+function providerWithModels(models: Array<Record<string, unknown>>) {
+  return {
+    id: 'test-provider',
+    name: 'Test Provider',
+    url: 'http://localhost:8000/v1',
+    backend: 'vllm' as const,
+    models: models as never,
   }
+}
+
+function clickSave() {
+  const saveButton = document.body.querySelector('[data-testid="provider-modal-save"]') as HTMLButtonElement | null
+  saveButton?.click()
+  return saveButton
+}
+
+const savedProvider = (): ProviderFormData => onSaveMock.mock.calls[0]![0]!
+
+const buttonByText = (text: string) =>
+  Array.from(document.body.querySelectorAll('button')).find((button) => button.textContent?.trim() === text) as
+    HTMLButtonElement | undefined
+
+/** React controlled inputs only react to the native value setter followed by an 'input' event. */
+function setInputValue(input: HTMLInputElement, value: string) {
+  Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')?.set?.call(input, value)
+  input.dispatchEvent(new Event('input', { bubbles: true }))
+}
+
+describe('ProviderModal - thinkingLevel persistence', () => {
+  setupRoot()
+
+  const makeEditProvider = () =>
+    providerWithModels([{ id: 'test-model', contextWindow: 200000, thinkingEnabled: true }])
 
   async function renderAndSave(thinkingLevel?: string) {
     const modelId = 'test-model'
-    await new Promise<void>((resolve) => {
-      root.render(
-        <ProviderModal
-          isOpen={true}
-          onClose={vi.fn()}
-          onSave={onSaveMock as (provider: ProviderFormData) => void}
-          initialStep={2}
-          editProvider={makeEditProvider()}
-          editModelId={modelId}
-        />,
-      )
-      // Wait for useEffect to initialize modelConfigs from editProvider
-      setTimeout(resolve, 200)
-    })
+    await renderProviderModal({ editProvider: makeEditProvider(), editModelId: modelId })
 
     // Find the reasoning effort input (free-text variant; the select variant is
     // matched via the same aria-label in other tests)
     const effortInput = document.body.querySelector('input[aria-label="Reasoning effort"]') as HTMLInputElement | null
-
-    if (thinkingLevel !== undefined && effortInput) {
-      // React controlled components listen to 'input' event with native setter
-      const nativeInputValueSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')?.set
-      nativeInputValueSetter?.call(effortInput, thinkingLevel)
-      effortInput.dispatchEvent(new Event('input', { bubbles: true }))
-    }
+    if (thinkingLevel !== undefined && effortInput) setInputValue(effortInput, thinkingLevel)
 
     // Click "Save Provider" (no separate review step anymore)
-    const saveButton = document.body.querySelector('[data-testid="provider-modal-save"]') as HTMLButtonElement | null
-    if (saveButton) saveButton.click()
+    clickSave()
 
     return { modelId }
   }
@@ -77,8 +94,7 @@ describe('ProviderModal - thinkingLevel persistence', () => {
     const { modelId } = await renderAndSave('high')
 
     expect(onSaveMock).toHaveBeenCalledTimes(1)
-    const savedData: ProviderFormData = onSaveMock.mock.calls[0]![0]!
-    const savedModel = savedData.models.find((m) => m.id === modelId)
+    const savedModel = savedProvider().models.find((m) => m.id === modelId)
     expect(savedModel).toBeDefined()
     expect(savedModel?.thinkingLevel).toBe('high')
   })
@@ -87,39 +103,29 @@ describe('ProviderModal - thinkingLevel persistence', () => {
     const { modelId } = await renderAndSave(undefined)
 
     expect(onSaveMock).toHaveBeenCalledTimes(1)
-    const savedData: ProviderFormData = onSaveMock.mock.calls[0]![0]!
-    const savedModel = savedData.models.find((m) => m.id === modelId)
+    const savedModel = savedProvider().models.find((m) => m.id === modelId)
     expect(savedModel).toBeDefined()
     // No default thinkingLevel — auto-config or user sets it explicitly
     expect(savedModel?.thinkingLevel).toBeUndefined()
   })
 
   it('uses a constrained reasoning effort selector with medium as the provider default', async () => {
-    await new Promise<void>((resolve) => {
-      root.render(
-        <ProviderModal
-          isOpen={true}
-          onClose={vi.fn()}
-          onSave={onSaveMock as (provider: ProviderFormData) => void}
-          initialStep={2}
-          editProvider={{
-            id: 'external-provider',
-            name: 'External Account Provider',
-            url: 'http://localhost:8000/v1',
-            backend: 'openai',
-            models: [
-              {
-                id: 'reasoning-model',
-                contextWindow: 1_050_000,
-                thinkingEnabled: true,
-                reasoningEfforts: ['none', 'low', 'medium', 'high', 'xhigh', 'max'],
-              },
-            ],
-          }}
-          editModelId="reasoning-model"
-        />,
-      )
-      setTimeout(resolve, 200)
+    await renderProviderModal({
+      editProvider: {
+        id: 'external-provider',
+        name: 'External Account Provider',
+        url: 'http://localhost:8000/v1',
+        backend: 'openai',
+        models: [
+          {
+            id: 'reasoning-model',
+            contextWindow: 1_050_000,
+            thinkingEnabled: true,
+            reasoningEfforts: ['none', 'low', 'medium', 'high', 'xhigh', 'max'],
+          },
+        ],
+      },
+      editModelId: 'reasoning-model',
     })
 
     const effortSelect = document.body.querySelector(
@@ -136,59 +142,44 @@ describe('ProviderModal - thinkingLevel persistence', () => {
       'max',
     ])
 
-    const saveButton = document.body.querySelector('[data-testid="provider-modal-save"]') as HTMLButtonElement | null
-    saveButton?.click()
+    clickSave()
 
-    const savedData: ProviderFormData = onSaveMock.mock.calls[0]![0]!
-    expect(savedData.models.find((model) => model.id === 'reasoning-model')?.thinkingLevel).toBe('medium')
+    expect(savedProvider().models.find((model) => model.id === 'reasoning-model')?.thinkingLevel).toBe('medium')
   })
 
   it('saves a provider reasoning effort selected from the catalog values', async () => {
-    await new Promise<void>((resolve) => {
-      root.render(
-        <ProviderModal
-          isOpen={true}
-          onClose={vi.fn()}
-          onSave={onSaveMock as (provider: ProviderFormData) => void}
-          initialStep={2}
-          editProvider={{
-            id: 'external-provider',
-            name: 'External Account Provider',
-            url: 'http://localhost:8000/v1',
-            backend: 'openai',
-            models: [
-              {
-                id: 'reasoning-model',
-                contextWindow: 1_050_000,
-                thinkingEnabled: true,
-                reasoningEfforts: ['low', 'medium', 'high'],
-              },
-            ],
-          }}
-          editModelId="reasoning-model"
-        />,
-      )
-      setTimeout(resolve, 200)
+    await renderProviderModal({
+      editProvider: {
+        id: 'external-provider',
+        name: 'External Account Provider',
+        url: 'http://localhost:8000/v1',
+        backend: 'openai',
+        models: [
+          {
+            id: 'reasoning-model',
+            contextWindow: 1_050_000,
+            thinkingEnabled: true,
+            reasoningEfforts: ['low', 'medium', 'high'],
+          },
+        ],
+      },
+      editModelId: 'reasoning-model',
     })
 
     const effortSelect = document.body.querySelector('select[aria-label="Reasoning effort"]') as HTMLSelectElement
-    const nativeSelectValueSetter = Object.getOwnPropertyDescriptor(window.HTMLSelectElement.prototype, 'value')?.set
-    nativeSelectValueSetter?.call(effortSelect, 'high')
+    Object.getOwnPropertyDescriptor(window.HTMLSelectElement.prototype, 'value')?.set?.call(effortSelect, 'high')
     effortSelect.dispatchEvent(new Event('change', { bubbles: true }))
 
-    const saveButton = document.body.querySelector('[data-testid="provider-modal-save"]') as HTMLButtonElement | null
-    saveButton?.click()
+    clickSave()
 
-    const savedData: ProviderFormData = onSaveMock.mock.calls[0]![0]!
-    expect(savedData.models.find((model) => model.id === 'reasoning-model')?.thinkingLevel).toBe('high')
+    expect(savedProvider().models.find((model) => model.id === 'reasoning-model')?.thinkingLevel).toBe('high')
   })
 
   it('includes all model fields in save payload', async () => {
     const { modelId } = await renderAndSave(undefined)
 
     expect(onSaveMock).toHaveBeenCalledTimes(1)
-    const savedData: ProviderFormData = onSaveMock.mock.calls[0]![0]!
-    const savedModel = savedData.models.find((m) => m.id === modelId)
+    const savedModel = savedProvider().models.find((m) => m.id === modelId)
     expect(savedModel).toBeDefined()
 
     // Every field the UI can set must be present in the save payload.
@@ -214,12 +205,8 @@ describe('ProviderModal - thinkingLevel persistence', () => {
   })
 
   it('preserves previously-saved advanced parameters when reopening the modal', async () => {
-    const editProvider = {
-      id: 'test-provider',
-      name: 'Test Provider',
-      url: 'http://localhost:8000/v1',
-      backend: 'vllm' as const,
-      models: [
+    await renderProviderModal({
+      editProvider: providerWithModels([
         {
           id: 'test-model',
           contextWindow: 200000,
@@ -230,31 +217,16 @@ describe('ProviderModal - thinkingLevel persistence', () => {
           maxTokens: 2048,
           compactionThreshold: 0.7,
         },
-      ],
-    }
-
-    await new Promise<void>((resolve) => {
-      root.render(
-        <ProviderModal
-          isOpen={true}
-          onClose={vi.fn()}
-          onSave={onSaveMock as (provider: ProviderFormData) => void}
-          initialStep={2}
-          editProvider={editProvider}
-          editModelId="test-model"
-        />,
-      )
-      setTimeout(resolve, 200)
+      ]),
+      editModelId: 'test-model',
     })
 
     // Save immediately without touching any field — reopening the modal must not
     // silently reset previously-persisted advanced parameters to undefined/defaults.
-    const saveButton = document.body.querySelector('[data-testid="provider-modal-save"]') as HTMLButtonElement | null
-    saveButton?.click()
+    clickSave()
 
     expect(onSaveMock).toHaveBeenCalledTimes(1)
-    const savedData: ProviderFormData = onSaveMock.mock.calls[0]![0]!
-    const savedModel = savedData.models.find((m) => m.id === 'test-model')
+    const savedModel = savedProvider().models.find((m) => m.id === 'test-model')
     expect(savedModel).toBeDefined()
     expect(savedModel?.temperature).toBe(0.42)
     expect(savedModel?.topP).toBe(0.9)
@@ -264,75 +236,44 @@ describe('ProviderModal - thinkingLevel persistence', () => {
   })
 
   it('does not reset form step when editProvider reference changes (parent re-render)', async () => {
-    await new Promise<void>((resolve) => {
-      root.render(
-        <ProviderModal
-          isOpen={true}
-          onClose={vi.fn()}
-          onSave={onSaveMock as (provider: ProviderFormData) => void}
-          initialStep={2}
-          editProvider={makeEditProvider()}
-          editModelId="test-model"
-        />,
-      )
-      setTimeout(resolve, 200)
-    })
+    await renderProviderModal({ editProvider: makeEditProvider(), editModelId: 'test-model' })
 
     // On step 2, the save button is visible (no separate review step)
-    const saveButton = document.body.querySelector('[data-testid="provider-modal-save"]') as HTMLButtonElement | null
-    expect(saveButton).toBeTruthy()
+    expect(document.body.querySelector('[data-testid="provider-modal-save"]')).toBeTruthy()
     expect(document.body.querySelector('[data-testid="provider-modal-next"]')).toBeNull()
 
     // Simulate parent re-render with new editProvider reference (identical data)
-    root.render(
-      <ProviderModal
-        isOpen={true}
-        onClose={vi.fn()}
-        onSave={onSaveMock as (provider: ProviderFormData) => void}
-        initialStep={2}
-        editProvider={makeEditProvider()}
-        editModelId="test-model"
-      />,
-    )
-    await new Promise((resolve) => setTimeout(resolve, 100))
+    await renderProviderModal({ editProvider: makeEditProvider(), editModelId: 'test-model' }, 100)
 
     // MUST still be on step 2 — save button still visible
     expect(document.body.querySelector('[data-testid="provider-modal-save"]')).toBeTruthy()
     expect(document.body.querySelector('[data-testid="provider-modal-next"]')).toBeNull()
   })
+
   it('prefills the catalog context window when a model is selected', async () => {
     vi.stubGlobal(
       'fetch',
       vi.fn(async () => new Response(JSON.stringify({ state: 'connected' }), { status: 200 })),
     )
-    await new Promise<void>((resolve) => {
-      root.render(
-        <ProviderModal
-          isOpen={true}
-          onClose={vi.fn()}
-          onSave={onSaveMock as (provider: ProviderFormData) => void}
-          initialStep={2}
-          editProvider={{
-            id: 'provider-1',
-            name: 'External Provider',
-            url: 'https://provider.example/v1',
-            backend: 'openai',
-            transportAdapter: 'example-transport',
-            models: [
-              { id: 'selected-model', contextWindow: 1050000, selected: true },
-              {
-                id: 'catalog-model',
-                name: 'Catalog model',
-                apiModelId: 'catalog-model',
-                requestBody: { service_tier: 'priority' },
-                reasoningEfforts: ['low', 'high'],
-                contextWindow: 400000,
-              },
-            ],
-          }}
-        />,
-      )
-      setTimeout(resolve, 200)
+    await renderProviderModal({
+      editProvider: {
+        id: 'provider-1',
+        name: 'External Provider',
+        url: 'https://provider.example/v1',
+        backend: 'openai',
+        transportAdapter: 'example-transport',
+        models: [
+          { id: 'selected-model', contextWindow: 1050000, selected: true },
+          {
+            id: 'catalog-model',
+            name: 'Catalog model',
+            apiModelId: 'catalog-model',
+            requestBody: { service_tier: 'priority' },
+            reasoningEfforts: ['low', 'high'],
+            contextWindow: 400000,
+          },
+        ],
+      },
     })
 
     const availableRows = Array.from(document.body.querySelectorAll('[role="checkbox"]'))
@@ -340,13 +281,11 @@ describe('ProviderModal - thinkingLevel persistence', () => {
       HTMLElement | undefined
     expect(catalogRow).toBeTruthy()
     catalogRow?.click()
-    await new Promise((resolve) => setTimeout(resolve, 50))
+    await tick()
 
-    const saveButton = document.body.querySelector('[data-testid="provider-modal-save"]') as HTMLButtonElement | null
-    saveButton?.click()
+    clickSave()
 
-    const savedData: ProviderFormData = onSaveMock.mock.calls[0]![0]!
-    expect(savedData.models.find((model) => model.id === 'catalog-model')).toEqual(
+    expect(savedProvider().models.find((model) => model.id === 'catalog-model')).toEqual(
       expect.objectContaining({
         name: 'Catalog model',
         apiModelId: 'catalog-model',
@@ -373,24 +312,18 @@ describe('ProviderModal - thinkingLevel persistence', () => {
       }),
     )
 
-    await new Promise<void>((resolve) => {
-      root.render(
-        <ProviderModal
-          isOpen={true}
-          onClose={vi.fn()}
-          onSave={onSaveMock as (provider: ProviderFormData) => void}
-          initialStep={2}
-          editProvider={{
-            id: 'no-models-provider',
-            name: 'No Models Provider',
-            url: 'http://localhost:8000/v1',
-            backend: 'openai',
-            models: [],
-          }}
-        />,
-      )
-      setTimeout(resolve, 300)
-    })
+    await renderProviderModal(
+      {
+        editProvider: {
+          id: 'no-models-provider',
+          name: 'No Models Provider',
+          url: 'http://localhost:8000/v1',
+          backend: 'openai',
+          models: [],
+        },
+      },
+      300,
+    )
 
     // The manual model input is available even though discovery failed.
     const manualInput = document.body.querySelector(
@@ -398,69 +331,52 @@ describe('ProviderModal - thinkingLevel persistence', () => {
     ) as HTMLInputElement
     expect(manualInput).toBeTruthy()
 
-    const nativeInputValueSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')?.set
-    nativeInputValueSetter?.call(manualInput, 'my-cline-model')
-    manualInput.dispatchEvent(new Event('input', { bubbles: true }))
+    setInputValue(manualInput, 'my-cline-model')
 
     const addButton = document.body.querySelector(
       '[data-testid="provider-modal-manual-model-add"]',
     ) as HTMLButtonElement | null
     addButton?.click()
-    await new Promise((resolve) => setTimeout(resolve, 50))
+    await tick()
 
-    const saveButton = document.body.querySelector('[data-testid="provider-modal-save"]') as HTMLButtonElement | null
-    saveButton?.click()
+    clickSave()
 
     expect(onSaveMock).toHaveBeenCalledTimes(1)
-    const savedData: ProviderFormData = onSaveMock.mock.calls[0]![0]!
-    const savedModel = savedData.models.find((m) => m.id === 'my-cline-model')
+    const savedModel = savedProvider().models.find((m) => m.id === 'my-cline-model')
     expect(savedModel).toBeDefined()
     expect(savedModel?.selected).toBe(true)
     expect(savedModel?.contextWindow).toBe(200000)
   })
 
   it('rejects a duplicate manual model id and selects the existing one', async () => {
-    await new Promise<void>((resolve) => {
-      root.render(
-        <ProviderModal
-          isOpen={true}
-          onClose={vi.fn()}
-          onSave={onSaveMock as (provider: ProviderFormData) => void}
-          initialStep={2}
-          editProvider={{
-            id: 'dup-provider',
-            name: 'Dup Provider',
-            url: 'http://localhost:8000/v1',
-            backend: 'vllm',
-            models: [{ id: 'existing-model', contextWindow: 200000 }],
-          }}
-        />,
-      )
-      setTimeout(resolve, 200)
+    await renderProviderModal({
+      editProvider: {
+        id: 'dup-provider',
+        name: 'Dup Provider',
+        url: 'http://localhost:8000/v1',
+        backend: 'vllm',
+        models: [{ id: 'existing-model', contextWindow: 200000 }],
+      },
     })
 
     const manualInput = document.body.querySelector(
       '[data-testid="provider-modal-manual-model-input"]',
     ) as HTMLInputElement
-    const nativeInputValueSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')?.set
-    nativeInputValueSetter?.call(manualInput, 'existing-model')
-    manualInput.dispatchEvent(new Event('input', { bubbles: true }))
+    setInputValue(manualInput, 'existing-model')
 
     const addButton = document.body.querySelector(
       '[data-testid="provider-modal-manual-model-add"]',
     ) as HTMLButtonElement | null
     addButton?.click()
-    await new Promise((resolve) => setTimeout(resolve, 50))
+    await tick()
 
     // An error message is shown and the duplicate was not added.
     expect(document.body.textContent).toContain('already in the list')
 
-    const saveButton = document.body.querySelector('[data-testid="provider-modal-save"]') as HTMLButtonElement | null
-    saveButton?.click()
+    clickSave()
 
-    const savedData: ProviderFormData = onSaveMock.mock.calls[0]![0]!
     // Only the original model is present — no duplicate.
-    expect(savedData.models.filter((m) => m.id === 'existing-model')).toHaveLength(1)
+    expect(savedProvider().models.filter((m) => m.id === 'existing-model')).toHaveLength(1)
   })
 
   it.each([
@@ -498,32 +414,23 @@ describe('ProviderModal - thinkingLevel persistence', () => {
       }),
     )
 
-    await new Promise<void>((resolve) => {
-      root.render(
-        <ProviderModal isOpen={true} onClose={vi.fn()} onSave={onSaveMock as (provider: ProviderFormData) => void} />,
-      )
-      setTimeout(resolve, 100)
-    })
-
-    const buttonByText = (text: string) =>
-      Array.from(document.body.querySelectorAll('button')).find((button) => button.textContent?.trim() === text) as
-        HTMLButtonElement | undefined
+    // Starts on step 1: the engine picker is only reachable from there.
+    await renderProviderModal({ initialStep: undefined }, 100)
 
     buttonByText('Account Provider')?.click()
-    await new Promise((resolve) => setTimeout(resolve, 0))
+    await tick(0)
     buttonByText(engineName)?.click()
-    await new Promise((resolve) => setTimeout(resolve, 0))
+    await tick(0)
 
     const nextButton = document.body.querySelector('[data-testid="provider-modal-next"]') as HTMLButtonElement | null
     expect(nextButton?.disabled).toBe(false)
     nextButton?.click()
-    await new Promise((resolve) => setTimeout(resolve, 50))
+    await tick()
 
-    const saveButton = document.body.querySelector('[data-testid="provider-modal-save"]') as HTMLButtonElement | null
-    saveButton?.click()
+    clickSave()
 
     expect(onSaveMock).toHaveBeenCalledTimes(1)
-    const savedData: ProviderFormData = onSaveMock.mock.calls[0]![0]!
+    const savedData = savedProvider()
     expect(savedData.backend).toBe(expectedBackend)
     expect(savedData.authAdapter).toBeUndefined()
     expect(savedData.transportAdapter).toBeUndefined()
@@ -555,72 +462,22 @@ describe('ProviderModal - thinkingLevel persistence', () => {
       }),
     )
 
-    await new Promise<void>((resolve) => {
-      root.render(
-        <ProviderModal
-          isOpen={true}
-          onClose={vi.fn()}
-          onSave={onSaveMock as (provider: ProviderFormData) => void}
-          initialStep={2}
-          editProvider={makeEditProvider()}
-          editModelId="test-model"
-        />,
-      )
-      setTimeout(resolve, 200)
-    })
+    await renderProviderModal({ editProvider: makeEditProvider(), editModelId: 'test-model' })
 
-    const autoConfigButton = Array.from(document.body.querySelectorAll('button')).find(
-      (button) => button.textContent?.trim() === 'Auto-config',
-    ) as HTMLButtonElement | undefined
-    autoConfigButton?.click()
-    await new Promise((resolve) => setTimeout(resolve, 50))
+    buttonByText('Auto-config')?.click()
+    await tick()
 
-    const saveButton = document.body.querySelector('[data-testid="provider-modal-save"]') as HTMLButtonElement | null
-    saveButton?.click()
+    clickSave()
 
-    const savedData: ProviderFormData = onSaveMock.mock.calls[0]![0]!
-    expect(savedData.sendReasoningInMessages).toBe(false)
+    expect(savedProvider().sendReasoningInMessages).toBe(false)
   })
 })
 
 describe('ProviderModal - sampling param Send checkboxes', () => {
-  let container: HTMLElement
-  let root: ReturnType<typeof createRoot>
-  let onSaveMock: ReturnType<typeof vi.fn>
+  setupRoot()
 
-  beforeEach(() => {
-    container = document.createElement('div')
-    document.body.appendChild(container)
-    root = createRoot(container)
-    onSaveMock = vi.fn()
-  })
-
-  afterEach(() => {
-    root.unmount()
-    document.body.removeChild(container)
-  })
-
-  async function renderModal(models: Array<Record<string, unknown>>, editModelId?: string) {
-    await new Promise<void>((resolve) => {
-      root.render(
-        <ProviderModal
-          isOpen={true}
-          onClose={vi.fn()}
-          onSave={onSaveMock as (provider: ProviderFormData) => void}
-          initialStep={2}
-          editProvider={{
-            id: 'test-provider',
-            name: 'Test Provider',
-            url: 'http://localhost:8000/v1',
-            backend: 'vllm' as const,
-            models: models as never,
-          }}
-          editModelId={editModelId}
-        />,
-      )
-      setTimeout(resolve, 200)
-    })
-  }
+  const renderModal = (models: Array<Record<string, unknown>>, editModelId?: string) =>
+    renderProviderModal({ editProvider: providerWithModels(models), editModelId })
 
   function getSendCheckbox(paramKey: string): HTMLInputElement | null {
     return document.body.querySelector(`input[data-testid="send-${paramKey}"]`) as HTMLInputElement | null
@@ -630,10 +487,7 @@ describe('ProviderModal - sampling param Send checkboxes', () => {
     return document.body.querySelector(`input[data-testid="param-${paramKey}"]`) as HTMLInputElement | null
   }
 
-  function save() {
-    const saveButton = document.body.querySelector('[data-testid="provider-modal-save"]') as HTMLButtonElement | null
-    saveButton?.click()
-  }
+  const savedTestModel = () => savedProvider().models.find((m) => m.id === 'test-model')
 
   it('renders Send checkboxes for Temperature, Top P, Top K, Max tokens checked by default', async () => {
     await renderModal([{ id: 'test-model', contextWindow: 200000 }], 'test-model')
@@ -656,10 +510,8 @@ describe('ProviderModal - sampling param Send checkboxes', () => {
     expect(input?.disabled).toBe(true)
     expect(input?.value).toBe('')
 
-    save()
-    const savedData: ProviderFormData = onSaveMock.mock.calls[0]![0]!
-    const savedModel = savedData.models.find((m) => m.id === 'test-model')
-    expect(savedModel?.omitParams).toEqual(['temperature'])
+    clickSave()
+    expect(savedTestModel()?.omitParams).toEqual(['temperature'])
   })
 
   it('re-checking Temperature removes it from omitParams', async () => {
@@ -669,10 +521,8 @@ describe('ProviderModal - sampling param Send checkboxes', () => {
     cb.click()
     cb.click()
 
-    save()
-    const savedData: ProviderFormData = onSaveMock.mock.calls[0]![0]!
-    const savedModel = savedData.models.find((m) => m.id === 'test-model')
-    expect(savedModel?.omitParams).toBeUndefined()
+    clickSave()
+    expect(savedTestModel()?.omitParams).toBeUndefined()
   })
 
   it('preserves pre-existing omitParams entries (e.g. reasoning_effort) when toggling Temperature', async () => {
@@ -682,11 +532,9 @@ describe('ProviderModal - sampling param Send checkboxes', () => {
     expect(tempCb.checked).toBe(true)
     tempCb.click()
 
-    save()
-    const savedData: ProviderFormData = onSaveMock.mock.calls[0]![0]!
-    const savedModel = savedData.models.find((m) => m.id === 'test-model')
-    expect(savedModel?.omitParams).toEqual(expect.arrayContaining(['reasoning_effort', 'temperature']))
-    expect(savedModel?.omitParams).toHaveLength(2)
+    clickSave()
+    expect(savedTestModel()?.omitParams).toEqual(expect.arrayContaining(['reasoning_effort', 'temperature']))
+    expect(savedTestModel()?.omitParams).toHaveLength(2)
   })
 
   it('reflects auto-config omitParams as unchecked boxes on modal open', async () => {
@@ -703,49 +551,67 @@ describe('ProviderModal - sampling param Send checkboxes', () => {
     const tempInput = getParamInput('temperature')
     expect(tempInput?.disabled).toBe(true)
 
-    save()
-    const savedData: ProviderFormData = onSaveMock.mock.calls[0]![0]!
-    const savedModel = savedData.models.find((m) => m.id === 'test-model')
-    expect(savedModel?.omitParams).toEqual(['temperature', 'top_p', 'top_k', 'reasoning_effort'])
+    clickSave()
+    expect(savedTestModel()?.omitParams).toEqual(['temperature', 'top_p', 'top_k', 'reasoning_effort'])
   })
 
-  it('shows a re-enable checkbox for reasoning_effort when auto-config omitted it, and re-checking removes it', async () => {
-    await renderModal(
-      [{ id: 'test-model', contextWindow: 200000, thinkingEnabled: true, omitParams: ['reasoning_effort'] }],
-      'test-model',
-    )
+  it.each([true, false])(
+    'shows a re-enable checkbox for reasoning_effort omitted by auto-config (thinkingEnabled: %s)',
+    async (thinkingEnabled) => {
+      await renderModal(
+        [{ id: 'test-model', contextWindow: 200000, thinkingEnabled, omitParams: ['reasoning_effort'] }],
+        'test-model',
+      )
 
-    const reEnableCb = document.body.querySelector(
-      'input[data-testid="re-enable-reasoning_effort"]',
-    ) as HTMLInputElement | null
-    expect(reEnableCb).toBeTruthy()
-    expect(reEnableCb?.checked).toBe(false)
+      const reEnableCb = document.body.querySelector(
+        'input[data-testid="re-enable-reasoning_effort"]',
+      ) as HTMLInputElement | null
+      expect(reEnableCb).toBeTruthy()
+      expect(reEnableCb?.checked).toBe(false)
 
-    reEnableCb!.click()
+      // Re-checking it removes the param from omitParams.
+      reEnableCb!.click()
 
-    save()
-    const savedData: ProviderFormData = onSaveMock.mock.calls[0]![0]!
-    const savedModel = savedData.models.find((m) => m.id === 'test-model')
-    expect(savedModel?.omitParams).toBeUndefined()
+      clickSave()
+      expect(savedTestModel()?.omitParams).toBeUndefined()
+    },
+  )
+})
+
+describe('ProviderModal - Provider-Level Defaults modal', () => {
+  setupRoot()
+
+  async function renderModalAndOpenDefaults() {
+    await renderProviderModal({ editProvider: providerWithModels([{ id: 'test-model', contextWindow: 200000 }]) })
+
+    const openButton = document.body.querySelector(
+      'button[title="Provider-level defaults"]',
+    ) as HTMLButtonElement | null
+    expect(openButton).toBeTruthy()
+    openButton!.click()
+  }
+
+  it('does not render hardcoded fake mode params fields', async () => {
+    await renderModalAndOpenDefaults()
+
+    const bodyText = document.body.textContent ?? ''
+    expect(bodyText).not.toContain('Thinking mode params')
+    expect(bodyText).not.toContain('Non-thinking mode params')
   })
 
-  it('shows re-enable reasoning_effort checkbox even when thinking is disabled', async () => {
-    await renderModal(
-      [{ id: 'test-model', contextWindow: 200000, thinkingEnabled: false, omitParams: ['reasoning_effort'] }],
-      'test-model',
-    )
+  it('keeps real fields (thinking response field, send reasoning) functional', async () => {
+    await renderModalAndOpenDefaults()
 
-    const reEnableCb = document.body.querySelector(
-      'input[data-testid="re-enable-reasoning_effort"]',
+    const thinkingFieldInput = document.body.querySelector(
+      'input[aria-label="Thinking response field"]',
     ) as HTMLInputElement | null
-    expect(reEnableCb).toBeTruthy()
-    expect(reEnableCb?.checked).toBe(false)
+    expect(thinkingFieldInput).toBeTruthy()
 
-    reEnableCb!.click()
-
-    save()
-    const savedData: ProviderFormData = onSaveMock.mock.calls[0]![0]!
-    const savedModel = savedData.models.find((m) => m.id === 'test-model')
-    expect(savedModel?.omitParams).toBeUndefined()
+    const sendReasoningLabel = Array.from(document.body.querySelectorAll('label')).find((l) =>
+      l.textContent?.includes('Send reasoning in messages'),
+    )
+    expect(sendReasoningLabel).toBeTruthy()
+    const sendReasoningCb = sendReasoningLabel?.querySelector('input[type="checkbox"]') as HTMLInputElement | null
+    expect(sendReasoningCb).toBeTruthy()
   })
 })

--- a/web/src/components/shared/ProviderModal.tsx
+++ b/web/src/components/shared/ProviderModal.tsx
@@ -1691,31 +1691,16 @@ export function ProviderModal({
           }
         >
           <div className="space-y-4">
-            <p className="text-xs text-text-muted">These apply to all models unless overridden per-model.</p>
-            <div>
-              <label className="text-xs text-text-secondary block mb-1">Non-thinking mode params</label>
-              <input
-                type="text"
-                defaultValue='{"chat_template_kwargs":{"enable_thinking":false}}'
-                readOnly
-                className="w-full px-3 py-2 bg-bg-primary border border-border rounded text-sm text-text-secondary font-mono"
-              />
-            </div>
-            <div>
-              <label className="text-xs text-text-secondary block mb-1">Thinking mode params</label>
-              <input
-                type="text"
-                defaultValue='reasoning_effort: "low"'
-                readOnly
-                className="w-full px-3 py-2 bg-bg-primary border border-border rounded text-sm text-text-secondary font-mono"
-              />
-            </div>
+            <p className="text-xs text-text-muted">
+              Thinking and reasoning effort are configured per model, in each model&rsquo;s Advanced section.
+            </p>
             <div>
               <label className="text-xs text-text-secondary block mb-1">
                 Thinking response field <span className="text-text-muted">(override)</span>
               </label>
               <input
                 type="text"
+                aria-label="Thinking response field"
                 value={thinkingField}
                 onChange={(e) => setThinkingField(e.target.value)}
                 placeholder="Leave blank for auto-detect"


### PR DESCRIPTION
## Summary

The "Provider-Level Defaults" modal displayed two `readOnly` text inputs — **Non-thinking mode params** and **Thinking mode params** — pre-filled with hardcoded example values (`{"chat_template_kwargs":{"enable_thinking":false}}` and `reasoning_effort: "low"`). They were bound to no state, no handler and no save payload: pure decoration that reads as configuration. Users see two settings fields that silently do nothing, right next to two fields that actually work.

**One production change**: 15 lines of dead JSX removed from `ProviderModal.tsx`, replaced by a note pointing at the per-model Advanced section where thinking and reasoning effort are genuinely configured.

```
web/src/components/shared/ProviderModal.tsx      4 insertions, 19 deletions
web/src/components/shared/ProviderModal.test.tsx 234 insertions, 368 deletions
```

## What Changed

**Removed**

- `web/src/components/shared/ProviderModal.tsx` — the `Non-thinking mode params` and `Thinking mode params` `readOnly` inputs, and the "These apply to all models unless overridden per-model." caption that described them.

**Modified**

- `web/src/components/shared/ProviderModal.tsx` — a note replaces the removed block: thinking and reasoning effort are configured per model, in each model's Advanced section. The `Thinking response field` input also gains an `aria-label`; it had a visible `<label>` but no `htmlFor` and no nesting, so it was unlabelled for assistive tech and unaddressable from tests.
- `web/src/components/shared/ProviderModal.test.tsx` — a new `Provider-Level Defaults modal` suite covers the fix, and the file's shared scaffolding is hoisted out of the three suites. 816 → 617 lines, 20 → 22 tests.

**Added**

- Two tests: the fake mode-params fields no longer render, and the two real controls (`Thinking response field`, `Send reasoning in messages`) still render and stay reachable.

## Motivation & Context

I was trying to work out how reasoning modes are configured in OpenFox — specifically where Qwen 3.8's thinking mode gets driven from — and went looking through the provider settings. In **Test & Configure Models** I opened the gear icon and found `reasoning_effort: "low"` sitting in a field labelled "Thinking mode params". That looked like the answer: a provider-wide reasoning-effort default. I got a bit confused, as I knew reasonning effort were already set in another section.  So I tried to change it.

Nothing happened. I retyped, clicked elsewhere, reopened the modal, and kept getting the same value back. It took me a while to work out that the field simply is not editable: `readOnly`, a `defaultValue` instead of `value`, no `onChange`, no state, and no entry in the save payload. Same for "Non-thinking mode params" right above it. They render exactly like the two live controls sitting immediately below them in the same modal — same border, same font, same layout — with nothing to signal that two of the four fields are decoration.

The values chosen make it worse, because they are not obviously placeholders. `enable_thinking: false` and `reasoning_effort: "low"` are plausible real settings, and the caption above them ("These apply to all models unless overridden per-model.") describes a provider-wide override layer. There is no such layer. Thinking and reasoning effort are per-model, edited in each model's Advanced section — which is exactly where I should have been looking, and exactly what the modal steered me away from. Deleting the block and naming where the real settings live is the smallest fix that stops the modal from sending people down that path.

The test refactor rides along because the second commit had to add a suite to a file that already carried three copies of the same React-root scaffolding — see `<details>` for the numbers.

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing

- `npm run test:unit` — **4099 passed, 39 skipped** (4097 before this branch; the two new tests account for the delta).
- `npx vitest run web/src/components/shared/ProviderModal.test.tsx` — **22 passed** before and after the refactor, so the dedup is behaviour-preserving.
- `npm run typecheck` (server + web + e2e), `npm run lint`, `npm run format`, `npm run duplicate` — all clean. `duplicate:web` runs jscpd at `--threshold 0`, and the 19-line clone group that previously sat at `ProviderModal.test.tsx:97-115` / `:146-164` is gone.
- Manual: opened the provider defaults modal on an API provider in `npm run dev`, confirmed the two fake fields are gone, the new note reads correctly, and the thinking-response-field and send-reasoning controls still edit and persist. 
- `npm run test:e2e` is **flaky on my Windows 11 machine** and unrelated to this diff — see the honesty note below.

**Pre-existing e2e flakiness (not caused by this PR).** Across seven full `npm test` runs the e2e suite failed a different set of files each time — `instructions`, `session-name`, `session-rest`, `provider-plugins`, `ask-user`, `planner`, `tools-read` — mostly with `Error: Hook timed out in 10000ms` inside `beforeAll(async () => { server = await createTestServer() })`, followed by `TypeError: Cannot read properties of undefined (reading 'close')` in the matching `afterAll`. I reproduced the same class of failure on a clean `develop` checkout with my changes stashed, so it is a local server-startup timing issue under parallel load, not a regression. None of the failing files import anything from `web/src/`; this PR touches one React component and its test file only. The unit suite (4099 tests) was green on every single run. The second commit was therefore made with `--no-verify` after the four other pre-commit checks (`lint`, `format`, `typecheck`, `duplicate`) passed — CI has the final word.

## Breaking Changes

None. The removed inputs were `readOnly`, had no `onChange` and never contributed to `ProviderFormData`, so no persisted provider configuration reads or writes them. The change is visual only.

- [ ] This PR introduces breaking changes

## Related Issues

None. The modal itself was last touched by `aee8e8e9 refactor(web): unify all modals on shared Modal with fixed header/footer`; this PR builds directly on top of it and does not conflict with it.

## AI-Enhanced Development

- **AI Models:** GLM 5.3 and Opus 5

## Cache Impact

- **No** — the diff is confined to one React component and its test file under `web/src/components/shared/`. It touches no system prompt, tool definition, skill, or any other cached context.

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed

**Key files to review:** `web/src/components/shared/ProviderModal.tsx`, `web/src/components/shared/ProviderModal.test.tsx`

---

<details>
<summary><b>Technical investigation</b> — symptoms, root causes, and proofs</summary>

### Symptoms

The removed block, verbatim from `ProviderModal.tsx` before this PR:

```jsx
<p className="text-xs text-text-muted">These apply to all models unless overridden per-model.</p>
<div>
  <label className="text-xs text-text-secondary block mb-1">Non-thinking mode params</label>
  <input
    type="text"
    defaultValue='{"chat_template_kwargs":{"enable_thinking":false}}'
    readOnly
    className="w-full px-3 py-2 bg-bg-primary border border-border rounded text-sm text-text-secondary font-mono"
  />
</div>
<div>
  <label className="text-xs text-text-secondary block mb-1">Thinking mode params</label>
  <input
    type="text"
    defaultValue='reasoning_effort: "low"'
    readOnly
    className="w-full px-3 py-2 bg-bg-primary border border-border rounded text-sm text-text-secondary font-mono"
  />
</div>
```

Three tells that this is decoration rather than configuration: `defaultValue` instead of `value`, `readOnly` with no `onChange`, and no corresponding key anywhere in `ProviderFormData` or in the `handleSave` payload builder.

### Causes

1. **Dead UI in `ProviderModal.tsx`.** The two inputs were static markup. Their caption ("These apply to all models unless overridden per-model.") described a provider-level override layer that the codebase does not implement — thinking mode and reasoning effort are per-model settings, read from `modelConfigs[model.id]` and edited in the model's Advanced section. Users had no way to tell these two fields apart from the two live controls sitting immediately below them in the same modal.

2. **Unlabelled real input.** `Thinking response field` rendered as a `<label>` followed by a sibling `<input>`, with no `htmlFor` and no nesting. Assistive tech never associated the two. Adding `aria-label="Thinking response field"` fixes the accessibility gap and, as a side effect, gives the new test a stable selector that does not require adding a test-only attribute to production markup.

3. **Test scaffolding triplication.** `ProviderModal.test.tsx` carried three verbatim copies of the same React-root lifecycle (`container = document.createElement('div')` → `createRoot` → `unmount` + `removeChild`), twelve inline `await new Promise((resolve) => { root.render(<ProviderModal ... />); setTimeout(resolve, 200) })` blocks, and a dozen repetitions of `document.body.querySelector('[data-testid="provider-modal-save"]')` and `onSaveMock.mock.calls[0]![0]!`. Adding a fourth suite for the defaults modal would have made it a fourth copy, so the scaffolding was hoisted first.

### Refactor detail

Module-scope helpers now shared by all three suites:

| Helper                               | Replaces                                                                            |
| ------------------------------------ | ----------------------------------------------------------------------------------- |
| `setupRoot()`                        | 3 copies of the `beforeEach`/`afterEach` root lifecycle                             |
| `renderProviderModal(props, waitMs)` | 12 inline render-and-wait blocks                                                    |
| `providerWithModels(models)`         | 3 copies of the same test-provider fixture                                          |
| `clickSave()`                        | 12 `provider-modal-save` lookups                                                    |
| `savedProvider()`                    | 17 `onSaveMock.mock.calls[0]![0]!` casts                                            |
| `tick(ms)`                           | 8 bare `setTimeout` awaits                                                          |
| `buttonByText(text)`                 | 2 button-by-text-content lookups                                                    |
| `setInputValue(input, value)`        | 3 copies of the native-setter + `input` event dance React controlled inputs require |

The two near-identical `re-enable reasoning_effort` tests (identical except `thinkingEnabled: true` / `false`) collapse into one `it.each([true, false])`, keeping both cases.

One assertion from the first draft of the new suite was deliberately dropped: `expect(bodyText).not.toContain('reasoning_effort')`, scoped to the whole `document.body`. `ProviderModal.tsx` renders the literal text `Re-enable reasoning_effort` on step 2 whenever a model carries `omitParams: ['reasoning_effort']`. The assertion passed only because the suite's fixture happens to omit that field — it coupled the defaults-modal test to unrelated step-2 markup and would break on any fixture change. The two `mode params` assertions that remain are unique to the removed block and cover the fix precisely.

The new suite also queries the settings button by its existing `title="Provider-level defaults"` attribute rather than a `data-testid` added for the test, which keeps the production diff at pure deletion.

### Proofs and measurements

- **Behaviour preservation:** `npx vitest run web/src/components/shared/ProviderModal.test.tsx` reports **22 passed** both before the refactor (new tests added to the original 816-line file) and after (617-line refactored file). Same count, same names except the two merged into `it.each`.
- **Suite-wide:** `npm run test:unit` goes from **4097 passed** on `develop` to **4099 passed** on this branch — exactly the two new tests, no collateral.
- **Duplication:** `fallow audit` flagged a 19-line, 2-instance clone group at `ProviderModal.test.tsx:97-115` / `:146-164` before the refactor. It no longer appears, and `npm run duplicate` (jscpd, `--threshold 0` for web) is clean.
- **Flakiness control:** with the branch changes stashed, a clean-`develop` `npm test` run reproduced `Error: Hook timed out in 10000ms` in `e2e/tools-read.test.ts > Read Tools`, confirming the e2e failures are environmental. A second clean-`develop` run passed entirely, which is the definition of flaky. Individually, `npx vitest run e2e/planner.test.ts --config e2e/vitest.config.ts` passes in 7.34s (15 tests) while the same file fails inside a full parallel run.

</details>
