### PR TITLE
fix(web): scope session-list reloads to the active project after mutations

### DIFF
--- a/web/src/stores/session/messageHandler.test.ts
+++ b/web/src/stores/session/messageHandler.test.ts
@@ -559,7 +559,6 @@ describe('chat.stats handler', () => {
     generationTokens: 10,
     generationSpeed: 5,
   } as any
-
   beforeEach(() => {
     wsSendMock.mockClear()
     wsSubscribeMock.mockClear()
@@ -738,5 +737,214 @@ describe('chat.stats handler', () => {
     })
 
     expect(useSessionStore.getState().liveTurnStats).toEqual(liveStats)
+  })
+})
+
+describe('session.deleted handler', () => {
+  beforeEach(() => {
+    wsSendMock.mockClear()
+    wsSubscribeMock.mockClear()
+    wsConnectMock.mockClear()
+    wsDisconnectMock.mockClear()
+    wsStatusMock.mockClear()
+    playNotificationMock.mockClear()
+    playAchievementMock.mockClear()
+    playInterventionMock.mockClear()
+    playWaitingForUserMock.mockClear()
+    playNewMessageMock.mockClear()
+    fetchMock.mockClear()
+  })
+
+  it('removes the deleted session from state.sessions immediately and reloads scoped to its project', async () => {
+    const useSessionStore = await loadSessionStore()
+
+    useSessionStore.setState((state: any) => ({
+      ...state,
+      sessions: [
+        {
+          id: 'a1',
+          projectId: 'project-a',
+          workdir: '/tmp/a',
+          mode: 'planner',
+          phase: 'plan',
+          isRunning: false,
+          isFavorite: false,
+          createdAt: 'a',
+          updatedAt: 'b',
+          criteriaCount: 0,
+          criteriaCompleted: 0,
+          messageCount: 0,
+        },
+        {
+          id: 'a2',
+          projectId: 'project-a',
+          workdir: '/tmp/a',
+          mode: 'planner',
+          phase: 'plan',
+          isRunning: false,
+          isFavorite: false,
+          createdAt: 'a',
+          updatedAt: 'b',
+          criteriaCount: 0,
+          criteriaCompleted: 0,
+          messageCount: 0,
+        },
+        {
+          id: 'b1',
+          projectId: 'project-b',
+          workdir: '/tmp/b',
+          mode: 'planner',
+          phase: 'plan',
+          isRunning: false,
+          isFavorite: false,
+          createdAt: 'a',
+          updatedAt: 'b',
+          criteriaCount: 0,
+          criteriaCompleted: 0,
+          messageCount: 0,
+        },
+      ],
+    }))
+
+    // Scoped reload returns the 1 remaining project-a session
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve({
+          sessions: [
+            {
+              id: 'a2',
+              projectId: 'project-a',
+              workdir: '/tmp/a',
+              mode: 'planner',
+              phase: 'plan',
+              isRunning: false,
+              isFavorite: false,
+              createdAt: 'a',
+              updatedAt: 'b',
+              criteriaCount: 0,
+              criteriaCompleted: 0,
+              messageCount: 0,
+            },
+          ],
+          hasMore: false,
+          pendingConfirmationsBySession: {},
+        }),
+    } as never)
+
+    useSessionStore.getState().handleServerMessage({
+      type: 'session.deleted',
+      sessionId: 'a1',
+      payload: { sessionId: 'a1' },
+    } as any)
+
+    // Wait for the async listSessions reload
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    const state = useSessionStore.getState()
+    // Deleted session is gone immediately, even before/without the reload
+    expect(state.sessions.find((s: any) => s.id === 'a1')).toBeUndefined()
+    // Reload was scoped to project-a, not a bare global list
+    const urls = fetchMock.mock.calls.map((c) => String((c as unknown[])[0]))
+    expect(urls.some((url) => url.includes('projectId=project-a'))).toBe(true)
+    expect(urls.some((url) => url === '/api/sessions?limit=20')).toBe(false)
+    // project-b session preserved
+    expect(state.sessions.find((s: any) => s.id === 'b1')).toBeDefined()
+  })
+})
+
+describe('session.deletedAll handler', () => {
+  beforeEach(() => {
+    wsSendMock.mockClear()
+    wsSubscribeMock.mockClear()
+    wsConnectMock.mockClear()
+    wsDisconnectMock.mockClear()
+    wsStatusMock.mockClear()
+    playNotificationMock.mockClear()
+    playAchievementMock.mockClear()
+    playInterventionMock.mockClear()
+    playWaitingForUserMock.mockClear()
+    playNewMessageMock.mockClear()
+    fetchMock.mockClear()
+  })
+
+  it('removes the project sessions immediately and reloads scoped to the project id, not globally', async () => {
+    const useSessionStore = await loadSessionStore()
+
+    useSessionStore.setState((state: any) => ({
+      ...state,
+      sessions: [
+        {
+          id: 'a1',
+          projectId: 'project-a',
+          workdir: '/tmp/a',
+          mode: 'planner',
+          phase: 'plan',
+          isRunning: false,
+          isFavorite: false,
+          createdAt: 'a',
+          updatedAt: 'b',
+          criteriaCount: 0,
+          criteriaCompleted: 0,
+          messageCount: 0,
+        },
+        {
+          id: 'a2',
+          projectId: 'project-a',
+          workdir: '/tmp/a',
+          mode: 'planner',
+          phase: 'plan',
+          isRunning: false,
+          isFavorite: false,
+          createdAt: 'a',
+          updatedAt: 'b',
+          criteriaCount: 0,
+          criteriaCompleted: 0,
+          messageCount: 0,
+        },
+        {
+          id: 'b1',
+          projectId: 'project-b',
+          workdir: '/tmp/b',
+          mode: 'planner',
+          phase: 'plan',
+          isRunning: false,
+          isFavorite: false,
+          createdAt: 'a',
+          updatedAt: 'b',
+          criteriaCount: 0,
+          criteriaCompleted: 0,
+          messageCount: 0,
+        },
+      ],
+    }))
+
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ sessions: [], hasMore: false, pendingConfirmationsBySession: {} }),
+    } as never)
+
+    // The server broadcasts sessionId = projectId for deletedAll
+    useSessionStore.getState().handleServerMessage({
+      type: 'session.deletedAll',
+      sessionId: 'project-a',
+      payload: {},
+    } as any)
+
+    // Immediate removal: project-a sessions are gone synchronously, before the
+    // async reload resolves.
+    const stateAfterSet = useSessionStore.getState()
+    expect(stateAfterSet.sessions.find((s: any) => s.id === 'a1')).toBeUndefined()
+    expect(stateAfterSet.sessions.find((s: any) => s.id === 'a2')).toBeUndefined()
+    // Other projects are preserved
+    expect(stateAfterSet.sessions.find((s: any) => s.id === 'b1')).toBeDefined()
+
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    const urls = fetchMock.mock.calls.map((c) => String((c as unknown[])[0]))
+    expect(urls.some((url) => url.includes('projectId=project-a'))).toBe(true)
+    expect(urls.some((url) => url === '/api/sessions?limit=20')).toBe(false)
   })
 })

