### PR TITLE
fix(llm): route reasoning effort via chat_template_kwargs for llama.cpp

### DIFF
--- a/src/server/llm/backend.test.ts
+++ b/src/server/llm/backend.test.ts
@@ -37,12 +37,20 @@ describe('backend', () => {
       const caps = getBackendCapabilities('llamacpp')
       expect(caps.supportsChatTemplateKwargs).toBe(false)
       expect(caps.supportsTopK).toBe(true)
+      expect(caps.routesEffortViaChatTemplateKwargs).toBe(true)
     })
 
     it('returns vllm-like capabilities for unknown', () => {
       const caps = getBackendCapabilities('unknown')
       expect(caps.supportsChatTemplateKwargs).toBe(true)
       expect(caps.supportsTopK).toBe(true)
+      expect(caps.routesEffortViaChatTemplateKwargs).toBe(false)
+    })
+
+    it('does not route effort via chat_template_kwargs for other backends', () => {
+      for (const backend of ['vllm', 'sglang', 'openai', 'anthropic', 'ollama', 'lmstudio', 'opencode-go'] as const) {
+        expect(getBackendCapabilities(backend).routesEffortViaChatTemplateKwargs).toBe(false)
+      }
     })
   })
 

--- a/src/server/llm/backend.ts
+++ b/src/server/llm/backend.ts
@@ -13,6 +13,12 @@ export interface BackendCapabilities {
   supportsTopK: boolean
   /** Whether the client uses Ollama's native /api/chat (consumes num_ctx) */
   supportsNumCtx: boolean
+  /**
+   * Whether reasoning effort must be routed through chat_template_kwargs
+   * (llama.cpp only populates Jinja template variables from kwargs; a
+   * top-level reasoning_effort body field is silently ignored).
+   */
+  routesEffortViaChatTemplateKwargs: boolean
 }
 
 const BACKEND_CAPABILITIES: Record<Backend, BackendCapabilities> = {
@@ -20,46 +26,55 @@ const BACKEND_CAPABILITIES: Record<Backend, BackendCapabilities> = {
     supportsChatTemplateKwargs: true,
     supportsTopK: true,
     supportsNumCtx: false,
+    routesEffortViaChatTemplateKwargs: false,
   },
   sglang: {
     supportsChatTemplateKwargs: true,
     supportsTopK: true,
     supportsNumCtx: false,
+    routesEffortViaChatTemplateKwargs: false,
   },
   openai: {
     supportsChatTemplateKwargs: false,
     supportsTopK: false,
     supportsNumCtx: false,
+    routesEffortViaChatTemplateKwargs: false,
   },
   anthropic: {
     supportsChatTemplateKwargs: false,
     supportsTopK: false,
     supportsNumCtx: false,
+    routesEffortViaChatTemplateKwargs: false,
   },
   ollama: {
     supportsChatTemplateKwargs: false,
     supportsTopK: false,
     supportsNumCtx: true,
+    routesEffortViaChatTemplateKwargs: false,
   },
   llamacpp: {
     supportsChatTemplateKwargs: false,
     supportsTopK: true,
     supportsNumCtx: false,
+    routesEffortViaChatTemplateKwargs: true,
   },
   lmstudio: {
     supportsChatTemplateKwargs: false,
     supportsTopK: true,
     supportsNumCtx: false,
+    routesEffortViaChatTemplateKwargs: false,
   },
   'opencode-go': {
     supportsChatTemplateKwargs: false,
     supportsTopK: true,
     supportsNumCtx: false,
+    routesEffortViaChatTemplateKwargs: false,
   },
   unknown: {
     supportsChatTemplateKwargs: true,
     supportsTopK: true,
     supportsNumCtx: false,
+    routesEffortViaChatTemplateKwargs: false,
   },
 }
 

