### PR TITLE
fix(mcp): OAuth HTTP transport 

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -2944,7 +2944,7 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
 
   /** Rendered on the OAuth callback. The message is always one of ours, never anything the caller sent. */
   function oauthCallbackPage(message: string): string {
-    return `<!doctype html><html lang="en"><head><meta charset="utf-8"><title>OpenFox</title></head><body style="font-family:system-ui;padding:2rem"><p>${message}</p></body></html>`
+    return `<!doctype html><html lang="en"><head><meta charset="utf-8"><title>OpenFox</title></head><body style="font-family:system-ui;padding:2rem"><p>${message}</p><script>try{new BroadcastChannel('openfox-oauth').postMessage({type:'oauth-callback-complete'})}catch{}</script></body></html>`
   }
 
   /** Accepts the whole callback URL or just its query string. Anything else yields no state and is refused. */
@@ -3013,8 +3013,9 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
     }
     try {
       const { auth } = await import('@modelcontextprotocol/sdk/client/auth.js')
-      const { McpOAuthProvider } = await import('./mcp/oauth-provider.js')
+      const { McpOAuthProvider, rejectStaleOAuthClient } = await import('./mcp/oauth-provider.js')
       const provider = new McpOAuthProvider(name, server.config.url)
+      await rejectStaleOAuthClient(provider)
       const result = await auth(provider, { serverUrl: server.config.url })
       if (result === 'AUTHORIZED') {
         await applyMcpOAuthResult(name)

--- a/src/server/mcp/manager.ts
+++ b/src/server/mcp/manager.ts
@@ -7,6 +7,7 @@ import type { McpServerConfig, McpServerState, McpToolInfo, McpManagerOptions, C
 import type { LLMToolDefinition } from '../llm/types.js'
 import { logger } from '../utils/logger.js'
 import { McpOAuthProvider } from './oauth-provider.js'
+import { readMcpOAuthEntry } from './oauth-store.js'
 
 /**
  * The SDK merges requestInit headers after the ones it derives from the auth provider, so a static
@@ -92,7 +93,13 @@ export class McpManager {
           httpOpts.requestInit = { headers }
         }
         if (entry.config.oauth) {
-          httpOpts.authProvider = new McpOAuthProvider(name, entry.config.url)
+          // A connection attempt is a probe, never an authorization: it must not touch stored
+          // credentials, or it would clobber an authorization the user has pending in a browser.
+          // But if tokens are already stored, the real provider must be used so they get attached.
+          const stored = await readMcpOAuthEntry(name, entry.config.url)
+          httpOpts.authProvider = stored?.tokens
+            ? new McpOAuthProvider(name, entry.config.url)
+            : McpOAuthProvider.forBackgroundProbe(name, entry.config.url)
         }
         transport = new StreamableHTTPClientTransport(new URL(entry.config.url), httpOpts) as unknown as Transport
       } else {

--- a/src/server/mcp/oauth-provider.ts
+++ b/src/server/mcp/oauth-provider.ts
@@ -1,5 +1,9 @@
 import { randomBytes } from 'node:crypto'
 import type { OAuthClientProvider } from '@modelcontextprotocol/sdk/client/auth.js'
+import {
+  discoverAuthorizationServerMetadata,
+  discoverOAuthProtectedResourceMetadata,
+} from '@modelcontextprotocol/sdk/client/auth.js'
 import type {
   OAuthClientInformationMixed,
   OAuthClientMetadata,
@@ -14,6 +18,69 @@ import {
   saveMcpOAuthState,
   saveMcpOAuthTokens,
 } from './oauth-store.js'
+import { logger } from '../utils/logger.js'
+
+/** Where a provider keeps its credentials. Persistent for the real flow, in-memory for probes. */
+interface ProviderStorage {
+  read(): Promise<
+    | {
+        clientInformation?: OAuthClientInformationMixed
+        tokens?: OAuthTokens
+        codeVerifier?: string
+        state?: string
+      }
+    | undefined
+  >
+  saveClientInformation(clientInformation: OAuthClientInformationMixed): Promise<void>
+  saveTokens(tokens: OAuthTokens): Promise<void>
+  saveCodeVerifier(codeVerifier: string): Promise<void>
+  saveState(state: string): Promise<void>
+  clearTokens(): Promise<void>
+  clearAll(): Promise<void>
+}
+
+function persistentStorage(serverName: string, serverUrl: string): ProviderStorage {
+  return {
+    read: () => readMcpOAuthEntry(serverName, serverUrl),
+    saveClientInformation: (info) => saveMcpOAuthClientInformation(serverName, serverUrl, info),
+    saveTokens: (tokens) => saveMcpOAuthTokens(serverName, serverUrl, tokens),
+    saveCodeVerifier: (verifier) => saveMcpOAuthCodeVerifier(serverName, serverUrl, verifier),
+    saveState: (state) => saveMcpOAuthState(serverName, serverUrl, state),
+    clearTokens: () => clearMcpOAuthTokens(serverName, serverUrl),
+    clearAll: () => clearMcpOAuthEntry(serverName),
+  }
+}
+
+/** Ephemeral storage for background probes: nothing they touch may clobber a pending authorization. */
+function memoryStorage(): ProviderStorage {
+  let entry: {
+    clientInformation?: OAuthClientInformationMixed
+    tokens?: OAuthTokens
+    codeVerifier?: string
+    state?: string
+  } = {}
+  return {
+    read: async () => entry,
+    saveClientInformation: async (info) => {
+      entry.clientInformation = info
+    },
+    saveTokens: async (tokens) => {
+      entry.tokens = tokens
+    },
+    saveCodeVerifier: async (verifier) => {
+      entry.codeVerifier = verifier
+    },
+    saveState: async (state) => {
+      entry.state = state
+    },
+    clearTokens: async () => {
+      delete entry.tokens
+    },
+    clearAll: async () => {
+      entry = {}
+    },
+  }
+}
 
 /** API routes are mounted on literal paths, so the callback always sits at the origin root. */
 const CALLBACK_PATH = '/api/mcp/oauth/callback'
@@ -65,7 +132,17 @@ export class McpOAuthProvider implements OAuthClientProvider {
     private readonly serverName: string,
     private readonly serverUrl: string,
     private readonly redirectUri: string = getMcpOAuthRedirectUri(),
+    private readonly storage: ProviderStorage = persistentStorage(serverName, serverUrl),
   ) {}
+
+  /** Kept for log context and for callers that need the identity of the server being probed. */
+  get name(): string {
+    return this.serverName
+  }
+
+  get url(): string {
+    return this.serverUrl
+  }
 
   get redirectUrl(): string {
     return this.redirectUri
@@ -88,26 +165,26 @@ export class McpOAuthProvider implements OAuthClientProvider {
 
   async state(): Promise<string> {
     const value = randomBytes(32).toString('base64url')
-    await saveMcpOAuthState(this.serverName, this.serverUrl, value)
+    await this.storage.saveState(value)
     return value
   }
 
   async clientInformation(): Promise<OAuthClientInformationMixed | undefined> {
-    const entry = await readMcpOAuthEntry(this.serverName, this.serverUrl)
+    const entry = await this.storage.read()
     return entry?.clientInformation
   }
 
   async saveClientInformation(clientInformation: OAuthClientInformationMixed): Promise<void> {
-    await saveMcpOAuthClientInformation(this.serverName, this.serverUrl, clientInformation)
+    await this.storage.saveClientInformation(clientInformation)
   }
 
   async tokens(): Promise<OAuthTokens | undefined> {
-    const entry = await readMcpOAuthEntry(this.serverName, this.serverUrl)
+    const entry = await this.storage.read()
     return entry?.tokens
   }
 
   async saveTokens(tokens: OAuthTokens): Promise<void> {
-    await saveMcpOAuthTokens(this.serverName, this.serverUrl, tokens)
+    await this.storage.saveTokens(tokens)
   }
 
   redirectToAuthorization(authorizationUrl: URL): void {
@@ -115,11 +192,11 @@ export class McpOAuthProvider implements OAuthClientProvider {
   }
 
   async saveCodeVerifier(codeVerifier: string): Promise<void> {
-    await saveMcpOAuthCodeVerifier(this.serverName, this.serverUrl, codeVerifier)
+    await this.storage.saveCodeVerifier(codeVerifier)
   }
 
   async codeVerifier(): Promise<string> {
-    const entry = await readMcpOAuthEntry(this.serverName, this.serverUrl)
+    const entry = await this.storage.read()
     if (!entry?.codeVerifier) {
       throw new Error('No stored PKCE verifier for this server, start the authorization again')
     }
@@ -131,9 +208,117 @@ export class McpOAuthProvider implements OAuthClientProvider {
     if (scope === 'discovery') return
     if (scope === 'all' || scope === 'client') {
       // Tokens issued to a client the server no longer knows are dead too.
-      await clearMcpOAuthEntry(this.serverName)
+      await this.storage.clearAll()
       return
     }
-    await clearMcpOAuthTokens(this.serverName, this.serverUrl)
+    await this.storage.clearTokens()
+  }
+
+  /**
+   * A provider whose reads and writes never reach the store.
+   *
+   * The transport runs one of these on every connection, and a connection happens to receive a 401
+   * exactly when no valid token exists — the same moment an explicit authorization may be pending.
+   * Letting that probe run against the store would overwrite the pending state and verifier with its
+   * own, and the browser callback would then no longer match anything. The probe still gets a full
+   * SDK flow against its private copy, so a 401 during a plain reconnect stays a plain failure.
+   */
+  static forBackgroundProbe(serverName: string, serverUrl: string): McpOAuthProvider {
+    return new McpOAuthProvider(serverName, serverUrl, getMcpOAuthRedirectUri(), memoryStorage())
+  }
+}
+
+/**
+ * The authorize endpoint URL this server's flow would send the browser to, resolved the same way the
+ * SDK resolves it (RFC 9728 for the authorization server, then RFC 8414/OIDC for the endpoints).
+ * Only used as a liveness probe for the stored client, never to authorize anything.
+ */
+export async function buildOAuthProbeUrl(provider: McpOAuthProvider): Promise<URL | undefined> {
+  try {
+    const resource = await discoverOAuthProtectedResourceMetadata(provider.url)
+    const authorizationServerUrl = resource?.authorization_servers?.[0] ?? provider.url
+    const metadata = await discoverAuthorizationServerMetadata(authorizationServerUrl)
+    if (!metadata?.authorization_endpoint) return undefined
+    const client = await provider.clientInformation()
+    if (!client) return undefined
+    const url = new URL(metadata.authorization_endpoint)
+    url.searchParams.set('client_id', client.client_id)
+    return url
+  } catch {
+    return undefined
+  }
+}
+
+/** Statuses an authorization server uses to say "I do not know this client". */
+const STALE_CLIENT_STATUSES = new Set([401, 403])
+
+/** Bodies that explicitly name an unknown/invalid client, as opposed to a generic invalid_request. */
+function isUnknownClientBody(body: string): boolean {
+  const lowered = body.toLowerCase()
+  return (
+    lowered.includes('unrecognized client') ||
+    lowered.includes('unknown client') ||
+    lowered.includes('invalid client') ||
+    lowered.includes('client not found') ||
+    lowered.includes('client_id not found')
+  )
+}
+
+const PROBE_TIMEOUT_MS = 5000
+
+/** Cache probe results so repeated clicks on Authorize don't add two discovery round-trips each time. */
+const probeCache = new Map<string, { result: boolean; expiresAt: number }>()
+const PROBE_TTL_MS = 10 * 60 * 1000
+
+/** Reset probe cache. Only exported for tests. */
+export function resetProbeCache(): void {
+  probeCache.clear()
+}
+
+/**
+ * Authorization servers are free to forget dynamically registered clients, and Supabase is known to
+ * purge ones that never completed an authorization. A stale client id would then poison every
+ * further attempt, since the SDK keeps reusing it and only recovers on errors it recognizes. An
+ * authorize URL is cheap and side effect free, so it doubles as a liveness check: a rejection burns
+ * the stored registration and the SDK registers a fresh client instead.
+ */
+export async function rejectStaleOAuthClient(
+  provider: McpOAuthProvider,
+  fetchImpl: typeof fetch = fetch,
+): Promise<void> {
+  const client = await provider.clientInformation()
+  if (!client) return
+  const cacheKey = `${provider.name}:${provider.url}:${client.client_id}`
+  const cached = probeCache.get(cacheKey)
+  if (cached && cached.expiresAt > Date.now()) {
+    if (cached.result) await provider.invalidateCredentials('client')
+    return
+  }
+  const authorizationUrl = await buildOAuthProbeUrl(provider)
+  if (!authorizationUrl) return
+  let response: Response
+  try {
+    response = await fetchImpl(authorizationUrl, {
+      redirect: 'manual',
+      signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+    })
+  } catch {
+    return
+  }
+  const body = await response.text().catch(() => '')
+  let stale = STALE_CLIENT_STATUSES.has(response.status)
+  if (!stale && (response.status === 400 || response.status === 422)) {
+    // A 400/422 from an authorize endpoint is usually a missing-param invalid_request, which is not
+    // a stale client. Only treat it as stale when the body names an unknown/invalid client.
+    stale = isUnknownClientBody(body)
+  }
+  probeCache.set(cacheKey, { result: stale, expiresAt: Date.now() + PROBE_TTL_MS })
+  if (stale) {
+    logger.warn('Discarding an OAuth client the authorization server no longer recognizes', {
+      server: provider.name,
+      status: response.status,
+      body: body.slice(0, 200),
+    })
+    await provider.invalidateCredentials('client')
   }
 }

--- a/web/src/components/settings/tabs/ToolsTab.tsx
+++ b/web/src/components/settings/tabs/ToolsTab.tsx
@@ -160,6 +160,16 @@ function McpOAuthPanel({ serverName, onChanged }: McpOAuthPanelProps) {
   const [pasted, setPasted] = useState('')
   const [error, setError] = useState('')
 
+  useEffect(() => {
+    const bc = new BroadcastChannel('openfox-oauth')
+    bc.onmessage = (e) => {
+      if (e.data?.type === 'oauth-callback-complete') {
+        setRedirectUri('')
+      }
+    }
+    return () => bc.close()
+  }, [])
+
   const endpoint = `/api/mcp/servers/${encodeURIComponent(serverName)}/oauth`
 
   const call = async (run: () => Promise<void>) => {

--- a/web/src/stores/session/messageHandler.ts
+++ b/web/src/stores/session/messageHandler.ts
@@ -1043,9 +1043,8 @@ export function handleServerMessage(
       if (payload?.servers) {
         const sorted = [...payload.servers].sort((a, b) => a.name.localeCompare(b.name))
         useMcpStore.getState().setServers(sorted)
-      } else {
-        window.dispatchEvent(new CustomEvent('mcp-servers-changed'))
       }
+      window.dispatchEvent(new CustomEvent('mcp-servers-changed'))
       break
     }
 


### PR DESCRIPTION
### Summary

Fixes several interconnected bugs in MCP OAuth HTTP transport handling that prevented Supabase (and other OAuth-dependent MCP servers) from connecting properly.

**Root causes:**
1. Background reconnects used `McpOAuthProvider.forBackgroundProbe()` with in-memory storage, so after a successful OAuth callback saved tokens to disk, reconnection read an empty provider — no Authorization header → 401 → "Unauthorized".
2. Stale DCR clients (Supabase purges uncompleted registrations) were reused forever, poisoning every subsequent Authorize attempt with "Unrecognized client_id".
3. The OAuth callback opened in a separate browser tab (`_blank`, `noopener`) and never communicated back to the OpenFox tab — the paste-back UI stayed visible even after the callback succeeded.
4. The `mcp.servers.changed` WebSocket handler updated the MCP store but did not dispatch the `mcp-servers-changed` custom event, so ToolsTab's server list never refreshed.

### AI-Enhanced Development

Tell what models helped shape this PR:

- **AI Models:** ox-alpha-free

_No AI used? Enter 'none'_

### Cache Impact

Does this PR affect anything cached — system prompts, tool definitions, skills, or other context?

- **No**