--- a/web/src/stores/session/messageHandler.ts
+++ b/web/src/stores/session/messageHandler.ts
@@ -47,6 +47,7 @@ import {
   replacePane,
   updatePane,
   updatePaneSession,
+  resolveSessionProjectId,
 } from './panes'
 
 const triggeredNewMessageSound = new Set<string>()
@@ -309,23 +310,33 @@ export function handleServerMessage(
 
     case 'session.deleted': {
       const payload = message.payload as { sessionId: string }
+      const deletedId = payload.sessionId
+      // Resolve the deleted session's projectId before removing it, so the
+      // reload can be scoped to its project instead of fetching globally.
+      const projectId = resolveSessionProjectId(get(), deletedId)
       set((state) => {
         const panes = { ...state.panes }
-        delete panes[payload.sessionId]
+        delete panes[deletedId]
         return {
           panes,
-          openSessionIds: state.openSessionIds.filter((id) => id !== payload.sessionId),
-          unreadSessionIds: removeUnreadSessionId(state.unreadSessionIds, payload.sessionId),
+          sessions: state.sessions.filter((s) => s.id !== deletedId),
+          openSessionIds: state.openSessionIds.filter((id) => id !== deletedId),
+          unreadSessionIds: removeUnreadSessionId(state.unreadSessionIds, deletedId),
           searchSessions: null,
         }
       })
-      get().listSessions()
+      get().listSessions(projectId)
       break
     }
 
     case 'session.deletedAll': {
-      set({ searchSessions: null })
-      get().listSessions()
+      // The server broadcasts sessionId = projectId for deletedAll
+      const projectId = message.sessionId
+      set((state) => ({
+        searchSessions: null,
+        sessions: projectId !== undefined ? state.sessions.filter((s) => s.projectId !== projectId) : state.sessions,
+      }))
+      get().listSessions(projectId)
       break
     }
 

--- a/web/src/stores/session/panes.ts
+++ b/web/src/stores/session/panes.ts
@@ -77,6 +77,20 @@ export function effectiveFocusedId(state: SessionState): string | null {
   return state.focusedSessionId ?? state.currentSession?.id ?? null
 }
 
+// Resolve a session's projectId from any source available in state: the
+// sessions list, the live pane, or the current session. Used to scope
+// post-mutation reloads to the right project instead of fetching globally.
+export function resolveSessionProjectId(state: SessionState, sessionId: string): string | undefined {
+  const summary = state.sessions.find((s) => s.id === sessionId)
+  if (summary?.projectId) return summary.projectId
+  const pane = state.panes[sessionId]
+  if (pane?.session?.projectId) return pane.session.projectId
+  if (state.currentSession?.id === sessionId && state.currentSession.projectId) {
+    return state.currentSession.projectId
+  }
+  return undefined
+}
+
 /** True when the session is focused or already an open pane (live updates). */
 export function isLivePane(state: SessionState, sessionId: string | undefined): boolean {
   if (!sessionId) return false

--- a/web/src/stores/session/session.test.ts
+++ b/web/src/stores/session/session.test.ts
@@ -2379,8 +2379,12 @@ describe('toggleFavorite', () => {
         body: JSON.stringify({ isFavorite: true }),
       }),
     )
-    // listSessions refresh
-    expect(fetchMock).toHaveBeenNthCalledWith(2, '/api/sessions?limit=20', expect.objectContaining({}))
+    // listSessions refresh — scoped to the session's project, not global
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      '/api/sessions?limit=20&projectId=project-1',
+      expect.objectContaining({}),
+    )
   })
 
   it('returns false, reverts the optimistic update, and does not refresh the list when the API fails', async () => {
@@ -2509,6 +2513,91 @@ describe('homepage session loading', () => {
     expect(urls).not.toContain('/api/sessions')
   })
 
+  it('listHomeSessions REPLACES the list so sessions falling out of the curated set are removed', async () => {
+    const useSessionStore = await loadSessionStore()
+
+    // Seed the store with several sessions across projects (as if a prior
+    // home poll populated them).
+    useSessionStore.setState((state: any) => ({
+      ...state,
+      sessions: [
+        {
+          id: 'old-a1',
+          projectId: 'pa',
+          workdir: '/tmp/a',
+          mode: 'planner',
+          phase: 'plan',
+          isRunning: false,
+          isFavorite: false,
+          createdAt: 'a',
+          updatedAt: 'b',
+          criteriaCount: 0,
+          criteriaCompleted: 0,
+          messageCount: 0,
+        },
+        {
+          id: 'old-a2',
+          projectId: 'pa',
+          workdir: '/tmp/a',
+          mode: 'planner',
+          phase: 'plan',
+          isRunning: false,
+          isFavorite: false,
+          createdAt: 'a',
+          updatedAt: 'b',
+          criteriaCount: 0,
+          criteriaCompleted: 0,
+          messageCount: 0,
+        },
+        {
+          id: 'old-b1',
+          projectId: 'pb',
+          workdir: '/tmp/b',
+          mode: 'planner',
+          phase: 'plan',
+          isRunning: false,
+          isFavorite: false,
+          createdAt: 'a',
+          updatedAt: 'b',
+          criteriaCount: 0,
+          criteriaCompleted: 0,
+          messageCount: 0,
+        },
+      ],
+    }))
+
+    // The curated home poll now returns only a1 (a2 fell out of top-5, b1 removed)
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve({
+          sessions: [
+            {
+              id: 'old-a1',
+              projectId: 'pa',
+              workdir: '/tmp/a',
+              mode: 'planner',
+              phase: 'plan',
+              isRunning: false,
+              messageCount: 1,
+              createdAt: '2024-01-01T00:00:00.000Z',
+              updatedAt: '2024-01-01T00:00:00.000Z',
+            },
+          ],
+        }),
+    } as never)
+
+    await useSessionStore.getState().listHomeSessions()
+
+    const state = useSessionStore.getState()
+    // REPLACE semantics: only the curated session remains; stale ones dropped
+    expect(state.sessions).toHaveLength(1)
+    expect(state.sessions[0]!.id).toBe('old-a1')
+    expect(state.sessions.find((s: any) => s.id === 'old-a2')).toBeUndefined()
+    expect(state.sessions.find((s: any) => s.id === 'old-b1')).toBeUndefined()
+  })
+
   it('ensureFullSessionList loads the full corpus once and caches it for later calls', async () => {
     const useSessionStore = await loadSessionStore()
     fetchMock.mockResolvedValue({
@@ -2584,6 +2673,270 @@ describe('homepage session loading', () => {
     await useSessionStore.getState().deleteSession('s1')
 
     expect(useSessionStore.getState().searchSessions).toBeNull()
+  })
+})
+
+describe('cross-project session list stability after mutation', () => {
+  beforeEach(() => {
+    fetchMock.mockClear()
+  })
+
+  // Build N sessions for project A and M sessions for project B in the store.
+  function seedCrossProjectSessions(useSessionStore: any, n: number, m: number): void {
+    const sessions: any[] = []
+    for (let i = 0; i < n; i++) {
+      sessions.push({
+        id: `a${i}`,
+        projectId: 'project-a',
+        workdir: '/tmp/a',
+        mode: 'planner',
+        phase: 'plan',
+        isRunning: false,
+        isFavorite: false,
+        createdAt: 'a',
+        updatedAt: 'b',
+        criteriaCount: 0,
+        criteriaCompleted: 0,
+        messageCount: 0,
+      })
+    }
+    for (let i = 0; i < m; i++) {
+      sessions.push({
+        id: `b${i}`,
+        projectId: 'project-b',
+        workdir: '/tmp/b',
+        mode: 'planner',
+        phase: 'plan',
+        isRunning: false,
+        isFavorite: false,
+        createdAt: 'a',
+        updatedAt: 'b',
+        criteriaCount: 0,
+        criteriaCompleted: 0,
+        messageCount: 0,
+      })
+    }
+    useSessionStore.setState((state: any) => ({ ...state, sessions }))
+  }
+
+  it('deleteSession reloads scoped to the deleted session project and does not drop other projects', async () => {
+    const useSessionStore = await loadSessionStore()
+    seedCrossProjectSessions(useSessionStore, 10, 8)
+
+    // DELETE succeeds
+    fetchMock.mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve({}) } as never)
+    // Scoped reload returns the 9 remaining project-a sessions
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve({
+          sessions: Array.from({ length: 9 }, (_, i) => ({
+            id: `a${i}`,
+            projectId: 'project-a',
+            workdir: '/tmp/a',
+            mode: 'planner',
+            phase: 'plan',
+            isRunning: false,
+            isFavorite: false,
+            createdAt: 'a',
+            updatedAt: 'b',
+            criteriaCount: 0,
+            criteriaCompleted: 0,
+            messageCount: 0,
+          })),
+          hasMore: false,
+          pendingConfirmationsBySession: {},
+        }),
+    } as never)
+
+    await useSessionStore.getState().deleteSession('a9')
+
+    const urls = fetchMock.mock.calls.map((c) => String((c as unknown[])[0]))
+    // The reload MUST be scoped to project-a, not a bare global list
+    expect(urls.some((url) => url.includes('projectId=project-a'))).toBe(true)
+    expect(urls.some((url) => url === '/api/sessions?limit=20')).toBe(false)
+
+    const state = useSessionStore.getState()
+    const projectA = state.sessions.filter((s: any) => s.projectId === 'project-a')
+    const projectB = state.sessions.filter((s: any) => s.projectId === 'project-b')
+    // project-a lost exactly the deleted session; project-b is untouched
+    expect(projectA).toHaveLength(9)
+    expect(projectB).toHaveLength(8)
+  })
+
+  it('deleteSession stays scoped even when the session.deleted WS event lands before the DELETE resolves', async () => {
+    const useSessionStore = await loadSessionStore()
+    seedCrossProjectSessions(useSessionStore, 10, 8)
+
+    const scopedPayload = {
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve({
+          sessions: Array.from({ length: 9 }, (_, i) => ({
+            id: `a${i}`,
+            projectId: 'project-a',
+            workdir: '/tmp/a',
+            mode: 'planner',
+            phase: 'plan',
+            isRunning: false,
+            isFavorite: false,
+            createdAt: 'a',
+            updatedAt: 'b',
+            criteriaCount: 0,
+            criteriaCompleted: 0,
+            messageCount: 0,
+          })),
+          hasMore: false,
+          pendingConfirmationsBySession: {},
+        }),
+    }
+
+    // The server broadcasts session.deleted BEFORE responding to the DELETE.
+    // Simulate that ordering: the WS handler wipes the session (and its pane)
+    // from state, then the DELETE resolves and deleteSession must still know
+    // which project to scope its reload to.
+    fetchMock.mockImplementationOnce(() => {
+      useSessionStore.getState().handleServerMessage({
+        type: 'session.deleted',
+        sessionId: 'a9',
+        payload: { sessionId: 'a9' },
+      } as any)
+      return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({}) }) as never
+    })
+    fetchMock.mockResolvedValue(scopedPayload as never)
+
+    await useSessionStore.getState().deleteSession('a9')
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    const urls = fetchMock.mock.calls.map((c) => String((c as unknown[])[0]))
+    // No bare global list may ever be issued, even though the session was
+    // already gone from state when deleteSession resolved its projectId.
+    expect(urls.some((url) => url === '/api/sessions?limit=20')).toBe(false)
+    expect(urls.some((url) => url.includes('projectId=project-a'))).toBe(true)
+
+    const state = useSessionStore.getState()
+    expect(state.sessions.filter((s: any) => s.projectId === 'project-a')).toHaveLength(9)
+    expect(state.sessions.filter((s: any) => s.projectId === 'project-b')).toHaveLength(8)
+  })
+
+  it('toggleFavorite reloads scoped to the modified session project', async () => {
+    const useSessionStore = await loadSessionStore()
+    seedCrossProjectSessions(useSessionStore, 3, 5)
+
+    fetchMock.mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve({ success: true }) } as never)
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ sessions: [], hasMore: false, pendingConfirmationsBySession: {} }),
+    } as never)
+
+    await useSessionStore.getState().toggleFavorite('b2', true)
+
+    const urls = fetchMock.mock.calls.map((c) => String((c as unknown[])[0]))
+    expect(urls.some((url) => url.includes('projectId=project-b'))).toBe(true)
+    expect(urls.some((url) => url === '/api/sessions?limit=20')).toBe(false)
+  })
+
+  it('renameSession reloads scoped to the modified session project', async () => {
+    const useSessionStore = await loadSessionStore()
+    seedCrossProjectSessions(useSessionStore, 3, 5)
+
+    fetchMock.mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve({ success: true }) } as never)
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ sessions: [], hasMore: false, pendingConfirmationsBySession: {} }),
+    } as never)
+
+    await useSessionStore.getState().renameSession('a1', 'new title')
+
+    const urls = fetchMock.mock.calls.map((c) => String((c as unknown[])[0]))
+    expect(urls.some((url) => url.includes('projectId=project-a'))).toBe(true)
+    expect(urls.some((url) => url === '/api/sessions?limit=20')).toBe(false)
+  })
+
+  it('deleteAllSessions reloads scoped to the given project', async () => {
+    const useSessionStore = await loadSessionStore()
+    seedCrossProjectSessions(useSessionStore, 3, 5)
+
+    fetchMock.mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve({}) } as never)
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ sessions: [], hasMore: false, pendingConfirmationsBySession: {} }),
+    } as never)
+
+    await useSessionStore.getState().deleteAllSessions('project-a')
+
+    const urls = fetchMock.mock.calls.map((c) => String((c as unknown[])[0]))
+    expect(urls.some((url) => url.includes('projectId=project-a'))).toBe(true)
+    expect(urls.some((url) => url === '/api/sessions?limit=20')).toBe(false)
+  })
+
+  it('listSessions scoped to a project does not drop other projects already in state (union merge)', async () => {
+    const useSessionStore = await loadSessionStore()
+    seedCrossProjectSessions(useSessionStore, 3, 5)
+
+    // Scoped reload returns only project-a sessions
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve({
+          sessions: [
+            {
+              id: 'a0',
+              projectId: 'project-a',
+              workdir: '/tmp/a',
+              mode: 'planner',
+              phase: 'plan',
+              isRunning: false,
+              isFavorite: false,
+              createdAt: 'a',
+              updatedAt: 'b',
+              criteriaCount: 0,
+              criteriaCompleted: 0,
+              messageCount: 0,
+            },
+          ],
+          hasMore: false,
+          pendingConfirmationsBySession: {},
+        }),
+    } as never)
+
+    await useSessionStore.getState().listSessions('project-a')
+
+    const state = useSessionStore.getState()
+    const projectA = state.sessions.filter((s: any) => s.projectId === 'project-a')
+    const projectB = state.sessions.filter((s: any) => s.projectId === 'project-b')
+    // project-a refreshed (1 returned), project-b preserved (not dropped)
+    expect(projectA).toHaveLength(1)
+    expect(projectB).toHaveLength(5)
+  })
+
+  it('loadMoreSessions offsets by the target project count, not the global sessions length', async () => {
+    const useSessionStore = await loadSessionStore()
+    seedCrossProjectSessions(useSessionStore, 20, 8)
+
+    // Mark that there are more sessions to load
+    useSessionStore.setState({ sessionsHasMore: true })
+
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ sessions: [], hasMore: false }),
+    } as never)
+
+    await useSessionStore.getState().loadMoreSessions('project-a')
+
+    const urls = fetchMock.mock.calls.map((c) => String((c as unknown[])[0]))
+    const loadMoreUrl = urls.find((u) => u.includes('projectId=project-a') && u.includes('offset='))
+    expect(loadMoreUrl).toBeDefined()
+    // project-a has 20 sessions in state; offset must be 20, NOT 28 (20+8 preserved)
+    expect(loadMoreUrl!).toContain('offset=20')
+    expect(loadMoreUrl!).not.toContain('offset=28')
   })
 })
 