--- a/src/server/llm/client-pure.test.ts
+++ b/src/server/llm/client-pure.test.ts
@@ -221,8 +221,12 @@ describe('llm client pure helpers', () => {
         model: 'test-model',
         request: baseRequest,
         profile,
-        capabilities: { supportsTopK: true, supportsChatTemplateKwargs: true, supportsNumCtx: false },
-        capabilities: { supportsTopK: true, supportsChatTemplateKwargs: true, routesEffortViaChatTemplateKwargs: false },
+        capabilities: {
+          supportsTopK: true,
+          supportsChatTemplateKwargs: true,
+          supportsNumCtx: false,
+          routesEffortViaChatTemplateKwargs: false,
+        },
       }),
     ).toEqual({
       params: {
@@ -256,8 +260,12 @@ describe('llm client pure helpers', () => {
           modelSettings: { chatTemplateKwargs: { enable_thinking: false } },
         },
         profile,
-        capabilities: { supportsTopK: true, supportsChatTemplateKwargs: true, supportsNumCtx: false },
-        capabilities: { supportsTopK: true, supportsChatTemplateKwargs: true, routesEffortViaChatTemplateKwargs: false },
+        capabilities: {
+          supportsTopK: true,
+          supportsChatTemplateKwargs: true,
+          supportsNumCtx: false,
+          routesEffortViaChatTemplateKwargs: false,
+        },
         reasoningEffort: 'high', // client config has reasoning_effort set
       }),
     ).toEqual({
@@ -293,8 +301,12 @@ describe('llm client pure helpers', () => {
           modelSettings: { chatTemplateKwargs: { enable_thinking: false } },
         },
         profile,
-        capabilities: { supportsTopK: true, supportsChatTemplateKwargs: true, supportsNumCtx: false },
-        capabilities: { supportsTopK: true, supportsChatTemplateKwargs: true, routesEffortViaChatTemplateKwargs: false },
+        capabilities: {
+          supportsTopK: true,
+          supportsChatTemplateKwargs: true,
+          supportsNumCtx: false,
+          routesEffortViaChatTemplateKwargs: false,
+        },
       }),
     ).toEqual({
       params: {
@@ -329,8 +341,12 @@ describe('llm client pure helpers', () => {
           modelSettings: { queryParams: { disable_thinking: true, skip_special_tokens: false } },
         },
         profile,
-        capabilities: { supportsTopK: true, supportsChatTemplateKwargs: true, supportsNumCtx: false },
-        capabilities: { supportsTopK: true, supportsChatTemplateKwargs: true, routesEffortViaChatTemplateKwargs: false },
+        capabilities: {
+          supportsTopK: true,
+          supportsChatTemplateKwargs: true,
+          supportsNumCtx: false,
+          routesEffortViaChatTemplateKwargs: false,
+        },
       }),
     ).toEqual({
       params: {
@@ -365,8 +381,12 @@ describe('llm client pure helpers', () => {
           modelSettings: { queryParams: { reasoning_effort: 'low' } },
         },
         profile,
-        capabilities: { supportsTopK: true, supportsChatTemplateKwargs: true, supportsNumCtx: false },
-        capabilities: { supportsTopK: true, supportsChatTemplateKwargs: true, routesEffortViaChatTemplateKwargs: false },
+        capabilities: {
+          supportsTopK: true,
+          supportsChatTemplateKwargs: true,
+          supportsNumCtx: false,
+          routesEffortViaChatTemplateKwargs: false,
+        },
         reasoningEffort: 'max',
       }),
     ).toEqual({
@@ -398,8 +418,12 @@ describe('llm client pure helpers', () => {
         model: 'test-model',
         request: { messages: [{ role: 'user' as const, content: 'hi' }], tools: [] },
         profile,
-        capabilities: { supportsTopK: false, supportsChatTemplateKwargs: false, supportsNumCtx: false },
-        capabilities: { supportsTopK: false, supportsChatTemplateKwargs: false, routesEffortViaChatTemplateKwargs: false },
+        capabilities: {
+          supportsTopK: false,
+          supportsChatTemplateKwargs: false,
+          supportsNumCtx: false,
+          routesEffortViaChatTemplateKwargs: false,
+        },
       }),
     ).toEqual({
       params: {
@@ -426,8 +450,12 @@ describe('llm client pure helpers', () => {
           modelSettings: { maxTokens: 5000, temperature: 0.5, topP: 0.95 },
         },
         profile,
-        capabilities: { supportsTopK: false, supportsChatTemplateKwargs: false, supportsNumCtx: false },
-        capabilities: { supportsTopK: false, supportsChatTemplateKwargs: false, routesEffortViaChatTemplateKwargs: false },
+        capabilities: {
+          supportsTopK: false,
+          supportsChatTemplateKwargs: false,
+          supportsNumCtx: false,
+          routesEffortViaChatTemplateKwargs: false,
+        },
       }),
     ).toEqual({
       params: {
@@ -459,8 +487,12 @@ describe('llm client pure helpers', () => {
       profile,
       // reasoningEffort simulates session model's thinking config leaking into override client
       reasoningEffort: 'low',
-      capabilities: { supportsTopK: true, supportsChatTemplateKwargs: true, supportsNumCtx: false },
-      capabilities: { supportsTopK: true, supportsChatTemplateKwargs: true, routesEffortViaChatTemplateKwargs: false },
+      capabilities: {
+        supportsTopK: true,
+        supportsChatTemplateKwargs: true,
+        supportsNumCtx: false,
+        routesEffortViaChatTemplateKwargs: false,
+      },
     })
     // chat_template_kwargs must NOT be here — the modelSettings don't request it
     expect(result.params).not.toHaveProperty('chat_template_kwargs')
@@ -477,6 +509,7 @@ describe('llm client pure helpers', () => {
     const llamacppCaps = {
       supportsTopK: true,
       supportsChatTemplateKwargs: false,
+      supportsNumCtx: false,
       routesEffortViaChatTemplateKwargs: true,
     }
     const baseRequest = {
@@ -589,8 +622,12 @@ describe('llm client pure helpers', () => {
         modelSettings: { omitParams: ['temperature'] },
       },
       profile,
-      capabilities: { supportsTopK: false, supportsChatTemplateKwargs: false, supportsNumCtx: false },
-      capabilities: { supportsTopK: false, supportsChatTemplateKwargs: false, routesEffortViaChatTemplateKwargs: false },
+      capabilities: {
+        supportsTopK: false,
+        supportsChatTemplateKwargs: false,
+        supportsNumCtx: false,
+        routesEffortViaChatTemplateKwargs: false,
+      },
     })
     expect(result.params).not.toHaveProperty('temperature')
     expect(result.params).toHaveProperty('top_p', 0.9)
@@ -611,8 +648,12 @@ describe('llm client pure helpers', () => {
         modelSettings: { omitParams: ['top_p'] },
       },
       profile,
-      capabilities: { supportsTopK: false, supportsChatTemplateKwargs: false, supportsNumCtx: false },
-      capabilities: { supportsTopK: false, supportsChatTemplateKwargs: false, routesEffortViaChatTemplateKwargs: false },
+      capabilities: {
+        supportsTopK: false,
+        supportsChatTemplateKwargs: false,
+        supportsNumCtx: false,
+        routesEffortViaChatTemplateKwargs: false,
+      },
     })
     expect(result.params).not.toHaveProperty('top_p')
     expect(result.params).toHaveProperty('temperature', 0.7)
@@ -636,8 +677,12 @@ describe('llm client pure helpers', () => {
         },
       },
       profile,
-      capabilities: { supportsTopK: false, supportsChatTemplateKwargs: false, supportsNumCtx: false },
-      capabilities: { supportsTopK: false, supportsChatTemplateKwargs: false, routesEffortViaChatTemplateKwargs: false },
+      capabilities: {
+        supportsTopK: false,
+        supportsChatTemplateKwargs: false,
+        supportsNumCtx: false,
+        routesEffortViaChatTemplateKwargs: false,
+      },
     })
     expect(result.params).not.toHaveProperty('temperature')
     expect(result.params).toHaveProperty('custom_param', true)
@@ -657,7 +702,12 @@ describe('llm client pure helpers', () => {
         modelSettings: { numCtx: 32768 },
       },
       profile,
-      capabilities: { supportsTopK: false, supportsChatTemplateKwargs: false, supportsNumCtx: true },
+      capabilities: {
+        supportsTopK: false,
+        supportsChatTemplateKwargs: false,
+        supportsNumCtx: true,
+        routesEffortViaChatTemplateKwargs: false,
+      },
     })
     expect(result.params).toHaveProperty('num_ctx', 32768)
   })
@@ -676,7 +726,12 @@ describe('llm client pure helpers', () => {
         modelSettings: { numCtx: 32768 },
       },
       profile,
-      capabilities: { supportsTopK: false, supportsChatTemplateKwargs: false, supportsNumCtx: false },
+      capabilities: {
+        supportsTopK: false,
+        supportsChatTemplateKwargs: false,
+        supportsNumCtx: false,
+        routesEffortViaChatTemplateKwargs: false,
+      },
     })
     expect(result.params).not.toHaveProperty('num_ctx')
   })
@@ -694,8 +749,12 @@ describe('llm client pure helpers', () => {
       model: 'test-model',
       request: baseReq,
       profile,
-      capabilities: { supportsTopK: false, supportsChatTemplateKwargs: false, supportsNumCtx: false },
-      capabilities: { supportsTopK: false, supportsChatTemplateKwargs: false, routesEffortViaChatTemplateKwargs: false },
+      capabilities: {
+        supportsTopK: false,
+        supportsChatTemplateKwargs: false,
+        supportsNumCtx: false,
+        routesEffortViaChatTemplateKwargs: false,
+      },
     })
     expect(withoutOmit.params).toHaveProperty('temperature', 0.7)
 
@@ -703,8 +762,12 @@ describe('llm client pure helpers', () => {
       model: 'test-model',
       request: { ...baseReq, modelSettings: { omitParams: [] } },
       profile,
-      capabilities: { supportsTopK: false, supportsChatTemplateKwargs: false, supportsNumCtx: false },
-      capabilities: { supportsTopK: false, supportsChatTemplateKwargs: false, routesEffortViaChatTemplateKwargs: false },
+      capabilities: {
+        supportsTopK: false,
+        supportsChatTemplateKwargs: false,
+        supportsNumCtx: false,
+        routesEffortViaChatTemplateKwargs: false,
+      },
     })
     expect(withEmpty.params).toHaveProperty('temperature', 0.7)
   })
