### PR TITLE
Fix/mcp oauth http

### DIFF
--- a/src/server/chat/dynamic-context.test.ts
+++ b/src/server/chat/dynamic-context.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest'
-import { computeUnifiedDiff, computeDynamicContextHash } from './dynamic-context.js'
+import {
+  computeUnifiedDiff,
+  computeDynamicContextHash,
+  computeToolDiff,
+  computePreviewToolDiff,
+} from './dynamic-context.js'
 
 describe('computeUnifiedDiff', () => {
   it('returns unchanged lines when texts are identical', () => {
@@ -176,6 +181,90 @@ Respond concisely and clearly.
       { type: 'removed', content: 'old' },
       { type: 'added', content: 'new' },
     ])
+  })
+})
+
+describe('computeToolDiff', () => {
+  const tool = (name: string) => ({
+    type: 'function' as const,
+    function: { name, description: `desc ${name}`, parameters: { type: 'object', properties: {} } },
+  })
+
+  it('returns empty array when tool sets are identical', () => {
+    const tools = [tool('read_file'), tool('write_file')]
+    expect(computeToolDiff(tools, [...tools])).toEqual([])
+  })
+
+  it('detects removed tools', () => {
+    const oldTools = [tool('read_file'), tool('write_file')]
+    const newTools = [tool('read_file')]
+    expect(computeToolDiff(oldTools, newTools)).toEqual([{ type: 'removed', content: 'write_file' }])
+  })
+
+  it('detects added tools', () => {
+    const oldTools = [tool('read_file')]
+    const newTools = [tool('read_file'), tool('write_file')]
+    expect(computeToolDiff(oldTools, newTools)).toEqual([{ type: 'added', content: 'write_file' }])
+  })
+
+  it('detects both additions and removals with removals first', () => {
+    const oldTools = [tool('a'), tool('b')]
+    const newTools = [tool('b'), tool('c')]
+    expect(computeToolDiff(oldTools, newTools)).toEqual([
+      { type: 'removed', content: 'a' },
+      { type: 'added', content: 'c' },
+    ])
+  })
+})
+
+describe('computePreviewToolDiff', () => {
+  const tool = (name: string) => ({
+    type: 'function' as const,
+    function: { name, description: `desc ${name}`, parameters: { type: 'object', properties: {} } },
+  })
+
+  it('uses cached tools as baseline when a cached prompt exists', () => {
+    const cached = [tool('read_file'), tool('write_file')]
+    const unfiltered = [tool('read_file'), tool('write_file'), tool('chrome_click')]
+    const fresh = [tool('read_file'), tool('write_file')]
+    expect(computePreviewToolDiff(cached, unfiltered, fresh)).toEqual([])
+  })
+
+  it('uses cached tools as baseline and detects removals when MCP is toggled off', () => {
+    const cached = [tool('read_file'), tool('chrome_click')]
+    const unfiltered = [tool('read_file'), tool('chrome_click')]
+    const fresh = [tool('read_file')]
+    expect(computePreviewToolDiff(cached, unfiltered, fresh)).toEqual([{ type: 'removed', content: 'chrome_click' }])
+  })
+
+  it('falls back to unfiltered registry when no cached prompt exists', () => {
+    const unfiltered = [tool('read_file'), tool('chrome_click')]
+    const fresh = [tool('read_file')]
+    expect(computePreviewToolDiff(undefined, unfiltered, fresh)).toEqual([{ type: 'removed', content: 'chrome_click' }])
+  })
+
+  it('falls back to unfiltered registry when cached tools are empty', () => {
+    const unfiltered = [tool('read_file'), tool('chrome_click')]
+    const fresh = [tool('read_file')]
+    expect(computePreviewToolDiff([], unfiltered, fresh)).toEqual([{ type: 'removed', content: 'chrome_click' }])
+  })
+
+  it('reports no additions without a cached prompt since the baseline already includes all MCP tools', () => {
+    const unfiltered = [tool('read_file'), tool('chrome_click')]
+    const fresh = [tool('read_file'), tool('chrome_click')]
+    expect(computePreviewToolDiff(undefined, unfiltered, fresh)).toEqual([])
+  })
+
+  it('detects additions when a cached prompt was built with MCP off and it is toggled on', () => {
+    const cached = [tool('read_file')]
+    const unfiltered = [tool('read_file'), tool('chrome_click')]
+    const fresh = [tool('read_file'), tool('chrome_click')]
+    expect(computePreviewToolDiff(cached, unfiltered, fresh)).toEqual([{ type: 'added', content: 'chrome_click' }])
+  })
+
+  it('reports no change when both baselines match the fresh tool set', () => {
+    const unfiltered = [tool('read_file')]
+    expect(computePreviewToolDiff(undefined, unfiltered, [tool('read_file')])).toEqual([])
   })
 })
 