--- a/web/src/stores/session/store.ts
+++ b/web/src/stores/session/store.ts
@@ -22,6 +22,7 @@ import {
   replacePane,
   updatePaneSession,
   dropPane,
+  resolveSessionProjectId,
 } from './panes'
 
 let isSubscribed = false
@@ -91,8 +92,19 @@ async function postMessage(
 // Merge a freshly fetched session list into the store: keep the live
 // focusedSession's mode/phase, preserve titles/prompts already in state, and
 // never resurrect a session the server reports as not running.
-function mergeSessionSummaries(incoming: SessionSummary[], state: SessionState): SessionSummary[] {
-  return incoming.map((s) => {
+//
+// When `projectId` is provided (scoped reload), incoming represents the
+// complete current set of sessions for that project: it REPLACES that
+// project's slice while preserving every other project's sessions. This is
+// what makes a per-project refresh after a mutation (delete/rename/favorite)
+// not drop other projects from the sidebar.
+//
+// When `projectId` is undefined (home/global reload), incoming is the
+// authoritative full result (e.g. the curated 5-per-project home list) and
+// REPLACES the list entirely — so sessions that fall out of the curated set
+// are removed. This preserves the original listHomeSessions behavior.
+function mergeSessionSummaries(incoming: SessionSummary[], state: SessionState, projectId?: string): SessionSummary[] {
+  const merged = incoming.map((s) => {
     const existing = state.sessions.find((e) => e.id === s.id)
     const pane = state.panes[s.id]
     const liveSession = pane?.session
@@ -106,6 +118,10 @@ function mergeSessionSummaries(incoming: SessionSummary[], state: SessionState):
       ...(s.recentUserPrompts !== undefined && { recentUserPrompts: s.recentUserPrompts }),
     }
   })
+  if (!projectId) return merged
+  const incomingIds = new Set(incoming.map((s) => s.id))
+  const preserved = state.sessions.filter((s) => s.projectId !== projectId && !incomingIds.has(s.id))
+  return [...merged, ...preserved]
 }
 
 /** Resolve the pane backing a session, materializing from flat when needed. */
@@ -648,7 +664,7 @@ export const useSessionStore = create<SessionState>((set, get) => {
           const data = await res.json()
           const incoming = (data.sessions ?? []) as SessionSummary[]
           set((state) => ({
-            sessions: mergeSessionSummaries(incoming, state),
+            sessions: mergeSessionSummaries(incoming, state, projectId),
             sessionsHasMore: projectId ? (data.hasMore ?? false) : true,
           }))
 
@@ -722,7 +738,11 @@ export const useSessionStore = create<SessionState>((set, get) => {
       try {
         const params = new URLSearchParams()
         params.set('limit', '20')
-        params.set('offset', String(state.sessions.length))
+        // Offset is the count of sessions already loaded for THIS project,
+        // not the global sessions length — the store now holds sessions from
+        // multiple projects (preserved across scoped reloads), so the global
+        // length would skip real sessions of the target project.
+        params.set('offset', String(state.sessions.filter((s) => s.projectId === projectId).length))
         params.set('projectId', projectId)
         const res = await authFetch(`/api/sessions?${params.toString()}`)
         const data = await res.json()
@@ -744,11 +764,16 @@ export const useSessionStore = create<SessionState>((set, get) => {
     },
 
     deleteSession: async (sessionId) => {
+      // Resolve the project BEFORE the request: the server broadcasts
+      // session.deleted before answering the DELETE, and that handler wipes
+      // the session from state. Resolving afterwards would yield undefined and
+      // fall back to an unscoped global reload, dropping other projects.
+      const projectId = resolveSessionProjectId(get(), sessionId)
       try {
         const res = await authFetch(`/api/sessions/${sessionId}`, { method: 'DELETE' })
         if (!res.ok) return false
         set({ searchSessions: null })
-        await get().listSessions()
+        await get().listSessions(projectId)
         if (get().focusedSessionId === sessionId || get().currentSession?.id === sessionId) {
           get().clearSession()
         }
@@ -759,6 +784,7 @@ export const useSessionStore = create<SessionState>((set, get) => {
     },
 
     renameSession: async (sessionId: string, title: string) => {
+      const projectId = resolveSessionProjectId(get(), sessionId)
       try {
         const res = await authFetch(`/api/sessions/${sessionId}/title`, {
           method: 'PUT',
@@ -767,7 +793,7 @@ export const useSessionStore = create<SessionState>((set, get) => {
         })
         if (!res.ok) return false
         set({ searchSessions: null })
-        await get().listSessions()
+        await get().listSessions(projectId)
         set((state) => {
           const pane = state.panes[sessionId]
           if (!pane) return {}
@@ -783,6 +809,7 @@ export const useSessionStore = create<SessionState>((set, get) => {
     },
 
     toggleFavorite: async (sessionId: string, isFavorite: boolean) => {
+      const projectId = resolveSessionProjectId(get(), sessionId)
       // Optimistic update: flip immediately for responsive UI
       set((state) => ({
         sessions: state.sessions.map((s) => (s.id === sessionId ? { ...s, isFavorite } : s)),
@@ -801,7 +828,7 @@ export const useSessionStore = create<SessionState>((set, get) => {
           }))
           return false
         }
-        await get().listSessions()
+        await get().listSessions(projectId)
         return true
       } catch (error) {
         console.error('Error toggling favorite:', error)
@@ -818,7 +845,7 @@ export const useSessionStore = create<SessionState>((set, get) => {
         const res = await authFetch(`/api/projects/${projectId}/sessions`, { method: 'DELETE' })
         if (!res.ok) return false
         set({ searchSessions: null })
-        await get().listSessions()
+        await get().listSessions(projectId)
         return true
       } catch {
         return false


### PR DESCRIPTION
### Summary

Deleting a session from a project sidebar shrank the list far below the project's real count (e.g. 10 -> 3) and a page refresh restored it.

**Root cause:** post-mutation reloads (\`deleteSession\`, \`renameSession\`, \`toggleFavorite\`, \`deleteAllSessions\` and the \`session.deleted\` / \`session.deletedAll\` WS handlers) called \`listSessions()\` with no \`projectId\`, fetching the 20 most-recent sessions across ALL projects. \`mergeSessionSummaries\` then replaced the whole \`sessions\` array with that global subset, and the sidebar's per-project filter dropped the other projects' sessions.

**Race condition found while fixing:** the server broadcasts \`session.deleted\` BEFORE responding to the HTTP DELETE, so the WS handler wiped the session from state before \`deleteSession\` resolved its \`projectId\` -> \`undefined\` -> global reload. The fix resolves \`projectId\` BEFORE the network request.

**Fix (web-only):**
- \`mergeSessionSummaries\` is project-aware: a scoped reload REPLACES that project's slice while preserving other projects; the home/global path REPLACES entirely (preserves \`listHomeSessions\` curated-set behavior).
- \`deleteSession\`, \`renameSession\`, \`toggleFavorite\` resolve the session's \`projectId\` before the request and reload scoped.
- \`deleteAllSessions\` reloads scoped to its \`projectId\` param.
- WS \`session.deleted\` removes the session from \`state.sessions\` immediately and reloads scoped; \`session.deletedAll\` removes the project's sessions immediately and reloads scoped to \`message.sessionId\` (the projectId).
- \`loadMoreSessions\` offsets by the target project's loaded count, not the global \`sessions.length\` (which now spans multiple projects).
- \`resolveSessionProjectId\` is shared via \`panes.ts\` (no import cycle).

**Tests:** 8 new Vitest cases covering cross-project delete/rename/favorite/deleteAll, the WS race condition, \`listHomeSessions\` replace semantics, and \`loadMoreSessions\` offset.

### AI-Enhanced Development

- **AI Models:** GLM 5.2

### Cache Impact

- **No**