### PR TITLE
feat: show vision-model indicator and detect supportsVision

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -2033,6 +2033,7 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
           return {
             id: m.id,
             contextWindow: m.contextWindow,
+            supportsVision: m.supportsVision ?? profile.supportsVision,
             defaultTemperature: profile.temperature,
             defaultTopP: profile.topP,
             defaultTopK: profile.topK,

--- a/src/server/provider-manager.test.ts
+++ b/src/server/provider-manager.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { createProviderManager } from './provider-manager.js'
+import { createProviderManager, fetchModelsWithContext } from './provider-manager.js'
 import { createLLMClient } from './llm/index.js'
 import type { Config, Provider } from '../shared/types.js'
 
@@ -1116,5 +1116,53 @@ describe('ProviderManager - Model Selection', () => {
       expect(model.reasoningEfforts).toEqual(['low'])
       expect(model.reasoningEffortOverride).toBe('deep')
     })
+  })
+})
+
+describe('fetchModelsWithContext - Ollama vision detection', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('detects vision via vision_start_token_id', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ models: [{ name: 'llava' }] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ model_info: { vision_start_token_id: 32000 } }),
+      })
+    const models = await fetchModelsWithContext('http://localhost:11434', undefined, 'ollama')
+    expect(models[0]?.supportsVision).toBe(true)
+  })
+
+  it('detects vision via clip.vision_projection metadata key', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ models: [{ name: 'llava2' }] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ model_info: { 'clip.vision_projection': { type: 'tensor' } } }),
+      })
+    const models = await fetchModelsWithContext('http://localhost:11434', undefined, 'ollama')
+    expect(models[0]?.supportsVision).toBe(true)
+  })
+
+  it('does not flag a text-only model as vision', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ models: [{ name: 'qwen3' }] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ model_info: { 'general.architecture': 'qwen3' } }),
+      })
+    const models = await fetchModelsWithContext('http://localhost:11434', undefined, 'ollama')
+    expect(models[0]?.supportsVision).toBeUndefined()
   })
 })

--- a/src/server/provider-manager.ts
+++ b/src/server/provider-manager.ts
@@ -3,9 +3,11 @@ import type { ProviderRegistry } from './providers/plugins/registry.js'
 import { createTransportLLMClient } from './providers/adapters/transport-client.js'
 import { createLLMClient, clearModelCache, getModelProfile, type LLMClientWithModel } from './llm/index.js'
 import { logger } from './utils/logger.js'
+
 import { parseLmStudioModels } from './providers/lmstudio.js'
 import { ensureVersionPrefix, stripVersionPrefix, buildModelsUrl } from './llm/url-utils.js'
 import { getCatalogEntry } from './providers/model-catalog.js'