--- a/src/server/chat/dynamic-context.ts
+++ b/src/server/chat/dynamic-context.ts
@@ -112,6 +112,40 @@ export function getToolFingerprint(tools: LLMToolDefinition[]): string {
     .join('|')
 }
 
+/**
+ * Compute a diff of tool names between two tool lists.
+ * Returns added/removed lines (removals first) for tools present in only one list.
+ */
+export function computeToolDiff(oldTools: LLMToolDefinition[], newTools: LLMToolDefinition[]): DiffLine[] {
+  const oldNames = oldTools.map((t) => t.function.name).sort()
+  const newNames = newTools.map((t) => t.function.name).sort()
+  const oldSet = new Set(oldNames)
+  const newSet = new Set(newNames)
+  const result: DiffLine[] = []
+  for (const name of oldNames) {
+    if (!newSet.has(name)) result.push({ type: 'removed', content: name })
+  }
+  for (const name of newNames) {
+    if (!oldSet.has(name)) result.push({ type: 'added', content: name })
+  }
+  return result
+}
+
+/**
+ * Compute the tool diff shown in the apply-dynamic-context preview.
+ * Baseline: cached prompt tools if present, otherwise the unfiltered registry
+ * (all MCP tools, no session overrides) so tool add/remove is visible even
+ * before a cached prompt exists.
+ */
+export function computePreviewToolDiff(
+  oldCachedTools: LLMToolDefinition[] | undefined,
+  unfilteredTools: LLMToolDefinition[],
+  newTools: LLMToolDefinition[],
+): DiffLine[] {
+  const baseline = oldCachedTools && oldCachedTools.length > 0 ? oldCachedTools : unfilteredTools
+  return computeToolDiff(baseline, newTools)
+}
+
 async function loadSessionContext(
   sessionManager: SessionManager,
   sessionId: string,

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1301,7 +1301,14 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
       return res.status(400).json({ error: 'disabledServers must be an array of strings' })
     }
     setSessionDisabledServers(sessionId, disabledServers)
-    sessionManager.setDynamicContextChanged(sessionId, true)
+    const messages = session.messages ?? []
+    if (messages.length === 0) {
+      const { applyDynamicContext } = await import('./chat/dynamic-context.js')
+      const modelName = session.providerModel ?? providerManager.getCurrentModel()
+      await applyDynamicContext(sessionManager, sessionId, modelName)
+    } else {
+      sessionManager.setDynamicContextChanged(sessionId, true)
+    }
     const state = sessionManager.getContextState(sessionId)
     wssExports.broadcastForSession(sessionId, createContextStateMessage(state))
     res.json({ disabledServers: getSessionDisabledServers(sessionId) })

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -2944,7 +2944,7 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
 
   /** Rendered on the OAuth callback. The message is always one of ours, never anything the caller sent. */
   function oauthCallbackPage(message: string): string {
-    return `<!doctype html><html lang="en"><head><meta charset="utf-8"><title>OpenFox</title></head><body style="font-family:system-ui;padding:2rem"><p>${message}</p></body></html>`
+    return `<!doctype html><html lang="en"><head><meta charset="utf-8"><title>OpenFox</title></head><body style="font-family:system-ui;padding:2rem"><p>${message}</p><script>try{new BroadcastChannel('openfox-oauth').postMessage({type:'oauth-callback-complete'})}catch{}</script></body></html>`
   }
 
   /** Accepts the whole callback URL or just its query string. Anything else yields no state and is refused. */