@@ -723,8 +786,12 @@ describe('llm client pure helpers', () => {
         modelSettings: { omitParams: ['temperature', 'max_tokens'] },
       },
       profile,
-      capabilities: { supportsTopK: false, supportsChatTemplateKwargs: false, supportsNumCtx: false },
-      capabilities: { supportsTopK: false, supportsChatTemplateKwargs: false, routesEffortViaChatTemplateKwargs: false },
+      capabilities: {
+        supportsTopK: false,
+        supportsChatTemplateKwargs: false,
+        supportsNumCtx: false,
+        routesEffortViaChatTemplateKwargs: false,
+      },
     })
     expect(result.params).not.toHaveProperty('temperature')
     expect(result.params).not.toHaveProperty('max_tokens')

--- a/src/server/llm/client-pure.test.ts
+++ b/src/server/llm/client-pure.test.ts
@@ -222,6 +222,7 @@ describe('llm client pure helpers', () => {
         request: baseRequest,
         profile,
         capabilities: { supportsTopK: true, supportsChatTemplateKwargs: true, supportsNumCtx: false },
+        capabilities: { supportsTopK: true, supportsChatTemplateKwargs: true, routesEffortViaChatTemplateKwargs: false },
       }),
     ).toEqual({
       params: {
@@ -256,6 +257,7 @@ describe('llm client pure helpers', () => {
         },
         profile,
         capabilities: { supportsTopK: true, supportsChatTemplateKwargs: true, supportsNumCtx: false },
+        capabilities: { supportsTopK: true, supportsChatTemplateKwargs: true, routesEffortViaChatTemplateKwargs: false },
         reasoningEffort: 'high', // client config has reasoning_effort set
       }),
     ).toEqual({
@@ -292,6 +294,7 @@ describe('llm client pure helpers', () => {
         },
         profile,
         capabilities: { supportsTopK: true, supportsChatTemplateKwargs: true, supportsNumCtx: false },
+        capabilities: { supportsTopK: true, supportsChatTemplateKwargs: true, routesEffortViaChatTemplateKwargs: false },
       }),
     ).toEqual({
       params: {
@@ -327,6 +330,7 @@ describe('llm client pure helpers', () => {
         },
         profile,
         capabilities: { supportsTopK: true, supportsChatTemplateKwargs: true, supportsNumCtx: false },
+        capabilities: { supportsTopK: true, supportsChatTemplateKwargs: true, routesEffortViaChatTemplateKwargs: false },
       }),
     ).toEqual({
       params: {
@@ -362,6 +366,7 @@ describe('llm client pure helpers', () => {
         },
         profile,
         capabilities: { supportsTopK: true, supportsChatTemplateKwargs: true, supportsNumCtx: false },
+        capabilities: { supportsTopK: true, supportsChatTemplateKwargs: true, routesEffortViaChatTemplateKwargs: false },
         reasoningEffort: 'max',
       }),
     ).toEqual({
@@ -394,6 +399,7 @@ describe('llm client pure helpers', () => {
         request: { messages: [{ role: 'user' as const, content: 'hi' }], tools: [] },
         profile,
         capabilities: { supportsTopK: false, supportsChatTemplateKwargs: false, supportsNumCtx: false },
+        capabilities: { supportsTopK: false, supportsChatTemplateKwargs: false, routesEffortViaChatTemplateKwargs: false },
       }),
     ).toEqual({
       params: {
@@ -421,6 +427,7 @@ describe('llm client pure helpers', () => {
         },
         profile,
         capabilities: { supportsTopK: false, supportsChatTemplateKwargs: false, supportsNumCtx: false },
+        capabilities: { supportsTopK: false, supportsChatTemplateKwargs: false, routesEffortViaChatTemplateKwargs: false },
       }),
     ).toEqual({
       params: {
@@ -453,9 +460,117 @@ describe('llm client pure helpers', () => {
       // reasoningEffort simulates session model's thinking config leaking into override client
       reasoningEffort: 'low',
       capabilities: { supportsTopK: true, supportsChatTemplateKwargs: true, supportsNumCtx: false },
+      capabilities: { supportsTopK: true, supportsChatTemplateKwargs: true, routesEffortViaChatTemplateKwargs: false },
     })
     // chat_template_kwargs must NOT be here — the modelSettings don't request it
     expect(result.params).not.toHaveProperty('chat_template_kwargs')
+  })
+
+  it('routes reasoning effort through chat_template_kwargs for llamacpp (top-level field is ignored by llama.cpp)', async () => {
+    const profile = {
+      temperature: 0.2,
+      defaultMaxTokens: 2000,
+      topP: 0.9,
+      topK: 40,
+      supportsVision: false,
+    }
+    const llamacppCaps = {
+      supportsTopK: true,
+      supportsChatTemplateKwargs: false,
+      routesEffortViaChatTemplateKwargs: true,
+    }
+    const baseRequest = {
+      messages: [{ role: 'user' as const, content: 'hello' }],
+    }
+
+    // No model settings — effort goes into chat_template_kwargs, no top-level reasoning_effort
+    const noSettings = await buildNonStreamingCreateParams({
+      model: 'test-model',
+      request: baseRequest,
+      profile,
+      capabilities: llamacppCaps,
+      reasoningEffort: 'xhigh',
+    })
+    expect(noSettings.params).not.toHaveProperty('reasoning_effort')
+    expect(noSettings.params).toHaveProperty('chat_template_kwargs', { reasoning_effort: 'xhigh' })
+
+    // User queryParams (e.g. thinking:{type:enabled}) are merged, and the
+    // resolved effort is layered into chat_template_kwargs
+    const withQueryParams = await buildNonStreamingCreateParams({
+      model: 'test-model',
+      request: {
+        ...baseRequest,
+        modelSettings: { queryParams: { thinking: { type: 'enabled' } } },
+      },
+      profile,
+      capabilities: llamacppCaps,
+      reasoningEffort: 'low',
+    })
+    const qpParams = withQueryParams.params as unknown as Record<string, unknown>
+    expect(qpParams).not.toHaveProperty('reasoning_effort')
+    expect(qpParams).toHaveProperty('thinking', { type: 'enabled' })
+    expect(qpParams).toHaveProperty('chat_template_kwargs', { reasoning_effort: 'low' })
+
+    // User's explicit chat_template_kwargs in queryParams wins over the resolved effort
+    const explicitKwargs = await buildNonStreamingCreateParams({
+      model: 'test-model',
+      request: {
+        ...baseRequest,
+        modelSettings: { queryParams: { chat_template_kwargs: { reasoning_effort: 'medium' } } },
+      },
+      profile,
+      capabilities: llamacppCaps,
+      reasoningEffort: 'xhigh',
+    })
+    expect(explicitKwargs.params).toHaveProperty('chat_template_kwargs', { reasoning_effort: 'medium' })
+
+    // Effort 'none' is expressed as enable_thinking:false (official Qwen templates
+    // reject reasoning_effort:'none' with a 400)
+    const noneEffort = await buildNonStreamingCreateParams({
+      model: 'test-model',
+      request: baseRequest,
+      profile,
+      capabilities: llamacppCaps,
+      reasoningEffort: 'none',
+    })
+    expect(noneEffort.params).not.toHaveProperty('reasoning_effort')
+    expect(noneEffort.params).toHaveProperty('chat_template_kwargs', { enable_thinking: false })
+
+    // 'none' also overrides a user-provided reasoning_effort in kwargs
+    const noneOverKwargs = await buildNonStreamingCreateParams({
+      model: 'test-model',
+      request: {
+        ...baseRequest,
+        modelSettings: { queryParams: { chat_template_kwargs: { reasoning_effort: 'low' } } },
+      },
+      profile,
+      capabilities: llamacppCaps,
+      reasoningEffort: 'none',
+    })
+    expect(noneOverKwargs.params).toHaveProperty('chat_template_kwargs', { enable_thinking: false })
+
+    // No resolved effort and no kwargs — nothing injected
+    const nothing = await buildNonStreamingCreateParams({
+      model: 'test-model',
+      request: baseRequest,
+      profile,
+      capabilities: llamacppCaps,
+    })
+    expect(nothing.params).not.toHaveProperty('chat_template_kwargs')
+    expect(nothing.params).not.toHaveProperty('reasoning_effort')
+
+    // Streaming path behaves identically
+    const streaming = await buildStreamingCreateParams({
+      model: 'test-model',
+      request: { ...baseRequest, modelSettings: { queryParams: { thinking: { type: 'enabled' } } } },
+      profile,
+      capabilities: llamacppCaps,
+      reasoningEffort: 'medium',
+    })
+    const streamParams = streaming.params as unknown as Record<string, unknown>
+    expect(streamParams).not.toHaveProperty('reasoning_effort')
+    expect(streamParams).toHaveProperty('thinking', { type: 'enabled' })
+    expect(streamParams).toHaveProperty('chat_template_kwargs', { reasoning_effort: 'medium' })
   })
 
   it('strips params listed in modelSettings.omitParams from the final request', async () => {
@@ -475,6 +590,7 @@ describe('llm client pure helpers', () => {
       },
       profile,
       capabilities: { supportsTopK: false, supportsChatTemplateKwargs: false, supportsNumCtx: false },
+      capabilities: { supportsTopK: false, supportsChatTemplateKwargs: false, routesEffortViaChatTemplateKwargs: false },
     })
     expect(result.params).not.toHaveProperty('temperature')
     expect(result.params).toHaveProperty('top_p', 0.9)
@@ -496,6 +612,7 @@ describe('llm client pure helpers', () => {
       },
       profile,
       capabilities: { supportsTopK: false, supportsChatTemplateKwargs: false, supportsNumCtx: false },
+      capabilities: { supportsTopK: false, supportsChatTemplateKwargs: false, routesEffortViaChatTemplateKwargs: false },
     })
     expect(result.params).not.toHaveProperty('top_p')
     expect(result.params).toHaveProperty('temperature', 0.7)
@@ -520,6 +637,7 @@ describe('llm client pure helpers', () => {
       },
       profile,
       capabilities: { supportsTopK: false, supportsChatTemplateKwargs: false, supportsNumCtx: false },
+      capabilities: { supportsTopK: false, supportsChatTemplateKwargs: false, routesEffortViaChatTemplateKwargs: false },
     })
     expect(result.params).not.toHaveProperty('temperature')
     expect(result.params).toHaveProperty('custom_param', true)
@@ -577,6 +695,7 @@ describe('llm client pure helpers', () => {
       request: baseReq,
       profile,
       capabilities: { supportsTopK: false, supportsChatTemplateKwargs: false, supportsNumCtx: false },
+      capabilities: { supportsTopK: false, supportsChatTemplateKwargs: false, routesEffortViaChatTemplateKwargs: false },
     })
     expect(withoutOmit.params).toHaveProperty('temperature', 0.7)
 
@@ -585,6 +704,7 @@ describe('llm client pure helpers', () => {
       request: { ...baseReq, modelSettings: { omitParams: [] } },
       profile,
       capabilities: { supportsTopK: false, supportsChatTemplateKwargs: false, supportsNumCtx: false },
+      capabilities: { supportsTopK: false, supportsChatTemplateKwargs: false, routesEffortViaChatTemplateKwargs: false },
     })
     expect(withEmpty.params).toHaveProperty('temperature', 0.7)
   })
@@ -604,6 +724,7 @@ describe('llm client pure helpers', () => {
       },
       profile,
       capabilities: { supportsTopK: false, supportsChatTemplateKwargs: false, supportsNumCtx: false },
+      capabilities: { supportsTopK: false, supportsChatTemplateKwargs: false, routesEffortViaChatTemplateKwargs: false },
     })
     expect(result.params).not.toHaveProperty('temperature')
     expect(result.params).not.toHaveProperty('max_tokens')

--- a/src/server/llm/client-pure.ts
+++ b/src/server/llm/client-pure.ts
@@ -293,10 +293,7 @@ async function buildChatCompletionCreateParams(
     if (hasQueryParams) {
       // Merge the user's explicit queryParams, but route chat_template_kwargs
       // separately so the resolved effort can be layered onto it.
-      const { chat_template_kwargs: userKwargsFromQP, ...restQueryParams } = queryParams as Record<
-        string,
-        unknown
-      >
+      const { chat_template_kwargs: userKwargsFromQP, ...restQueryParams } = queryParams as Record<string, unknown>
       Object.assign(params as unknown as Record<string, unknown>, restQueryParams)
       if (userKwargsFromQP) {
         userKwargs = userKwargsFromQP as Record<string, unknown>

--- a/src/server/llm/client-pure.ts
+++ b/src/server/llm/client-pure.ts
@@ -87,7 +87,10 @@ async function buildAttachmentContent(
   return content
 }
 
-type MinimalCapabilities = Pick<BackendCapabilities, 'supportsTopK' | 'supportsChatTemplateKwargs' | 'supportsNumCtx'>
+type MinimalCapabilities = Pick<
+  BackendCapabilities,
+  'supportsTopK' | 'supportsChatTemplateKwargs' | 'supportsNumCtx' | 'routesEffortViaChatTemplateKwargs'
+>
 type MinimalProfile = Pick<ModelProfile, 'temperature' | 'defaultMaxTokens' | 'topP' | 'topK' | 'supportsVision'>
 
 function convertToolCalls(
@@ -283,7 +286,35 @@ async function buildChatCompletionCreateParams(
   const hasQueryParams = queryParams && Object.keys(queryParams).length > 0
   const hasExplicitModelSettings = hasQueryParams || !!request.modelSettings?.chatTemplateKwargs
 
-  if (hasQueryParams) {
+  if (capabilities.routesEffortViaChatTemplateKwargs) {
+    // llama.cpp only reads reasoning_effort from chat_template_kwargs (Jinja
+    // template variables); a top-level body field is silently ignored.
+    let userKwargs: Record<string, unknown> | undefined = request.modelSettings?.chatTemplateKwargs
+    if (hasQueryParams) {
+      // Merge the user's explicit queryParams, but route chat_template_kwargs
+      // separately so the resolved effort can be layered onto it.
+      const { chat_template_kwargs: userKwargsFromQP, ...restQueryParams } = queryParams as Record<
+        string,
+        unknown
+      >
+      Object.assign(params as unknown as Record<string, unknown>, restQueryParams)
+      if (userKwargsFromQP) {
+        userKwargs = userKwargsFromQP as Record<string, unknown>
+      }
+    }
+    const kwargs: Record<string, unknown> = { ...(userKwargs ?? {}) }
+    if (resolvedEffort === 'none') {
+      // 'none' is the universal "thinking off" switch. Official Qwen templates
+      // reject reasoning_effort:'none' (400), so express it as enable_thinking.
+      delete kwargs['reasoning_effort']
+      kwargs['enable_thinking'] = false
+    } else if (resolvedEffort && kwargs['reasoning_effort'] === undefined) {
+      kwargs['reasoning_effort'] = resolvedEffort
+    }
+    if (Object.keys(kwargs).length > 0) {
+      ;(params as unknown as Record<string, unknown>)['chat_template_kwargs'] = kwargs
+    }
+  } else if (hasQueryParams) {
     // queryParams are the user's explicit config — merge into params
     Object.assign(params as unknown as Record<string, unknown>, queryParams)
     // reasoning_effort from client config supersedes queryParams (user-set thinkingLevel wins)

--- a/src/server/llm/types.ts
+++ b/src/server/llm/types.ts
@@ -19,7 +19,7 @@ export interface LLMToolDefinition {
   }
 }
 
-export type ReasoningEffort = 'low' | 'medium' | 'high' | 'xhigh' | 'max'
+export type ReasoningEffort = 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max'
 
 export interface LLMCompletionRequest {
   messages: LLMMessage[]

--- a/src/server/llm/vision-override.test.ts
+++ b/src/server/llm/vision-override.test.ts
@@ -60,8 +60,12 @@ describe('user vision override', () => {
         messages: makeMessagesWithImage(),
       },
       profile,
-      capabilities: { supportsTopK: false, supportsChatTemplateKwargs: false, supportsNumCtx: false },
-      capabilities: { supportsTopK: false, supportsChatTemplateKwargs: false, routesEffortViaChatTemplateKwargs: false },
+      capabilities: {
+        supportsTopK: false,
+        supportsChatTemplateKwargs: false,
+        supportsNumCtx: false,
+        routesEffortViaChatTemplateKwargs: false,
+      },
     })
 
     expect((result.params as any).messages).toEqual([
@@ -90,8 +94,12 @@ describe('user vision override', () => {
         modelSettings: { supportsVision: true },
       },
       profile,
-      capabilities: { supportsTopK: false, supportsChatTemplateKwargs: false, supportsNumCtx: false },
-      capabilities: { supportsTopK: false, supportsChatTemplateKwargs: false, routesEffortViaChatTemplateKwargs: false },
+      capabilities: {
+        supportsTopK: false,
+        supportsChatTemplateKwargs: false,
+        supportsNumCtx: false,
+        routesEffortViaChatTemplateKwargs: false,
+      },
     })
 
     expect((result.params as any).messages).toEqual([
@@ -120,8 +128,12 @@ describe('user vision override', () => {
         modelSettings: { supportsVision: false },
       },
       profile,
-      capabilities: { supportsTopK: false, supportsChatTemplateKwargs: false, supportsNumCtx: false },
-      capabilities: { supportsTopK: false, supportsChatTemplateKwargs: false, routesEffortViaChatTemplateKwargs: false },
+      capabilities: {
+        supportsTopK: false,
+        supportsChatTemplateKwargs: false,
+        supportsNumCtx: false,
+        routesEffortViaChatTemplateKwargs: false,
+      },
     })
 
     expect((result.params as any).messages).toEqual([
@@ -150,8 +162,12 @@ describe('user vision override', () => {
         modelSettings: { supportsVision: true },
       },
       profile,
-      capabilities: { supportsTopK: false, supportsChatTemplateKwargs: false, supportsNumCtx: false },
-      capabilities: { supportsTopK: false, supportsChatTemplateKwargs: false, routesEffortViaChatTemplateKwargs: false },
+      capabilities: {
+        supportsTopK: false,
+        supportsChatTemplateKwargs: false,
+        supportsNumCtx: false,
+        routesEffortViaChatTemplateKwargs: false,
+      },
     })
 
     expect((result.params as any).messages).toEqual([

--- a/src/server/llm/vision-override.test.ts
+++ b/src/server/llm/vision-override.test.ts
@@ -61,6 +61,7 @@ describe('user vision override', () => {
       },
       profile,
       capabilities: { supportsTopK: false, supportsChatTemplateKwargs: false, supportsNumCtx: false },
+      capabilities: { supportsTopK: false, supportsChatTemplateKwargs: false, routesEffortViaChatTemplateKwargs: false },
     })
 
     expect((result.params as any).messages).toEqual([
@@ -90,6 +91,7 @@ describe('user vision override', () => {
       },
       profile,
       capabilities: { supportsTopK: false, supportsChatTemplateKwargs: false, supportsNumCtx: false },
+      capabilities: { supportsTopK: false, supportsChatTemplateKwargs: false, routesEffortViaChatTemplateKwargs: false },
     })
 
     expect((result.params as any).messages).toEqual([
@@ -119,6 +121,7 @@ describe('user vision override', () => {
       },
       profile,
       capabilities: { supportsTopK: false, supportsChatTemplateKwargs: false, supportsNumCtx: false },
+      capabilities: { supportsTopK: false, supportsChatTemplateKwargs: false, routesEffortViaChatTemplateKwargs: false },
     })
 
     expect((result.params as any).messages).toEqual([
@@ -148,6 +151,7 @@ describe('user vision override', () => {
       },
       profile,
       capabilities: { supportsTopK: false, supportsChatTemplateKwargs: false, supportsNumCtx: false },
+      capabilities: { supportsTopK: false, supportsChatTemplateKwargs: false, routesEffortViaChatTemplateKwargs: false },
     })
 
     expect((result.params as any).messages).toEqual([

--- a/src/server/provider-manager.test.ts
+++ b/src/server/provider-manager.test.ts
@@ -752,6 +752,7 @@ describe('ProviderManager - Model Selection', () => {
 
       expect(createLLMClientMock).toHaveBeenLastCalledWith(
         expect.objectContaining({ llm: expect.objectContaining({ model: 'model-large' }) }),
+        'openai',
       )
     })
 
@@ -777,6 +778,7 @@ describe('ProviderManager - Model Selection', () => {
 
       expect(createLLMClientMock).toHaveBeenLastCalledWith(
         expect.objectContaining({ llm: expect.objectContaining({ model: 'model-large' }) }),
+        'openai',
       )
     })
 
@@ -805,6 +807,7 @@ describe('ProviderManager - Model Selection', () => {
 
       expect(createLLMClientMock).toHaveBeenLastCalledWith(
         expect.objectContaining({ llm: expect.objectContaining({ model: 'model-large' }) }),
+        'openai',
       )
     })
   })
@@ -1054,6 +1057,31 @@ describe('ProviderManager - Model Selection', () => {
       manager.createClient('p', 'model-a')
       const config = createLLMClientMock.mock.calls.at(-1)![0]!
       expect(config.llm.reasoningEffort).toBe('medium')
+    })
+
+    it('passes the provider backend to createLLMClient (session clients must not default to unknown)', () => {
+      const manager = buildManager([
+        providerWith([{ id: 'model-a', contextWindow: 100000, source: 'default' as const }]),
+        {
+          id: 'llama',
+          name: 'Llama',
+          url: 'http://localhost:8000/v1',
+          backend: 'llamacpp',
+          models: [{ id: 'model-b', contextWindow: 100000, source: 'default' as const }],
+          isActive: false,
+          createdAt: new Date().toISOString(),
+        },
+      ])
+      manager.createClient('p', 'model-a')
+      expect(createLLMClientMock.mock.calls.at(-1)).toEqual([
+        expect.objectContaining({ llm: expect.objectContaining({ model: 'model-a' }) }),
+        'vllm',
+      ])
+      manager.createClient('llama', 'model-b')
+      expect(createLLMClientMock.mock.calls.at(-1)).toEqual([
+        expect.objectContaining({ llm: expect.objectContaining({ model: 'model-b' }) }),
+        'llamacpp',
+      ])
     })
 
     it('persists reasoningEfforts and reasoningEffortOverride via updateModelSettings', async () => {

--- a/src/server/provider-manager.ts
+++ b/src/server/provider-manager.ts
@@ -460,7 +460,10 @@ export function createProviderManager(config: Config, options: ProviderManagerOp
     const transport = options.adapters?.getTransport(resolveTransportAdapter(provider))
     return transport
       ? createTransportLLMClient(provider, resolvedModel, transport, reasoningEffort)
-      : createLLMClient(createConfigForProvider(provider, resolvedModel, reasoningEffort))
+      : createLLMClient(
+          createConfigForProvider(provider, resolvedModel, reasoningEffort),
+          provider.backend as import('./llm/backend.js').Backend,
+        )
   }
 
   async function fetchProviderModels(provider: Provider): Promise<ModelConfig[]> {

--- a/src/server/session/name-generator.ts
+++ b/src/server/session/name-generator.ts
@@ -257,7 +257,7 @@ function resolveSessionProvider(
   session: Session,
   providerManager: ProviderManager,
   effective?: { providerId: string | null; model: string | null },
-): { providerId: string; baseUrl: string; apiKey?: string; model: string } | undefined {
+): { providerId: string; baseUrl: string; apiKey?: string; model: string; backend?: string } | undefined {
   const providers = providerManager.getProviders()
   const effectiveProviderId = effective?.providerId ?? session.providerId ?? undefined
   const effectiveModel = effective?.model ?? session.providerModel ?? providerManager.getCurrentModel()
@@ -275,6 +275,7 @@ function resolveSessionProvider(
     baseUrl: provider.url,
     ...(provider.apiKey ? { apiKey: provider.apiKey } : {}),
     model: effectiveModel,
+    ...(provider.backend ? { backend: provider.backend } : {}),
   }
 }
 
@@ -330,13 +331,16 @@ export async function generateSessionNameForSession(
       client.setModel(providerConfig.model)
     } else if (providerConfig) {
       const { createLLMClient } = await import('../llm/client.js')
-      client = createLLMClient({
-        llm: {
-          baseUrl: providerConfig.baseUrl,
-          model: providerConfig.model,
-          ...(providerConfig.apiKey ? { apiKey: providerConfig.apiKey } : {}),
-        },
-      } as never)
+      client = createLLMClient(
+        {
+          llm: {
+            baseUrl: providerConfig.baseUrl,
+            model: providerConfig.model,
+            ...(providerConfig.apiKey ? { apiKey: providerConfig.apiKey } : {}),
+          },
+        } as never,
+        (providerConfig.backend ?? 'unknown') as import('../llm/backend.js').Backend,
+      )
     } else if (deps.getLLMClient) {
       // No session-specific provider — use the global/mock client
       client = deps.getLLMClient()


### PR DESCRIPTION
Fixes #256, #258
Related: #252

## Problem

Two related bugs made the reasoning effort level ineffective on the llama.cpp backend:

1. **llama.cpp ignores top-level `reasoning_effort`** (#256). llama.cpp only populates Jinja chat-template variables from `chat_template_kwargs`; a top-level `reasoning_effort` body field is silently ignored, so the selected effort level never reached the model — the chat template always used its default effort.
2. **Session LLM clients were created with the `unknown` backend** (#258). `createClientForProvider` called `createLLMClient` without the backend argument, so every session/agent/sub-agent client defaulted to the `unknown` backend and its capability table. This silently disabled any backend-specific capability for session clients (for llamacpp it neutralized fix 1; for ollama/openai it could inject unsupported params like `top_k` or `chat_template_kwargs`).

## Changes

- **`src/server/llm/backend.ts`** — new `routesEffortViaChatTemplateKwargs` capability, set only for `llamacpp`
- **`src/server/llm/client-pure.ts`** — when the capability is set, the resolved effort is layered into `chat_template_kwargs.reasoning_effort` instead of the top-level field. User-provided `chat_template_kwargs` (e.g. from `thinkingQueryParams`) take precedence for `reasoning_effort`; the rest of the query params are still merged. Effort `none` maps to `enable_thinking: false` (official Qwen templates 400 on `reasoning_effort: "none"`, froggeric templates treat `none` as "thinking off")
- **`src/server/provider-manager.ts`** — `createClientForProvider` passes `provider.backend` to `createLLMClient` so session clients get the correct capability table
- **`src/server/session/name-generator.ts`** — same backend passed in the legacy client fallback path
- **`src/server/llm/types.ts`** — widen the `ReasoningEffort` type to the full shared vocabulary (`none`/`minimal` were missing, which blocked routing `none`)

## Verification

- Unit tests: effort routing into kwargs, queryParams merge, user-kwargs precedence, `none` mapping, no-op case, streaming parity; `createClient` backend propagation (vllm + llamacpp)
- End-to-end against a live llama.cpp server (Qwen3.8, built from this branch): rendered prompt dumps show "Reasoning effort is set to low/xhigh" injected in the system prompt for the matching levels, and an empty think block with no instruction for `none` — including through a real OpenFox session (previously the instruction was absent because session clients used the `unknown` backend)
- `npm run typecheck` and `npm run lint` clean; full test suite green except 3 pre-existing timezone-dependent failures in `web/src/lib/format-date.test.ts` (reproduced on the base commit, unrelated to this change)

## Notes

- Other backends (vllm/sglang/openai/ollama/...) keep their existing top-level `reasoning_effort` behavior; the only change for them is that session clients now use their real capability table instead of `unknown`