### PR TITLE
feat(plugins): add openfox-openrouter-free plugin entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Restart OpenFox after installing or updating a plugin.
 - To authenticate with a Github copilot account, you can install the [`openfox-github-copilot`](https://github.com/JamesDAdams/openfox-github-copilot) plugin.
 - To authenticate with a Google Antigravity account, you can install the [`openfox-google-antigravity`](https://github.com/JamesDAdams/openfox-google-antigravity) plugin.
 - To authenticate with an X (xAI) SuperGrok subscription, you can install the [`openfox-xai-supergrok`](https://github.com/Olgean-Group/openfox-xai-supergrok) plugin.
+- To use free OpenRouter models, you can install the [`openfox-openrouter-free`](https://github.com/JamesDAdams/openfox-openrouter-free) plugin.
 
 ## Screenshots
 

--- a/plugins-registry.json
+++ b/plugins-registry.json
@@ -26,7 +26,7 @@
   {
     "name": "openfox-openrouter-free",
     "displayName": "OpenRouter (Free Models)",
-    "description": "Provider OpenRouter filteré sur les modèles gratuits uniquement, avec mise à jour horaire automatique (1x/heure) et auth 1-Click OAuth / API key.",
+    "description": "OpenRouter provider filtered to include only free plans, with automatic hourly updates (once per hour) and 1-Click OAuth / API key authentication.",
     "githubUrl": "https://github.com/JamesDAdams/openfox-openrouter-free"
   }
 ]

--- a/plugins-registry.json
+++ b/plugins-registry.json
@@ -22,5 +22,11 @@
     "displayName": "xAI Grok (SuperGrok)",
     "description": "Authenticate with an X (xAI) SuperGrok subscription via OAuth. No API key required. | ⚠️ Using this plugin may violate xAI's Terms of Service.",
     "githubUrl": "https://github.com/Olgean-Group/openfox-xai-supergrok"
+  },
+  {
+    "name": "openfox-openrouter-free",
+    "displayName": "OpenRouter (Free Models)",
+    "description": "Provider OpenRouter filteré sur les modèles gratuits uniquement, avec mise à jour horaire automatique (1x/heure) et auth 1-Click OAuth / API key.",
+    "githubUrl": "https://github.com/JamesDAdams/openfox-openrouter-free"
   }
 ]


### PR DESCRIPTION
### Summary

Add the `openfox-openrouter-free` provider plugin to the plugins registry and README.

This plugin provides an OpenRouter provider filtered to free models only (`pricing.prompt == "0"` and `pricing.completion == "0"`), with hourly automatic model discovery (adds new free models, removes deprecated/paid ones) and 1-click OAuth / API-key authentication, while supporting streaming, tool calls, and thinking/reasoning.

Changes:
- `plugins-registry.json`: added `openfox-openrouter-free` entry with `name` / `displayName` / `description` / `githubUrl`.
- `README.md`: documented the plugin in the Plugins section.

### AI-Enhanced Development

Tell what models helped shape this PR:

- **AI Models:** DeepSeek V4 Flash

_No AI used? Enter 'none'_

### Cache Impact

Does this PR affect anything cached — system prompts, tool definitions, skills, or other context?

- **No**