@@ -3013,8 +3013,9 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
     }
     try {
       const { auth } = await import('@modelcontextprotocol/sdk/client/auth.js')
-      const { McpOAuthProvider } = await import('./mcp/oauth-provider.js')
+      const { McpOAuthProvider, rejectStaleOAuthClient } = await import('./mcp/oauth-provider.js')
       const provider = new McpOAuthProvider(name, server.config.url)
+      await rejectStaleOAuthClient(provider)
       const result = await auth(provider, { serverUrl: server.config.url })
       if (result === 'AUTHORIZED') {
         await applyMcpOAuthResult(name)

--- a/src/server/mcp/manager.ts
+++ b/src/server/mcp/manager.ts
@@ -7,6 +7,7 @@ import type { McpServerConfig, McpServerState, McpToolInfo, McpManagerOptions, C
 import type { LLMToolDefinition } from '../llm/types.js'
 import { logger } from '../utils/logger.js'
 import { McpOAuthProvider } from './oauth-provider.js'
+import { readMcpOAuthEntry } from './oauth-store.js'
 
 /**
  * The SDK merges requestInit headers after the ones it derives from the auth provider, so a static
@@ -92,7 +93,13 @@ export class McpManager {
           httpOpts.requestInit = { headers }
         }
         if (entry.config.oauth) {
-          httpOpts.authProvider = new McpOAuthProvider(name, entry.config.url)
+          // A connection attempt is a probe, never an authorization: it must not touch stored
+          // credentials, or it would clobber an authorization the user has pending in a browser.
+          // But if tokens are already stored, the real provider must be used so they get attached.
+          const stored = await readMcpOAuthEntry(name, entry.config.url)
+          httpOpts.authProvider = stored?.tokens
+            ? new McpOAuthProvider(name, entry.config.url)
+            : McpOAuthProvider.forBackgroundProbe(name, entry.config.url)
         }
         transport = new StreamableHTTPClientTransport(new URL(entry.config.url), httpOpts) as unknown as Transport
       } else {

--- a/src/server/mcp/oauth-provider.ts
+++ b/src/server/mcp/oauth-provider.ts
@@ -1,5 +1,9 @@
 import { randomBytes } from 'node:crypto'
 import type { OAuthClientProvider } from '@modelcontextprotocol/sdk/client/auth.js'
+import {
+  discoverAuthorizationServerMetadata,
+  discoverOAuthProtectedResourceMetadata,
+} from '@modelcontextprotocol/sdk/client/auth.js'
 import type {
   OAuthClientInformationMixed,
   OAuthClientMetadata,
@@ -14,6 +18,69 @@ import {
   saveMcpOAuthState,
   saveMcpOAuthTokens,
 } from './oauth-store.js'
+import { logger } from '../utils/logger.js'
+
+/** Where a provider keeps its credentials. Persistent for the real flow, in-memory for probes. */
+interface ProviderStorage {
+  read(): Promise<
+    | {
+        clientInformation?: OAuthClientInformationMixed
+        tokens?: OAuthTokens
+        codeVerifier?: string
+        state?: string
+      }
+    | undefined
+  >
+  saveClientInformation(clientInformation: OAuthClientInformationMixed): Promise<void>
+  saveTokens(tokens: OAuthTokens): Promise<void>
+  saveCodeVerifier(codeVerifier: string): Promise<void>
+  saveState(state: string): Promise<void>
+  clearTokens(): Promise<void>
+  clearAll(): Promise<void>
+}
+
+function persistentStorage(serverName: string, serverUrl: string): ProviderStorage {
+  return {
+    read: () => readMcpOAuthEntry(serverName, serverUrl),
+    saveClientInformation: (info) => saveMcpOAuthClientInformation(serverName, serverUrl, info),
+    saveTokens: (tokens) => saveMcpOAuthTokens(serverName, serverUrl, tokens),
+    saveCodeVerifier: (verifier) => saveMcpOAuthCodeVerifier(serverName, serverUrl, verifier),
+    saveState: (state) => saveMcpOAuthState(serverName, serverUrl, state),
+    clearTokens: () => clearMcpOAuthTokens(serverName, serverUrl),
+    clearAll: () => clearMcpOAuthEntry(serverName),
+  }
+}
+
+/** Ephemeral storage for background probes: nothing they touch may clobber a pending authorization. */
+function memoryStorage(): ProviderStorage {
+  let entry: {
+    clientInformation?: OAuthClientInformationMixed
+    tokens?: OAuthTokens
+    codeVerifier?: string
+    state?: string
+  } = {}
+  return {
+    read: async () => entry,
+    saveClientInformation: async (info) => {
+      entry.clientInformation = info
+    },
+    saveTokens: async (tokens) => {
+      entry.tokens = tokens
+    },
+    saveCodeVerifier: async (verifier) => {
+      entry.codeVerifier = verifier
+    },
+    saveState: async (state) => {
+      entry.state = state
+    },
+    clearTokens: async () => {
+      delete entry.tokens
+    },
+    clearAll: async () => {
+      entry = {}
+    },
+  }
+}
 
 /** API routes are mounted on literal paths, so the callback always sits at the origin root. */
 const CALLBACK_PATH = '/api/mcp/oauth/callback'
@@ -65,7 +132,17 @@ export class McpOAuthProvider implements OAuthClientProvider {
     private readonly serverName: string,
     private readonly serverUrl: string,
     private readonly redirectUri: string = getMcpOAuthRedirectUri(),
+    private readonly storage: ProviderStorage = persistentStorage(serverName, serverUrl),
   ) {}
+
+  /** Kept for log context and for callers that need the identity of the server being probed. */
+  get name(): string {
+    return this.serverName
+  }
+
+  get url(): string {
+    return this.serverUrl
+  }
 
   get redirectUrl(): string {
     return this.redirectUri
@@ -88,26 +165,26 @@ export class McpOAuthProvider implements OAuthClientProvider {
 
   async state(): Promise<string> {
     const value = randomBytes(32).toString('base64url')
-    await saveMcpOAuthState(this.serverName, this.serverUrl, value)
+    await this.storage.saveState(value)
     return value
   }
 
   async clientInformation(): Promise<OAuthClientInformationMixed | undefined> {
-    const entry = await readMcpOAuthEntry(this.serverName, this.serverUrl)
+    const entry = await this.storage.read()
     return entry?.clientInformation
   }
 
   async saveClientInformation(clientInformation: OAuthClientInformationMixed): Promise<void> {
-    await saveMcpOAuthClientInformation(this.serverName, this.serverUrl, clientInformation)
+    await this.storage.saveClientInformation(clientInformation)
   }
 
   async tokens(): Promise<OAuthTokens | undefined> {
-    const entry = await readMcpOAuthEntry(this.serverName, this.serverUrl)
+    const entry = await this.storage.read()
     return entry?.tokens
   }
 
   async saveTokens(tokens: OAuthTokens): Promise<void> {
-    await saveMcpOAuthTokens(this.serverName, this.serverUrl, tokens)
+    await this.storage.saveTokens(tokens)
   }
 
   redirectToAuthorization(authorizationUrl: URL): void {
@@ -115,11 +192,11 @@ export class McpOAuthProvider implements OAuthClientProvider {
   }
 
   async saveCodeVerifier(codeVerifier: string): Promise<void> {
-    await saveMcpOAuthCodeVerifier(this.serverName, this.serverUrl, codeVerifier)
+    await this.storage.saveCodeVerifier(codeVerifier)
   }
 
   async codeVerifier(): Promise<string> {
-    const entry = await readMcpOAuthEntry(this.serverName, this.serverUrl)
+    const entry = await this.storage.read()
     if (!entry?.codeVerifier) {
       throw new Error('No stored PKCE verifier for this server, start the authorization again')
     }
@@ -131,9 +208,117 @@ export class McpOAuthProvider implements OAuthClientProvider {
     if (scope === 'discovery') return
     if (scope === 'all' || scope === 'client') {
       // Tokens issued to a client the server no longer knows are dead too.
-      await clearMcpOAuthEntry(this.serverName)
+      await this.storage.clearAll()
       return
     }
-    await clearMcpOAuthTokens(this.serverName, this.serverUrl)
+    await this.storage.clearTokens()
+  }
+
+  /**
+   * A provider whose reads and writes never reach the store.
+   *
+   * The transport runs one of these on every connection, and a connection happens to receive a 401
+   * exactly when no valid token exists — the same moment an explicit authorization may be pending.
+   * Letting that probe run against the store would overwrite the pending state and verifier with its
+   * own, and the browser callback would then no longer match anything. The probe still gets a full
+   * SDK flow against its private copy, so a 401 during a plain reconnect stays a plain failure.
+   */
+  static forBackgroundProbe(serverName: string, serverUrl: string): McpOAuthProvider {
+    return new McpOAuthProvider(serverName, serverUrl, getMcpOAuthRedirectUri(), memoryStorage())
+  }
+}
+
+/**
+ * The authorize endpoint URL this server's flow would send the browser to, resolved the same way the
+ * SDK resolves it (RFC 9728 for the authorization server, then RFC 8414/OIDC for the endpoints).
+ * Only used as a liveness probe for the stored client, never to authorize anything.
+ */
+export async function buildOAuthProbeUrl(provider: McpOAuthProvider): Promise<URL | undefined> {
+  try {
+    const resource = await discoverOAuthProtectedResourceMetadata(provider.url)
+    const authorizationServerUrl = resource?.authorization_servers?.[0] ?? provider.url
+    const metadata = await discoverAuthorizationServerMetadata(authorizationServerUrl)
+    if (!metadata?.authorization_endpoint) return undefined
+    const client = await provider.clientInformation()
+    if (!client) return undefined
+    const url = new URL(metadata.authorization_endpoint)
+    url.searchParams.set('client_id', client.client_id)
+    return url
+  } catch {
+    return undefined
+  }
+}
+
+/** Statuses an authorization server uses to say "I do not know this client". */
+const STALE_CLIENT_STATUSES = new Set([401, 403])
+
+/** Bodies that explicitly name an unknown/invalid client, as opposed to a generic invalid_request. */
+function isUnknownClientBody(body: string): boolean {
+  const lowered = body.toLowerCase()
+  return (
+    lowered.includes('unrecognized client') ||
+    lowered.includes('unknown client') ||
+    lowered.includes('invalid client') ||
+    lowered.includes('client not found') ||
+    lowered.includes('client_id not found')
+  )
+}
+
+const PROBE_TIMEOUT_MS = 5000
+
+/** Cache probe results so repeated clicks on Authorize don't add two discovery round-trips each time. */
+const probeCache = new Map<string, { result: boolean; expiresAt: number }>()
+const PROBE_TTL_MS = 10 * 60 * 1000
+
+/** Reset probe cache. Only exported for tests. */
+export function resetProbeCache(): void {
+  probeCache.clear()
+}
+
+/**
+ * Authorization servers are free to forget dynamically registered clients, and Supabase is known to
+ * purge ones that never completed an authorization. A stale client id would then poison every
+ * further attempt, since the SDK keeps reusing it and only recovers on errors it recognizes. An
+ * authorize URL is cheap and side effect free, so it doubles as a liveness check: a rejection burns
+ * the stored registration and the SDK registers a fresh client instead.
+ */
+export async function rejectStaleOAuthClient(
+  provider: McpOAuthProvider,
+  fetchImpl: typeof fetch = fetch,
+): Promise<void> {
+  const client = await provider.clientInformation()
+  if (!client) return
+  const cacheKey = `${provider.name}:${provider.url}:${client.client_id}`
+  const cached = probeCache.get(cacheKey)
+  if (cached && cached.expiresAt > Date.now()) {
+    if (cached.result) await provider.invalidateCredentials('client')
+    return
+  }
+  const authorizationUrl = await buildOAuthProbeUrl(provider)
+  if (!authorizationUrl) return
+  let response: Response
+  try {
+    response = await fetchImpl(authorizationUrl, {
+      redirect: 'manual',
+      signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+    })
+  } catch {
+    return
+  }
+  const body = await response.text().catch(() => '')
+  let stale = STALE_CLIENT_STATUSES.has(response.status)
+  if (!stale && (response.status === 400 || response.status === 422)) {
+    // A 400/422 from an authorize endpoint is usually a missing-param invalid_request, which is not
+    // a stale client. Only treat it as stale when the body names an unknown/invalid client.
+    stale = isUnknownClientBody(body)
+  }
+  probeCache.set(cacheKey, { result: stale, expiresAt: Date.now() + PROBE_TTL_MS })
+  if (stale) {
+    logger.warn('Discarding an OAuth client the authorization server no longer recognizes', {
+      server: provider.name,
+      status: response.status,
+      body: body.slice(0, 200),
+    })
+    await provider.invalidateCredentials('client')
   }
 }

--- a/src/server/tools/mcp-config.test.ts
+++ b/src/server/tools/mcp-config.test.ts
@@ -53,6 +53,10 @@ vi.mock('./index.js', () => ({
   createToolRegistry: vi.fn(() => ({ definitions: [] })),
 }))
 
+vi.mock('../mcp/session-overrides.js', () => ({
+  getSessionDisabledServers: (sessionId: string) => (sessionId === 's2' ? ['filesystem'] : []),
+}))
+
 vi.mock('../utils/logger.js', () => ({
   logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
 }))
@@ -175,6 +179,37 @@ describe('mcpConfigTool', () => {
       expect(result.output).not.toContain('(from cache)')
       expect(result.output).not.toContain('(live)')
       expect(result.output).toContain('0 tools')
+    })
+
+    it('should omit servers disabled for the session', async () => {
+      setMcpManagerForTools(mockManager)
+
+      const { mcpConfigTool } = await import('./mcp-config.js')
+
+      const result = await mcpConfigTool.execute(
+        { action: 'list' },
+        { workdir: '/tmp', sessionId: 's2', sessionManager: mockSessionManager() },
+      )
+
+      expect(result.success).toBe(true)
+      expect(result.output).toBe('No MCP servers configured.')
+      expect(result.output).not.toContain('filesystem')
+    })
+
+    it('should keep servers enabled for the session with their tool listing', async () => {
+      setMcpManagerForTools(mockManager)
+
+      const { mcpConfigTool } = await import('./mcp-config.js')
+
+      const result = await mcpConfigTool.execute(
+        { action: 'list' },
+        { workdir: '/tmp', sessionId: 's1', sessionManager: mockSessionManager() },
+      )
+
+      expect(result.success).toBe(true)
+      expect(result.output).not.toContain('disabled for this session')
+      expect(result.output).toContain('Enabled: read_file')
+      expect(result.output).toContain('Disabled: write_file')
     })
 
     it('should report no servers when none configured', async () => {

--- a/src/server/tools/mcp-config.ts
+++ b/src/server/tools/mcp-config.ts
@@ -154,8 +154,16 @@ export const mcpConfigTool: Tool = createTool<McpConfigArgs>(
         return helpers.success('No MCP servers configured.')
       }
 
+      const { getSessionDisabledServers } = await import('../mcp/session-overrides.js')
+      const disabledForSession = new Set(context.sessionId ? getSessionDisabledServers(context.sessionId) : [])
+
+      const visibleServers = servers.filter((server) => !disabledForSession.has(server.name))
+      if (visibleServers.length === 0) {
+        return helpers.success('No MCP servers configured.')
+      }
+
       const lines: string[] = []
-      for (const server of servers) {
+      for (const server of visibleServers) {
         const connStr = server.status === 'connected' ? '●' : server.status === 'error' ? '✗' : '○'
         const cmdStr = server.config.command
           ? `${server.config.command} ${(server.config.args ?? []).join(' ')}`

--- a/src/server/ws/server.ts
+++ b/src/server/ws/server.ts
@@ -1177,24 +1177,30 @@ async function handleClientMessage(
       const session = sessionManager.requireSession(sessionId)
 
       try {
-        const { buildCachedPrompt } = await import('../chat/dynamic-context.js')
+        const { buildCachedPrompt, computePreviewToolDiff } = await import('../chat/dynamic-context.js')
         const allAgents = await import('../agents/registry.js')
         const agentDef =
           allAgents.findAgentById(session.mode, await allAgents.loadAllAgentsDefault()) ??
           allAgents.findAgentById('planner', await allAgents.loadAllAgentsDefault())!
         const modelName = session.providerModel ?? _providerManager?.getCurrentModel()
-        const { systemPrompt: newPrompt, hash: newHash } = await buildCachedPrompt(
-          sessionManager,
-          sessionId,
-          agentDef,
-          modelName,
-        )
+        const {
+          systemPrompt: newPrompt,
+          tools: newTools,
+          hash: newHash,
+        } = await buildCachedPrompt(sessionManager, sessionId, agentDef, modelName)
 
         const oldCached = sessionManager.getCachedPrompt(sessionId)
         const oldPrompt = oldCached?.systemPrompt
 
         // Compute unified diff
         const diff = oldPrompt ? computeUnifiedDiff(oldPrompt, newPrompt) : []
+
+        // Baseline: cached tools if present, else the unfiltered registry
+        // (all MCP tools, no session overrides) so tool add/remove is visible
+        // even before a cached prompt exists.
+        const { getToolRegistryForAgent } = await import('../tools/index.js')
+        const unfilteredTools = getToolRegistryForAgent(agentDef).definitions
+        const toolDiff = computePreviewToolDiff(oldCached?.tools, unfilteredTools, newTools)
 
         send({
           type: 'context.preview',
@@ -1204,6 +1210,7 @@ async function handleClientMessage(
             oldHash: oldCached?.hash,
             newHash,
             diff,
+            ...(toolDiff.length > 0 ? { toolDiff } : {}),
           },
           id: message.id,
         })

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -442,6 +442,7 @@ export interface ContextPreviewPayload {
   oldHash?: string
   newHash: string
   diff: DiffLine[]
+  toolDiff?: DiffLine[]
 }
 
 // Provider payloads (server → client)

--- a/web/src/components/plan/DynamicContextPreviewModal.tsx
+++ b/web/src/components/plan/DynamicContextPreviewModal.tsx
@@ -16,6 +16,8 @@ interface DynamicContextPreviewModalProps {
 export function DynamicContextPreviewModal({ isOpen, onClose, isRunning, onApply }: DynamicContextPreviewModalProps) {
   const sessionId = useSessionScope()
   const [diffPreview, setDiffPreview] = useState<DiffLine[] | null>(null)
+  const [toolDiffPreview, setToolDiffPreview] = useState<DiffLine[]>([])
+  const [hasBaseline, setHasBaseline] = useState(false)
   const [isLoadingPreview, setIsLoadingPreview] = useState(false)
   const pendingPreviewRequestId = useRef<string | null>(null)
 
@@ -26,8 +28,10 @@ export function DynamicContextPreviewModal({ isOpen, onClose, isRunning, onApply
 
     const unsubscribe = wsClient.subscribe((message) => {
       if (message.id === requestId && message.type === 'context.preview') {
-        const payload = message.payload as { diff: DiffLine[] }
+        const payload = message.payload as { diff: DiffLine[]; toolDiff?: DiffLine[]; oldPrompt?: string }
         setDiffPreview(payload.diff ?? [])
+        setToolDiffPreview(payload.toolDiff ?? [])
+        setHasBaseline(payload.oldPrompt !== undefined)
         setIsLoadingPreview(false)
         pendingPreviewRequestId.current = null
         unsubscribe()
@@ -46,10 +50,15 @@ export function DynamicContextPreviewModal({ isOpen, onClose, isRunning, onApply
   useEffect(() => {
     if (isOpen) {
       setDiffPreview(null)
+      setToolDiffPreview([])
+      setHasBaseline(false)
       setIsLoadingPreview(true)
       fetchPreview()
     }
   }, [isOpen, fetchPreview])
+
+  const hasDiff = diffPreview !== null && diffPreview.length > 0
+  const hasToolDiff = toolDiffPreview.length > 0
 
   return (
     <Modal
@@ -86,14 +95,28 @@ export function DynamicContextPreviewModal({ isOpen, onClose, isRunning, onApply
       </p>
       {isLoadingPreview ? (
         <div className="py-8 text-center text-text-muted">Loading diff...</div>
-      ) : diffPreview && diffPreview.length > 0 ? (
+      ) : hasDiff || hasToolDiff ? (
         <ScrollArea className="max-h-[60vh] border border-border rounded-lg">
-          <UnifiedDiffViewer diff={diffPreview} />
+          {hasDiff && <UnifiedDiffViewer diff={diffPreview} />}
+          {hasToolDiff && (
+            <div>
+              {hasDiff && <div className="border-t border-border" />}
+              <div className="px-2 py-1 text-xs font-semibold text-text-muted uppercase tracking-wide">
+                Tools ({toolDiffPreview.filter((l) => l.type === 'added').length} added,{' '}
+                {toolDiffPreview.filter((l) => l.type === 'removed').length} removed)
+              </div>
+              <UnifiedDiffViewer diff={toolDiffPreview} hideHeader />
+            </div>
+          )}
         </ScrollArea>
-      ) : (
+      ) : hasBaseline ? (
         <p className="text-sm text-text-tertiary mb-4">
           The system prompt hash has changed (e.g., due to tool or skill changes), but the actual prompt text appears
           identical. Applying the update will still rebuild the cached prompt to ensure consistency.
+        </p>
+      ) : (
+        <p className="text-sm text-text-tertiary mb-4">
+          The cached system prompt will be built with the current tools and settings on apply.
         </p>
       )}
     </Modal>

--- a/web/src/components/settings/tabs/ToolsTab.tsx
+++ b/web/src/components/settings/tabs/ToolsTab.tsx
@@ -160,6 +160,16 @@ function McpOAuthPanel({ serverName, onChanged }: McpOAuthPanelProps) {
   const [pasted, setPasted] = useState('')
   const [error, setError] = useState('')
 
+  useEffect(() => {
+    const bc = new BroadcastChannel('openfox-oauth')
+    bc.onmessage = (e) => {
+      if (e.data?.type === 'oauth-callback-complete') {
+        setRedirectUri('')
+      }
+    }
+    return () => bc.close()
+  }, [])
+
   const endpoint = `/api/mcp/servers/${encodeURIComponent(serverName)}/oauth`
 
   const call = async (run: () => Promise<void>) => {

--- a/web/src/components/shared/DiffView.tsx
+++ b/web/src/components/shared/DiffView.tsx
@@ -289,6 +289,7 @@ function SimpleDiffLine({ type, content }: SimpleDiffLineProps) {
 
 interface UnifiedDiffViewerProps {
   diff: ProtocolDiffLine[]
+  hideHeader?: boolean
 }
 
 /**
@@ -296,7 +297,7 @@ interface UnifiedDiffViewerProps {
  * Groups removed lines before their corresponding added lines at each change location.
  * Used for system prompt diff preview and other text-based diffs.
  */
-export function UnifiedDiffViewer({ diff }: UnifiedDiffViewerProps) {
+export function UnifiedDiffViewer({ diff, hideHeader = false }: UnifiedDiffViewerProps) {
   const changes: Array<{ type: 'removed' | 'added'; content: string }> = []
 
   let i = 0
@@ -336,7 +337,9 @@ export function UnifiedDiffViewer({ diff }: UnifiedDiffViewerProps) {
 
   return (
     <div>
-      <div className="px-2 py-1 text-xs font-semibold text-text-muted uppercase tracking-wide">Changes:</div>
+      {!hideHeader && (
+        <div className="px-2 py-1 text-xs font-semibold text-text-muted uppercase tracking-wide">Changes:</div>
+      )}
       <div className="font-mono text-xs leading-5">
         {changes.map((change, idx) => (
           <SimpleDiffLine key={idx} type={change.type} content={change.content} />

--- a/web/src/stores/session/messageHandler.ts
+++ b/web/src/stores/session/messageHandler.ts
@@ -1043,9 +1043,8 @@ export function handleServerMessage(
       if (payload?.servers) {
         const sorted = [...payload.servers].sort((a, b) => a.name.localeCompare(b.name))
         useMcpStore.getState().setServers(sorted)
-      } else {
-        window.dispatchEvent(new CustomEvent('mcp-servers-changed'))
       }
+      window.dispatchEvent(new CustomEvent('mcp-servers-changed'))
       break
     }
 


### PR DESCRIPTION
### Summary

Fixes several interconnected bugs in MCP OAuth HTTP transport handling that prevented Supabase (and other OAuth-dependent MCP servers) from connecting properly.

**Root causes:**
1. Background reconnects used `McpOAuthProvider.forBackgroundProbe()` with in-memory storage, so after a successful OAuth callback saved tokens to disk, reconnection read an empty provider — no Authorization header → 401 → "Unauthorized".
2. Stale DCR clients (Supabase purges uncompleted registrations) were reused forever, poisoning every subsequent Authorize attempt with "Unrecognized client_id".
3. The OAuth callback opened in a separate browser tab (`_blank`, `noopener`) and never communicated back to the OpenFox tab — the paste-back UI stayed visible even after the callback succeeded.
4. The `mcp.servers.changed` WebSocket handler updated the MCP store but did not dispatch the `mcp-servers-changed` custom event, so ToolsTab's server list never refreshed.

### AI-Enhanced Development

Tell what models helped shape this PR:

- **AI Models:** ox-alpha-free

_No AI used? Enter 'none'_

### Cache Impact

Does this PR affect anything cached — system prompts, tool definitions, skills, or other context?

- **No**