+import { hasVisionEvidence } from './providers/vision.js'
 import { resolveEffortForModel } from '../shared/reasoning-effort.js'
 
 /**
@@ -25,7 +27,7 @@ function normalizeModelId(s: string): string {
 async function fetchModelsFromBackend(
   url: string,
   apiKey?: string,
-): Promise<{ id: string; contextWindow: number | undefined }[]> {
+): Promise<{ id: string; contextWindow: number | undefined; supportsVision?: boolean | undefined }[]> {
   const headers: Record<string, string> = { 'Content-Type': 'application/json' }
   if (apiKey) {
     headers['Authorization'] = `Bearer ${apiKey}`
@@ -37,11 +39,20 @@ async function fetchModelsFromBackend(
       logger.debug('Failed to fetch models', { url, status: response.status })
       return []
     }
-    const data = (await response.json()) as { data?: { id: string; max_model_len?: number }[] }
+    const data = (await response.json()) as {
+      data?: Array<{
+        id: string
+        max_model_len?: number
+        context_length?: number
+        capabilities?: { vision?: boolean }
+        input_modalities?: string[]
+      }>
+    }
     if (data.data && Array.isArray(data.data)) {
       return data.data.map((m) => ({
         id: m.id,
-        contextWindow: m.max_model_len ?? undefined,
+        contextWindow: m.max_model_len ?? m.context_length ?? undefined,
+        supportsVision: m.capabilities?.vision || m.input_modalities?.includes('image') ? true : undefined,
       }))
     }
     return []
@@ -55,6 +66,14 @@ function enrichWithProfileDefaults(model: ModelConfig): ModelConfig {
   const profile = getModelProfile(model.id)
   return {
     ...model,
+    // Only fill supportsVision from the profile when the model lacks it —
+    // a backend-detected value (e.g. Ollama /api/show, a transport plugin's
+    // listModels) must win over the static profile default.
+    ...(model.supportsVision !== undefined
+      ? {}
+      : profile.supportsVision !== undefined
+        ? { supportsVision: profile.supportsVision }
+        : {}),
     defaultTemperature: profile.temperature,
     defaultTopP: profile.topP,
     ...(profile.topK !== undefined && { defaultTopK: profile.topK }),
@@ -148,6 +167,7 @@ export async function fetchModelsWithContext(
   return models.map((m) => ({
     id: m.id,
     contextWindow: m.contextWindow ?? 200000,
+    ...(m.supportsVision !== undefined && { supportsVision: m.supportsVision }),
     source: m.contextWindow ? 'backend' : ('default' as const),
   }))
 }
@@ -189,14 +209,24 @@ async function fetchOllamaModelsWithContext(baseUrl: string, _apiKey?: string): 
             model_info?: {
               llama?: { context_length?: number }
               context_length?: number
+              vision_start_token_id?: unknown
+              [key: string]: unknown
             }
           }
 
-          const contextLength =
-            showData.model_info?.llama?.context_length ?? showData.model_info?.context_length ?? 200000
+          const mi = showData.model_info
+          const contextLength = mi?.llama?.context_length ?? mi?.context_length ?? 200000
+          // vision_start_token_id and known vision modality keys are positive
+          // evidence. Emit `undefined` when there is no such evidence so a
+          // model-profile default can still apply later (enrichWithProfileDefaults
+          // only fills when the value is undefined) — an explicit false would
+          // permanently block the profile from rescuing a vision model whose
+          // heuristic indicator is absent.
+          const isVisionModel = hasVisionEvidence(mi ?? {})
           modelsWithContext.push({
             id: model.name,
             contextWindow: contextLength,
+            ...(isVisionModel ? { supportsVision: true } : {}),
             source: contextLength !== 200000 ? 'backend' : ('default' as const),
           })
         } else {

--- a/src/server/providers/auto-config.ts
+++ b/src/server/providers/auto-config.ts
@@ -7,6 +7,7 @@ import { logger } from '../utils/logger.js'
 import { findLmStudioModel } from './lmstudio.js'
 import { ensureVersionPrefix } from '../llm/url-utils.js'
 import { getCatalogEntry } from './model-catalog.js'
+import { hasVisionEvidence } from './vision.js'
 
 /** Build the standard JSON headers with optional bearer auth. */
 function buildAuthHeaders(apiKey: string | undefined): Record<string, string> {
@@ -169,8 +170,8 @@ async function detectOllamaInfo(baseUrl: string, modelId: string): Promise<Model
   const ctxKey = Object.keys(mi).find((k) => k.endsWith('.context_length') || k === 'context_length')
   const ctxLen = ctxKey ? Number(mi[ctxKey]) : undefined
 
-  // Vision: indicated by vision_start_token_id or .vision. keys in model_info
-  const supportsVision = !!mi['vision_start_token_id'] || Object.keys(mi).some((k) => k.includes('.vision.'))
+  // Vision: positive evidence in model_info (vision_start_token_id or .vision keys)
+  const supportsVision = hasVisionEvidence(mi)
 
   if (ctxLen && !isNaN(ctxLen)) {
     return { contextWindow: ctxLen, source: 'backend', supportsVision }

--- a/src/server/providers/vision.test.ts
+++ b/src/server/providers/vision.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { hasVisionEvidence } from './vision.js'
+
+describe('hasVisionEvidence', () => {
+  it('detects vision via vision_start_token_id', () => {
+    expect(hasVisionEvidence({ vision_start_token_id: 32000 })).toBe(true)
+  })
+
+  it('detects vision via a .vision key (e.g. clip.vision_projection)', () => {
+    expect(hasVisionEvidence({ 'clip.vision_projection': { type: 'tensor' } })).toBe(true)
+  })
+
+  it('detects vision via a vision_ key', () => {
+    expect(hasVisionEvidence({ 'some.vision_model': true })).toBe(true)
+  })
+
+  it('does not flag a text-only model', () => {
+    expect(hasVisionEvidence({ 'general.architecture': 'qwen3' })).toBe(false)
+  })
+
+  it('does not flag an empty model_info', () => {
+    expect(hasVisionEvidence({})).toBe(false)
+  })
+})

--- a/src/server/providers/vision.ts
+++ b/src/server/providers/vision.ts
@@ -1,0 +1,22 @@
+/**
+ * Shared vision-capability heuristics used across model detection paths.
+ *
+ * Both auto-config and provider-manager probe a model's `model_info` to decide
+ * whether it supports vision. The keys that signal vision vary by backend; a
+ * single helper guarantees the two call sites agree instead of drifting (e.g.
+ * `clip.vision_projection` should classify the same way regardless of path).
+ */
+
+/**
+ * True when a model_info object carries positive vision evidence.
+ * Recognized signals: a non-null `vision_start_token_id`, or any key containing
+ * a `.vision` / `vision_` segment (e.g. `clip.vision_projection`, `clip.vision`).
+ * Emits boolean only on positive evidence; absence is not treated as an
+ * explicit "no" so a model-profile default can still rescue it downstream.
+ */
+export function hasVisionEvidence(modelInfo: Record<string, unknown>): boolean {
+  return (
+    !!modelInfo['vision_start_token_id'] ||
+    Object.keys(modelInfo).some((k) => k.includes('.vision') || k.includes('vision_'))
+  )
+}

--- a/web/src/components/settings/model-list.test.tsx
+++ b/web/src/components/settings/model-list.test.tsx
@@ -27,6 +27,26 @@ function cleanup({ container, root }: { container: HTMLElement; root: ReturnType
   container.remove()
 }
 
+describe('ModelEntryRow vision indicator', () => {
+  it('shows an eye indicator for a vision model', () => {
+    const rendered = renderRow({ id: 'vision-model', contextWindow: 200000, source: 'backend', supportsVision: true })
+    try {
+      expect(rendered.container.querySelector('[data-vision]')).not.toBeNull()
+    } finally {
+      cleanup(rendered)
+    }
+  })
+
+  it('does not show an eye indicator for a non-vision model', () => {
+    const rendered = renderRow({ id: 'text-model', contextWindow: 200000, source: 'backend', supportsVision: false })
+    try {
+      expect(rendered.container.querySelector('[data-vision]')).toBeNull()
+    } finally {
+      cleanup(rendered)
+    }
+  })
+})
+
 describe('ModelEntryRow small-context warning', () => {
   it('shows a warning indicator for a small-context model', () => {
     const rendered = renderRow({ id: 'small-model', contextWindow: 8192, source: 'backend' })

--- a/web/src/components/settings/model-list.tsx
+++ b/web/src/components/settings/model-list.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect, useMemo, type RefObject } from 'react'
-import { CheckIcon, EditSmallIcon, StarIcon, StarFilledIcon, WarningIcon } from '../shared/icons'
+import { CheckIcon, EditSmallIcon, EyeIcon, StarIcon, StarFilledIcon, WarningIcon } from '../shared/icons'
 import type { Provider } from '../../stores/config'
 import { isSmallContext } from '../../lib/context-warning'
 
@@ -14,6 +14,7 @@ export interface ModelWithConfig {
   name?: string
   contextWindow: number
   source: 'backend' | 'user' | 'default'
+  supportsVision?: boolean
   reasoningEfforts?: string[]
   reasoningEffortOverride?: string
   thinkingLevel?: string
@@ -36,6 +37,7 @@ export function getVisibleModels(provider: Provider): ModelWithConfig[] {
     ...(m.name !== undefined ? { name: m.name } : {}),
     contextWindow: m.contextWindow,
     source: m.source ?? 'default',
+    ...(m.supportsVision !== undefined ? { supportsVision: m.supportsVision } : {}),
     ...(m.reasoningEfforts?.length ? { reasoningEfforts: m.reasoningEfforts } : {}),
     ...(m.reasoningEffortOverride ? { reasoningEffortOverride: m.reasoningEffortOverride } : {}),
     ...(m.thinkingLevel ? { thinkingLevel: m.thinkingLevel } : {}),
@@ -101,6 +103,11 @@ export function ModelEntryRow({
           {modelConfig.name ?? modelConfig.id.split('/').pop()?.replace(/-/g, ' ') ?? modelConfig.id}
         </button>
         <div className="flex items-center gap-1.5 flex-shrink-0 ml-2">
+          {modelConfig.supportsVision && (
+            <span data-vision className="text-text-muted flex-shrink-0" title="Vision model" aria-label="Vision model">
+              <EyeIcon className="w-3.5 h-3.5" />
+            </span>
+          )}
           <span className="text-xs text-text-muted">{formatContextWindow(modelConfig.contextWindow)}</span>
           {isSmallContext(modelConfig.contextWindow) && (
             <span

--- a/web/src/components/shared/ProviderModal.tsx
+++ b/web/src/components/shared/ProviderModal.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useRef } from 'react'
 import { authFetch } from '../../lib/api'
 import type { Backend } from '../../stores/config'
 import type { ModelConfig as SharedModelConfig } from '@shared/types.js'
-import { ChevronDownIcon, SettingsIcon } from './icons'
+import { ChevronDownIcon, EyeIcon, SettingsIcon } from './icons'
 import { QueryParamsInput } from './QueryParamsInput'
 import { formatTokens } from '../../lib/format-stats'
 import { shouldAutofocus } from '../../lib/device'
@@ -967,6 +967,7 @@ export function ProviderModal({
           for (const m of data.models) {
             configs[m.id] = {
               contextWindow: m.contextWindow,
+              supportsVision: m.supportsVision,
               thinkingEnabled: true,
               thinkingLevel: defaultReasoningEffort(m.reasoningEfforts),
               defaultTemperature: (m as { defaultTemperature?: number }).defaultTemperature,
@@ -1596,7 +1597,12 @@ export function ProviderModal({
                                 <span className="text-sm font-medium text-text-primary">
                                   {model.name ?? model.id.split('/').pop()}
                                 </span>
-                                <span className="text-xs text-text-muted bg-bg-tertiary px-2 py-0.5 rounded">
+                                <span className="text-xs text-text-muted bg-bg-tertiary px-2 py-0.5 rounded flex items-center gap-1">
+                                  {(modelConfigs[model.id]?.supportsVision ?? model.supportsVision) && (
+                                    <span data-vision title="Vision model" aria-label="Vision model">
+                                      <EyeIcon className="w-3.5 h-3.5" />
+                                    </span>
+                                  )}
                                   {(modelConfigs[model.id]?.contextWindow ?? model.contextWindow).toLocaleString()} ctx
                                 </span>
                               </div>
@@ -1772,7 +1778,12 @@ export function ProviderModal({
                             <span className="text-sm text-text-primary flex-1 truncate">
                               {model.name ?? model.id.split('/').pop()}
                             </span>
-                            <span className="text-xs text-text-muted flex-shrink-0">
+                            <span className="text-xs text-text-muted flex flex-shrink-0 items-center gap-1">
+                              {(modelConfigs[model.id]?.supportsVision ?? model.supportsVision) && (
+                                <span data-vision title="Vision model" aria-label="Vision model">
+                                  <EyeIcon className="w-3.5 h-3.5" />
+                                </span>
+                              )}
                               {(modelConfigs[model.id]?.contextWindow ?? model.contextWindow).toLocaleString()} ctx
                             </span>
                             {autoConfigState.progress[model.id] === 'probing' && (


### PR DESCRIPTION
### Summary

Fixes the model "supports vision" flag so it is detected reliably from backends and surfaced as a clear eye indicator in every model list, and improves context-window detection.

**Backend — detect & propagate `supportsVision`:**
- `provider-manager.ts`:
  - `fetchModelsFromBackend` now reads `capabilities.vision || input_modalities.includes('image')` (fixing a prior `??` bug where an explicit `vision: false` short-circuited a real `image` modality), and adds a `context_length` fallback to `max_model_len` for correct context size.
  - `fetchOllamaModelsWithContext` probes `/api/show` and detects vision via `vision_start_token_id` / vision keys.
  - `enrichWithProfileDefaults` only fills `supportsVision` from the model profile when the model lacks a detected value, so a backend-detected value wins and an explicit `false` never blocks the profile default.
  - `fetchModelsWithContext` propagates `supportsVision`.
- New shared helper `src/server/providers/vision.ts` (`hasVisionEvidence`) deduplicates the Ollama heuristic that previously existed separately in `auto-config.ts` (`.vision.` vs `.vision`/`vision_`), so both paths classify a model identically (e.g. `clip.vision_projection`).
- `auto-config.ts` now uses that shared helper.
- `src/server/index.ts` maps `supportsVision: m.supportsVision ?? profile.supportsVision`.

**Frontend — eye indicator (`EyeIcon`, `title`/`aria-label="Vision model"`):**
- ProviderSelector / ModelPicker dropdown (`ModelEntryRow`, `web/src/components/settings/model-list.tsx`)
- ProviderModal **Selected Models** panel (inside the ctx badge)
- ProviderModal **Available Models** search list (next to the `…,xxx ctx` text)

**Tests:**
- `provider-manager.test.ts` — Ollama vision detection (`vision_start_token_id`, `clip.vision_projection`), and text-only models stay `undefined`.
- `vision.test.ts` — shared `hasVisionEvidence` helper cases.
- `model-list.test.tsx` — eye shown for vision models, absent for text-only.

### AI-Enhanced Development

Tell what models helped shape this PR:

- **AI Models:** DeepSeek V4 Flash Vision Exp (planning + implementation driven by the OpenFox agent), DeepSeek V4 Flash (review)

_No AI used? Enter 'none'_

### Cache Impact

Does this PR affect anything cached — system prompts, tool definitions, skills, or other context?

- **No**