### PR TITLE
fix(server): enforce default session history limit

### DIFF
--- a/src/server/db/settings.test.ts
+++ b/src/server/db/settings.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 import { loadConfig } from '../config.js'
 import { closeDatabase, initDatabase } from './index.js'
-import { SETTINGS_KEYS, deleteSetting, getAllSettings, getSetting, setSetting } from './settings.js'
+import { SETTINGS_KEYS, deleteSetting, getAllSettings, getMaxVisibleItems, getSetting, setSetting } from './settings.js'
 
 describe('db settings', () => {
   beforeEach(() => {
@@ -29,6 +29,25 @@ describe('db settings', () => {
     expect(getSetting('theme')).toBeNull()
     expect(getAllSettings()).toEqual({
       [SETTINGS_KEYS.GLOBAL_INSTRUCTIONS]: 'Always test first',
+    })
+  })
+
+  describe('max visible items', () => {
+    it('uses the declared default when the setting is absent', () => {
+      expect(getMaxVisibleItems()).toBe(300)
+    })
+
+    it('preserves explicit limits, including zero for unlimited history', () => {
+      setSetting(SETTINGS_KEYS.DISPLAY_MAX_VISIBLE_ITEMS, '150')
+      expect(getMaxVisibleItems()).toBe(150)
+
+      setSetting(SETTINGS_KEYS.DISPLAY_MAX_VISIBLE_ITEMS, '0')
+      expect(getMaxVisibleItems()).toBe(0)
+    })
+
+    it.each(['', 'not-a-number', '-1', '12.5'])('falls back to the default for invalid value %j', (value) => {
+      setSetting(SETTINGS_KEYS.DISPLAY_MAX_VISIBLE_ITEMS, value)
+      expect(getMaxVisibleItems()).toBe(300)
     })
   })
 

--- a/src/server/db/settings.ts
+++ b/src/server/db/settings.ts
@@ -140,5 +140,12 @@ export function getAllSettings(): Record<string, string> {
 
 export function getMaxVisibleItems(): number {
   const setting = getSetting(SETTINGS_KEYS.DISPLAY_MAX_VISIBLE_ITEMS)
-  return setting ? parseInt(setting, 10) : 0
+  const defaultValue = Number(SETTINGS_DEFAULTS[SETTINGS_KEYS.DISPLAY_MAX_VISIBLE_ITEMS])
+
+  if (setting === null || setting.trim() === '') {
+    return defaultValue
+  }
+
+  const value = Number(setting)
+  return Number.isInteger(value) && value >= 0 ? value : defaultValue
 }

--- a/src/server/routes/sessions.test.ts
+++ b/src/server/routes/sessions.test.ts
@@ -10,7 +10,9 @@ vi.mock('../db/settings.js', () => {
     setSetting: (key: string, value: string) => store.set(key, value),
     getMaxVisibleItems: () => {
       const setting = store.get('display.maxVisibleItems')
-      return setting ? parseInt(setting, 10) : 0
+      if (setting === undefined || setting.trim() === '') return 300
+      const parsed = Number(setting)
+      return Number.isInteger(parsed) && parsed >= 0 ? parsed : 300
     },
     SETTINGS_KEYS: { DISPLAY_MAX_VISIBLE_ITEMS: 'display.maxVisibleItems' },
     __store: store,
@@ -34,14 +36,14 @@ const mockSession = {
   executionState: null,
   metadata: { title: 'Test', totalTokensUsed: 0, totalToolCalls: 0, iterationCount: 0 },
   metadataEntries: {},
-  messageCount: 10,
+  messageCount: 305,
 }
 
-const mockMessages = Array.from({ length: 10 }, (_, i) => ({
+const mockMessages = Array.from({ length: 305 }, (_, i) => ({
   id: `msg-${i + 1}`,
   role: i % 2 === 0 ? 'user' : ('assistant' as 'user' | 'assistant'),
   content: `Message ${i + 1}`,
-  timestamp: new Date(Date.now() - (10 - i) * 60000).toISOString(),
+  timestamp: new Date(Date.now() - (305 - i) * 60000).toISOString(),
   tokenCount: 0,
   isStreaming: false,
 }))
@@ -151,7 +153,7 @@ describe('GET /api/sessions/:id — server-side truncation', () => {
     const res = await fetch(`${baseUrl}/api/sessions/session-1`)
     const data = (await res.json()) as { messages: { id: string }[]; hiddenCount: number }
 
-    expect(data.messages).toHaveLength(10)
+    expect(data.messages).toHaveLength(305)
     expect(data.hiddenCount).toBe(0)
   })
 
@@ -166,10 +168,10 @@ describe('GET /api/sessions/:id — server-side truncation', () => {
     const data = (await res.json()) as { messages: { id: string }[]; hiddenCount: number }
 
     expect(data.messages).toHaveLength(3)
-    expect(data.messages[0]!.id).toBe('msg-8')
-    expect(data.messages[1]!.id).toBe('msg-9')
-    expect(data.messages[2]!.id).toBe('msg-10')
-    expect(data.hiddenCount).toBe(7)
+    expect(data.messages[0]!.id).toBe('msg-303')
+    expect(data.messages[1]!.id).toBe('msg-304')
+    expect(data.messages[2]!.id).toBe('msg-305')
+    expect(data.hiddenCount).toBe(302)
   })
 
   it('[AUTOMATED] returns all messages when messages.length <= maxVisibleItems', async () => {
@@ -177,16 +179,16 @@ describe('GET /api/sessions/:id — server-side truncation', () => {
       __store: Map<string, string>
       setSetting: (k: string, v: string) => void
     }
-    settings.setSetting('display.maxVisibleItems', '50')
+    settings.setSetting('display.maxVisibleItems', '500')
 
     const res = await fetch(`${baseUrl}/api/sessions/session-1`)
     const data = (await res.json()) as { messages: { id: string }[]; hiddenCount: number }
 
-    expect(data.messages).toHaveLength(10)
+    expect(data.messages).toHaveLength(305)
     expect(data.hiddenCount).toBe(0)
   })
 
-  it('[AUTOMATED] returns hiddenCount = 0 when maxVisibleItems is not set (defaults to 0)', async () => {
+  it('[AUTOMATED] applies the default limit when maxVisibleItems is not set', async () => {
     const settings = (await import('../db/settings.js')) as unknown as {
       __store: Map<string, string>
       setSetting: (k: string, v: string) => void
@@ -196,8 +198,9 @@ describe('GET /api/sessions/:id — server-side truncation', () => {
     const res = await fetch(`${baseUrl}/api/sessions/session-1`)
     const data = (await res.json()) as { messages: { id: string }[]; hiddenCount: number }
 
-    expect(data.hiddenCount).toBe(0)
-    expect(data.messages).toHaveLength(10)
+    expect(data.messages).toHaveLength(300)
+    expect(data.messages[0]!.id).toBe('msg-6')
+    expect(data.hiddenCount).toBe(5)
   })
 
   it('[AUTOMATED] returns 404 for non-existent session', async () => {
@@ -216,7 +219,7 @@ describe('GET /api/sessions/:id — server-side truncation', () => {
     const res = await fetch(`${baseUrl}/api/sessions/session-1?full=true`)
     const data = (await res.json()) as { messages: { id: string }[]; hiddenCount: number }
 
-    expect(data.messages).toHaveLength(10)
+    expect(data.messages).toHaveLength(305)
     expect(data.hiddenCount).toBe(0)
   })
 


### PR DESCRIPTION
## Summary

- apply the declared `display.maxVisibleItems` default when no setting row exists
- fall back to that default for blank, malformed, negative, or fractional values
- preserve explicit `0` as the opt-in unlimited-history value
- cover the default 300-item truncation and the `?full=true` bypass

## Why

The web UI presents 300 as the default history limit, but `getMaxVisibleItems()` returned `0` when the setting had never been saved. The session route converts `0` to `undefined`, so a fresh/default configuration serialized and sent the complete conversation before the client truncated it.

This is especially noticeable in WebKit/Safari on long sessions. In the local reproduction, an 800-message response was about 8.16 MiB, while the most recent 300 messages accounted for about 3.67 MiB. Applying the existing default server-side avoids sending roughly 4.5 MiB on that session without changing the displayed default or the explicit full-history flow.

## Compatibility

- users who explicitly set `display.maxVisibleItems` keep their chosen limit
- explicit `0` remains unlimited
- `GET /api/sessions/:id?full=true` still returns the full history

## AI disclosure

- **AI Models:** GPT-5

## Tests

- `npx vitest run src/server/db/settings.test.ts src/server/routes/sessions.test.ts` (29 passed)
- `npm run typecheck`
- `npm run lint`
- `npx prettier --check src/server/db/settings.ts src/server/db/settings.test.ts src/server/routes/sessions.test.ts`
- full unit suite: 4,461 passed, 32 skipped
- full E2E suite: 325 passed, 49 skipped, with 3 unrelated transient failures in `ask-user` / `path-security`; isolated rerun passed all 24 tests
