### PR TITLE
feat: merge multi-mode models into a single model with mode chips

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1898,6 +1898,7 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
       ...(m.requestBody !== undefined && { requestBody: m.requestBody }),
       ...(m.reasoningEfforts !== undefined && { reasoningEfforts: m.reasoningEfforts }),
       ...(m.reasoningEffortOverride !== undefined && { reasoningEffortOverride: m.reasoningEffortOverride }),
+      ...(m.modes !== undefined && { modes: m.modes }),
       ...(m.supportsVision !== undefined && { supportsVision: m.supportsVision }),
       ...(m.thinkingEnabled !== undefined && { thinkingEnabled: m.thinkingEnabled }),
       ...(m.thinkingLevel !== undefined && { thinkingLevel: m.thinkingLevel }),

--- a/src/server/provider-manager.test.ts
+++ b/src/server/provider-manager.test.ts
@@ -440,6 +440,59 @@ describe('ProviderManager - Model Selection', () => {
       expect(modelA?.source).toBe('user')
     })
 
+    it('hides catalog variants claimed by a merged mode-chip user model', async () => {
+      // Simulate a user who merged three suffixed catalog variants into a
+      // single mode-chip model. On refresh, the raw catalog (still exposing the
+      // suffixed variants) must not reintroduce them alongside the merged one.
+      const mergedConfig: Config = {
+        ...config,
+        providers: [
+          {
+            id: 'omni',
+            name: 'OmniRoute',
+            url: 'http://localhost:9100',
+            backend: 'openai',
+            models: [
+              {
+                id: 'antigravity/gemini-3.6-flash',
+                contextWindow: 1048576,
+                source: 'user',
+                modes: [
+                  { level: 'low', apiModelId: 'antigravity/gemini-3.6-flash-low' },
+                  { level: 'medium', apiModelId: 'antigravity/gemini-3.6-flash-medium' },
+                  { level: 'high', apiModelId: 'antigravity/gemini-3.6-flash-high' },
+                ],
+              },
+            ],
+            isActive: true,
+            createdAt: new Date().toISOString(),
+          },
+        ],
+      }
+      const manager = createProviderManager(mergedConfig)
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: [
+            { id: 'antigravity/gemini-3.6-flash-low', max_model_len: 1048576 },
+            { id: 'antigravity/gemini-3.6-flash-medium', max_model_len: 1048576 },
+            { id: 'antigravity/gemini-3.6-flash-high', max_model_len: 1048576 },
+            { id: 'antigravity/other-model', max_model_len: 200000 },
+          ],
+        }),
+      })
+
+      const result = await manager.refreshProviderModels('omni')
+
+      expect(result).toEqual({ success: true })
+      const models = manager.getProviders().find((p) => p.id === 'omni')?.models ?? []
+      const ids = models.map((m) => m.id).sort()
+      expect(ids).toEqual(['antigravity/gemini-3.6-flash', 'antigravity/other-model'])
+      const merged = models.find((m) => m.id === 'antigravity/gemini-3.6-flash')
+      expect(merged?.modes?.length).toBe(3)
+    })
+
     it('returns error when backend returns no models', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,

--- a/src/server/provider-manager.ts
+++ b/src/server/provider-manager.ts
@@ -105,7 +105,21 @@ function mergeModelsWithUserOverrides(
 ): ModelConfig[] {
   const normalizedUserIdMap = new Map(userModels.map((m) => [normalizeModelId(m.id), m]))
 
-  const updatedModels = backendModels.map((backendModel) => {
+  // A user model with `modes` is a merged mode-chip model that represents
+  // multiple concrete backend catalog ids (its modes' apiModelIds). Hide
+  // those suffixed backend variants so they don't reappear alongside the
+  // merged model on refresh.
+  const claimedByMergedModes = new Set<string>()
+  for (const userModel of userModels) {
+    if (!userModel.modes?.length) continue
+    for (const mode of userModel.modes) {
+      if (mode.apiModelId) claimedByMergedModes.add(normalizeModelId(mode.apiModelId))
+    }
+  }
+
+  const filteredBackendModels = backendModels.filter((m) => !claimedByMergedModes.has(normalizeModelId(m.id)))
+
+  const updatedModels = filteredBackendModels.map((backendModel) => {
     const existingUserModel = normalizedUserIdMap.get(normalizeModelId(backendModel.id))
     if (existingUserModel) {
       return enrichWithProfileDefaults({ ...backendModel, ...existingUserModel, id: backendModel.id })
@@ -114,7 +128,7 @@ function mergeModelsWithUserOverrides(
   })
 
   if (preserveMissingUserModels) {
-    const normalizedBackendIds = new Set(backendModels.map((m) => normalizeModelId(m.id)))
+    const normalizedBackendIds = new Set(filteredBackendModels.map((m) => normalizeModelId(m.id)))
     for (const userModel of userModels) {
       if (!normalizedBackendIds.has(normalizeModelId(userModel.id))) {
         updatedModels.push(enrichWithProfileDefaults(userModel))

--- a/src/server/provider-manager.ts
+++ b/src/server/provider-manager.ts
@@ -8,7 +8,7 @@ import { parseLmStudioModels } from './providers/lmstudio.js'
 import { ensureVersionPrefix, stripVersionPrefix, buildModelsUrl } from './llm/url-utils.js'
 import { getCatalogEntry } from './providers/model-catalog.js'
 import { hasVisionEvidence } from './providers/vision.js'
-import { resolveEffortForModel } from '../shared/reasoning-effort.js'
+import { resolveEffortForModel, resolveModeModelId } from '../shared/reasoning-effort.js'
 
 /**
  * num_ctx is the context window we request from Ollama's native /api/chat
@@ -438,19 +438,30 @@ export function createProviderManager(config: Config, options: ProviderManagerOp
     // model's configured default, clamped to the model's advertised preset
     // list; otherwise the model default applies (override, else thinkingLevel).
     const modelThinking = resolveModelThinkingConfig(provider, model, reasoningEffort)
+    // A merged mode model maps the resolved effort to a concrete provider model
+    // id (e.g. OmniRoute "gemini-3.6-flash-high"). Send that id so the mode is
+    // applied via the catalog's distinct model entries, not a reasoning_effort.
+    const configureModel = provider.models.find((m) => m.id === model)
+    const send = resolveModeModelId(
+      configureModel?.modes,
+      modelThinking.reasoningEffort,
+      configureModel?.apiModelId,
+      model,
+    )
     return {
       ...config,
       llm: {
         ...config.llm,
         baseUrl: ensureVersionPrefix(provider.url),
-        model,
+        model: send.modelId,
         backend: provider.backend as LlmBackend,
         ...(provider.apiKey && { apiKey: provider.apiKey }),
         ...(provider.thinkingField && { thinkingField: provider.thinkingField }),
         ...(provider.sendReasoningInMessages !== undefined
           ? { sendReasoningInMessages: provider.sendReasoningInMessages }
           : {}),
-        ...(modelThinking.reasoningEffort && { reasoningEffort: modelThinking.reasoningEffort }),
+        ...(modelThinking.reasoningEffort &&
+          !send.suppressEffort && { reasoningEffort: modelThinking.reasoningEffort }),
       },
     }
   }
@@ -844,6 +855,9 @@ export function createProviderManager(config: Config, options: ProviderManagerOp
         id: modelId,
         contextWindow: settings.contextWindow ?? existingModel?.contextWindow ?? 200000,
         source: 'user',
+        ...(existingModel?.name !== undefined && { name: existingModel.name }),
+        ...(existingModel?.apiModelId !== undefined && { apiModelId: existingModel.apiModelId }),
+        ...(existingModel?.modes !== undefined && { modes: existingModel.modes }),
         ...(finalTemp !== undefined && { temperature: finalTemp }),
         ...(finalTopP !== undefined && { topP: finalTopP }),
         ...(finalTopK !== undefined && { topK: finalTopK }),

--- a/src/server/providers/adapters/transport-client.ts
+++ b/src/server/providers/adapters/transport-client.ts
@@ -4,7 +4,7 @@ import { getModelProfile } from '../../llm/profiles.js'
 import type { LLMClientWithModel } from '../../llm/client.js'
 import type { ProviderTransportAdapter } from '../../../provider/index.js'
 import { resolveAttachmentsInMessages } from '../../llm/client-pure.js'
-import { resolveEffortForModel } from '../../../shared/reasoning-effort.js'
+import { resolveEffortForModel, resolveModeModelId } from '../../../shared/reasoning-effort.js'
 
 export function createTransportLLMClient(
   provider: Provider,
@@ -30,11 +30,15 @@ export function createTransportLLMClient(
   let profile = profileFor(model)
   void getBackendCapabilities(backend)
 
-  const context = () => {
+  const context = (resolvedEffort?: string) => {
     const configured = provider.models.find((item) => item.id === model)
+    // A merged mode model sends the concrete per-level apiModelId; the base
+    // model id is only a catalog projection. The resolved effort selects which
+    // mode to emit.
+    const send = resolveModeModelId(configured?.modes, resolvedEffort, configured?.apiModelId, model)
     return {
       providerId: provider.id,
-      model: configured?.apiModelId ?? model,
+      model: send.modelId,
       catalogModel: model,
       ...(configured?.requestBody && { requestBody: configured.requestBody }),
       ...(provider.credentialRef && { credentialRef: provider.credentialRef }),
@@ -67,10 +71,18 @@ export function createTransportLLMClient(
   const resolveRequest = async (request: import('../../llm/types.js').LLMCompletionRequest) => {
     const supportsVision = request.modelSettings?.supportsVision ?? profile.supportsVision ?? false
     const resolvedEffort = resolveEffort(request)
+    const configured = provider.models.find((item) => item.id === model)
+    // A merged mode model encodes the effort in its distinct provider id, so the
+    // effort must not also be sent as a request-level reasoningEffort param.
+    // Mirrors createConfigForProvider via resolveModeModelId.
+    const send = resolveModeModelId(configured?.modes, resolvedEffort, configured?.apiModelId, model)
     return {
-      ...request,
-      messages: await resolveAttachmentsInMessages(request.messages, supportsVision),
-      ...(resolvedEffort ? { reasoningEffort: resolvedEffort } : {}),
+      request: {
+        ...request,
+        messages: await resolveAttachmentsInMessages(request.messages, supportsVision),
+        ...(resolvedEffort && !send.suppressEffort ? { reasoningEffort: resolvedEffort } : {}),
+      },
+      effort: resolvedEffort,
     }
   }
 
@@ -86,9 +98,13 @@ export function createTransportLLMClient(
       backend = next
     },
     getReasoningEffort: () => resolveEffort({}),
-    complete: async (request) => transport.complete(await resolveRequest(request), context()),
+    complete: async (request) => {
+      const resolved = await resolveRequest(request)
+      return transport.complete(resolved.request, context(resolved.effort))
+    },
     stream: async function* (request) {
-      yield* transport.stream(await resolveRequest(request), context())
+      const resolved = await resolveRequest(request)
+      yield* transport.stream(resolved.request, context(resolved.effort))
     },
   }
 }

--- a/src/shared/reasoning-effort.test.ts
+++ b/src/shared/reasoning-effort.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { resolveEffortForModel } from './reasoning-effort.js'
+import { resolveEffortForModel, splitModeSuffix, groupModeFamilies } from './reasoning-effort.js'
 
 describe('resolveEffortForModel', () => {
   it('passes an in-list candidate through unchanged', () => {
@@ -56,5 +56,56 @@ describe('resolveEffortForModel', () => {
     expect(resolveEffortForModel({ override: 'deep' })).toBe('deep')
     expect(resolveEffortForModel({ defaultEffort: 'medium' })).toBe('medium')
     expect(resolveEffortForModel({})).toBeUndefined()
+  })
+})
+
+describe('splitModeSuffix', () => {
+  it('strips a trailing low/medium/high/xhigh/max suffix from a model id', () => {
+    expect(splitModeSuffix('gemini-3.6-flash-high')).toEqual({ base: 'gemini-3.6-flash', level: 'high' })
+    expect(splitModeSuffix('claude-sonnet-4-6-low')).toEqual({ base: 'claude-sonnet-4-6', level: 'low' })
+  })
+
+  it('handles prefixed ids and keeps the path segment base', () => {
+    expect(splitModeSuffix('antigravity/gemini-3.6-flash-medium')).toEqual({
+      base: 'antigravity/gemini-3.6-flash',
+      level: 'medium',
+    })
+  })
+
+  it('returns undefined when there is no trailing mode suffix', () => {
+    expect(splitModeSuffix('gemini-3.6-flash')).toBeUndefined()
+    expect(splitModeSuffix('claude-sonnet-4-6')).toBeUndefined()
+  })
+})
+
+describe('groupModeFamilies', () => {
+  it('groups models that differ only by a trailing mode suffix', () => {
+    const groups = groupModeFamilies([
+      { id: 'gemini-3.6-flash-high', name: 'Gemini 3.6 Flash (High)' },
+      { id: 'gemini-3.6-flash-low', name: 'Gemini 3.6 Flash (Low)' },
+      { id: 'gemini-3.6-flash-medium', name: 'Gemini 3.6 Flash (Medium)' },
+    ])
+    expect(groups).toHaveLength(1)
+    expect(groups[0]?.baseId).toBe('gemini-3.6-flash')
+    expect(groups[0]?.members).toHaveLength(3)
+  })
+
+  it('uses the stripped base id as the stable name when no un-suffixed model exists', () => {
+    const groups = groupModeFamilies([{ id: 'claude-sonnet-4-6-low' }, { id: 'claude-sonnet-4-6-high' }])
+    expect(groups[0]?.name).toBe('claude-sonnet-4-6')
+  })
+
+  it('returns empty for a single mode (not a real duplicate family)', () => {
+    expect(groupModeFamilies([{ id: 'gemini-3.6-flash-high' }])).toHaveLength(0)
+  })
+
+  it('keeps separate families distinct', () => {
+    const groups = groupModeFamilies([
+      { id: 'gemini-3.6-flash-low' },
+      { id: 'gemini-3.6-flash-high' },
+      { id: 'claude-opus-4-6-low' },
+      { id: 'claude-opus-4-6-high' },
+    ])
+    expect(groups).toHaveLength(2)
   })
 })

--- a/src/shared/reasoning-effort.ts
+++ b/src/shared/reasoning-effort.ts
@@ -59,3 +59,83 @@ export function resolveEffortForModel({
   if (override) return override
   return defaultEffort && reasoningEfforts.includes(defaultEffort) ? defaultEffort : undefined
 }
+
+// ============================================================================
+// Mode-suffix model merging (e.g. OmniRoute, which exposes one model as
+// "gemini-3.6-flash-low" / "gemini-3.6-flash-medium" / "gemini-3.6-flash-high").
+// ============================================================================
+
+/** Suffixes OmniRoute-style providers use to qualify a mode on model IDs/names. */
+export const MODE_SUFFIXES = ['low', 'medium', 'high', 'xhigh', 'max'] as const
+export type ModeSuffix = (typeof MODE_SUFFIXES)[number]
+
+export interface ModeModelSeed {
+  id: string
+  name?: string
+}
+
+/**
+ * Detect whether a model ID carries a trailing mode suffix, returning the
+ * stripped base ID and the suffix, or undefined when the ID is un-suffixed.
+ */
+const MODE_SUFFIX_REGEX = new RegExp(`-(${MODE_SUFFIXES.join('|')})$`)
+export function splitModeSuffix(id: string): { base: string; level: string } | undefined {
+  const match = id.match(MODE_SUFFIX_REGEX)
+  if (!match) return undefined
+  return { base: id.slice(0, -match[0].length), level: match[1]! }
+}
+
+/**
+ * Group a list of models into "families" that differ only by a trailing mode
+ * suffix. Returns the grouped families, each with a stable base name (the
+ * un-suffixed model's name/ID, else the stripped member's name) and the
+ * members. Families with fewer than 2 members are not returned.
+ */
+export function groupModeFamilies(
+  models: ModeModelSeed[],
+): Array<{ baseId: string; name: string; members: ModeModelSeed[] }> {
+  const byId = new Map(models.map((m) => [m.id, m]))
+  const families = new Map<string, { name: string; members: ModeModelSeed[] }>()
+  for (const model of models) {
+    const split = splitModeSuffix(model.id)
+    if (!split) continue
+    const existing = families.get(split.base)
+    if (existing) {
+      existing.members.push(model)
+    } else {
+      families.set(split.base, { name: model.name ?? split.base, members: [model] })
+    }
+  }
+  const result: Array<{ baseId: string; name: string; members: ModeModelSeed[] }> = []
+  for (const [baseId, family] of families) {
+    if (family.members.length < 2) continue
+    const baseModel = byId.get(baseId)
+    const name = baseModel?.name ?? family.name ?? baseId
+    result.push({ baseId, name, members: family.members })
+  }
+  return result
+}
+
+/**
+ * Resolve the concrete provider model ID to send for a model given a resolved
+ * reasoning effort, and whether the effort should be forwarded as a
+ * `reasoning_effort` param.
+ *
+ * When the model is a merged mode model (has `modes`), the effort selects the
+ * matching per-level `apiModelId`; the effort is then encoded in the distinct
+ * provider id and must NOT also be sent as a `reasoning_effort` param. When the
+ * effort matches no listed mode, the model's base `apiModelId` (or the model id)
+ * is sent and the effort is forwarded as usual.
+ */
+export function resolveModeModelId(
+  modes: Array<{ level: string; apiModelId: string; name?: string }> | undefined,
+  effort: string | undefined,
+  fallbackApiModelId: string | undefined,
+  modelId: string,
+): { modelId: string; suppressEffort: boolean } {
+  const modeEntry = modes?.find((mode) => mode.level === effort)
+  if (modeEntry) {
+    return { modelId: modeEntry.apiModelId, suppressEffort: true }
+  }
+  return { modelId: fallbackApiModelId ?? modelId, suppressEffort: false }
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -660,6 +660,11 @@ export interface ModelConfig {
    *  Takes precedence over `thinkingLevel` as the model default and is never
    *  clamped to the preset list — the escape hatch for provider-specific values. */
   reasoningEffortOverride?: string
+  /** Modes a merged model exposes, each mapping a level to the concrete
+   *  provider model ID to send (e.g. OmniRoute exposes the same model as
+   *  "gemini-3.6-flash-low/-medium/-high"). When present, the active effort
+   *  selects the corresponding apiModelId at request time. */
+  modes?: Array<{ level: string; apiModelId: string; name?: string }>
   contextWindow: number // Context window size in tokens
   source: 'backend' | 'user' | 'default' // Where the value came from
   selected?: boolean // User explicitly selected this model (for multi-model providers)

--- a/web/src/components/settings/model-list.test.tsx
+++ b/web/src/components/settings/model-list.test.tsx
@@ -2,9 +2,13 @@
 import { describe, expect, it, vi } from 'vitest'
 import { createRoot } from 'react-dom/client'
 import { act } from 'react'
-import { ModelEntryRow, type ModelWithConfig } from './model-list'
+import { ModelEntryRow, getVisibleModels, type ModelWithConfig } from './model-list'
+import type { Provider } from '../../stores/config'
 
-function renderRow(modelConfig: ModelWithConfig) {
+function renderRow(
+  modelConfig: ModelWithConfig,
+  opts?: { onSelectEffort?: (p: string, m: string, e: string) => void; reasoningEfforts?: string[] },
+) {
   const container = document.createElement('div')
   document.body.appendChild(container)
   const root = createRoot(container)
@@ -16,6 +20,8 @@ function renderRow(modelConfig: ModelWithConfig) {
         isActive={false}
         highlighted={false}
         onModelClick={vi.fn()}
+        reasoningEfforts={opts?.reasoningEfforts}
+        onSelectEffort={opts?.onSelectEffort ?? vi.fn()}
       />,
     )
   })
@@ -64,5 +70,74 @@ describe('ModelEntryRow small-context warning', () => {
     } finally {
       cleanup(rendered)
     }
+  })
+})
+
+describe('ModelEntryRow mode chips', () => {
+  it('renders reasoning-effort chips for a merged mode model', () => {
+    const rendered = renderRow(
+      { id: 'gemini-3.6-flash', contextWindow: 1048576, source: 'backend' },
+      { reasoningEfforts: ['low', 'medium', 'high'] },
+    )
+    try {
+      const chipRow = rendered.container.querySelector('[aria-label="Reasoning efforts for gemini-3.6-flash"]')
+      const chips = Array.from(chipRow?.querySelectorAll('button') ?? []).map((b) => b.textContent?.trim())
+      expect(chips).toEqual(['low', 'medium', 'high'])
+    } finally {
+      cleanup(rendered)
+    }
+  })
+
+  it('does not render chips when no reasoning efforts are set', () => {
+    const rendered = renderRow({ id: 'plain-model', contextWindow: 1048576, source: 'backend' })
+    try {
+      const chipRow = rendered.container.querySelector('[aria-label^="Reasoning efforts"]')
+      expect(chipRow).toBeNull()
+    } finally {
+      cleanup(rendered)
+    }
+  })
+
+  it('calls onSelectEffort with the clicked level', () => {
+    const onSelectEffort = vi.fn()
+    const rendered = renderRow(
+      { id: 'gemini-3.6-flash', contextWindow: 1048576, source: 'backend' },
+      { onSelectEffort, reasoningEfforts: ['low', 'high'] },
+    )
+    try {
+      const chipRow = rendered.container.querySelector('[aria-label="Reasoning efforts for gemini-3.6-flash"]')
+      const high = Array.from(chipRow?.querySelectorAll('button') ?? []).find((b) => b.textContent?.trim() === 'high')
+      act(() => high?.click())
+      expect(onSelectEffort).toHaveBeenCalledWith('provider-1', 'gemini-3.6-flash', 'high')
+    } finally {
+      cleanup(rendered)
+    }
+  })
+})
+
+describe('getVisibleModels mode derivation', () => {
+  it('derives reasoningEfforts from a merged model modes', () => {
+    const provider = {
+      id: 'omni',
+      name: 'Omni',
+      url: 'https://omniroute.example/v1',
+      backend: 'openai',
+      models: [
+        {
+          id: 'gemini-3.6-flash',
+          name: 'Gemini 3.6 Flash',
+          contextWindow: 1048576,
+          source: 'backend',
+          modes: [
+            { level: 'low', apiModelId: 'gemini-3.6-flash-low' },
+            { level: 'high', apiModelId: 'gemini-3.6-flash-high' },
+          ],
+        },
+      ],
+      isActive: false,
+      createdAt: '',
+    } as unknown as Provider
+    const visible = getVisibleModels(provider)
+    expect(visible[0]?.reasoningEfforts).toEqual(['low', 'high'])
   })
 })

--- a/web/src/components/settings/model-list.tsx
+++ b/web/src/components/settings/model-list.tsx
@@ -32,17 +32,26 @@ export function modelMatchesQuery(model: { name?: string; id: string }, query: s
 export function getVisibleModels(provider: Provider): ModelWithConfig[] {
   const hasSelected = provider.models.some((m) => m.selected)
   const source = hasSelected ? provider.models.filter((m) => m.selected) : provider.models
-  return source.map((m) => ({
-    id: m.id,
-    ...(m.name !== undefined ? { name: m.name } : {}),
-    contextWindow: m.contextWindow,
-    source: m.source ?? 'default',
-    ...(m.supportsVision !== undefined ? { supportsVision: m.supportsVision } : {}),
-    ...(m.reasoningEfforts?.length ? { reasoningEfforts: m.reasoningEfforts } : {}),
-    ...(m.reasoningEffortOverride ? { reasoningEffortOverride: m.reasoningEffortOverride } : {}),
-    ...(m.thinkingLevel ? { thinkingLevel: m.thinkingLevel } : {}),
-    ...(m.thinkingEnabled !== undefined ? { thinkingEnabled: m.thinkingEnabled } : {}),
-  }))
+  return source.map((m) => {
+    // A merged mode model exposes its levels via `modes`; surface them as
+    // reasoning efforts so the picker renders mode chips.
+    const reasoningEfforts = m.reasoningEfforts?.length
+      ? m.reasoningEfforts
+      : m.modes?.length
+        ? m.modes.map((mode) => mode.level)
+        : undefined
+    return {
+      id: m.id,
+      ...(m.name !== undefined ? { name: m.name } : {}),
+      contextWindow: m.contextWindow,
+      source: m.source ?? 'default',
+      ...(m.supportsVision !== undefined ? { supportsVision: m.supportsVision } : {}),
+      ...(reasoningEfforts?.length ? { reasoningEfforts } : {}),
+      ...(m.reasoningEffortOverride ? { reasoningEffortOverride: m.reasoningEffortOverride } : {}),
+      ...(m.thinkingLevel ? { thinkingLevel: m.thinkingLevel } : {}),
+      ...(m.thinkingEnabled !== undefined ? { thinkingEnabled: m.thinkingEnabled } : {}),
+    }
+  })
 }
 
 // ============================================================================

--- a/web/src/components/shared/ProviderModal.test.tsx
+++ b/web/src/components/shared/ProviderModal.test.tsx
@@ -885,3 +885,105 @@ describe('ProviderModal - small context window warning', () => {
     expect(document.body.querySelector('[data-small-context]')).toBeNull()
   })
 })
+
+describe('ProviderModal - model mode merge', () => {
+  let container: HTMLElement
+  let root: ReturnType<typeof createRoot>
+  let onSaveMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    onSaveMock = vi.fn()
+  })
+
+  afterEach(() => {
+    root.unmount()
+    document.body.removeChild(container)
+    vi.unstubAllGlobals()
+  })
+
+  const omniModels = [
+    { id: 'antigravity/gemini-3.6-flash-high', contextWindow: 1048576 },
+    { id: 'antigravity/gemini-3.6-flash-low', contextWindow: 1048576 },
+    { id: 'antigravity/gemini-3.6-flash-medium', contextWindow: 1048576 },
+    { id: 'antigravity/claude-opus-4-6-thinking', contextWindow: 1048576 },
+  ] as const
+
+  async function renderOmni(editProviderModels: readonly unknown[]) {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input)
+        if (url.includes('/api/provider-presets')) {
+          return new Response(JSON.stringify({ presets: [] }), { status: 200 })
+        }
+        return new Response(JSON.stringify({ models: [], url: 'https://omniroute.example/v1' }), { status: 200 })
+      }),
+    )
+    await new Promise<void>((resolve) => {
+      root.render(
+        <ProviderModal
+          isOpen={true}
+          onClose={vi.fn()}
+          onSave={onSaveMock as (provider: ProviderFormData) => void}
+          initialStep={2}
+          editProvider={{
+            id: 'omni-provider',
+            name: 'OmniRoute',
+            url: 'https://omniroute.example/v1',
+            backend: 'openai' as const,
+            models: editProviderModels as never,
+          }}
+        />,
+      )
+      setTimeout(resolve, 200)
+    })
+  }
+
+  it('shows a merge button when models share a base name with mode suffixes', async () => {
+    await renderOmni(omniModels)
+    const mergeButton = Array.from(document.body.querySelectorAll('button')).find((b) =>
+      b.textContent?.includes('Merge gemini-3.6-flash'),
+    )
+    expect(mergeButton).toBeTruthy()
+  })
+
+  it('hides the merge button when there are no mergeable families', async () => {
+    await renderOmni([{ id: 'gemini-3.6-flash', name: 'Gemini 3.6 Flash', contextWindow: 1048576 }])
+    const anyMergeButton = Array.from(document.body.querySelectorAll('button')).find((b) =>
+      b.textContent?.includes('Merge '),
+    )
+    expect(anyMergeButton).toBeUndefined()
+  })
+
+  it('merges a family into a single model with modes in the save payload', async () => {
+    await renderOmni(omniModels)
+    const mergeButton = Array.from(document.body.querySelectorAll('button')).find((b) =>
+      b.textContent?.includes('Merge gemini-3.6-flash'),
+    )
+    expect(mergeButton).toBeTruthy()
+    mergeButton?.click()
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    const saveButton = document.body.querySelector('[data-testid="provider-modal-save"]') as HTMLButtonElement | null
+    saveButton?.click()
+
+    const savedData: ProviderFormData = onSaveMock.mock.calls[0]![0]!
+    const merged = savedData.models.find((m) => m.id === 'antigravity/gemini-3.6-flash')
+    expect(merged).toBeDefined()
+    // Display name is the path-stripped base id, not the full provider path.
+    expect(merged?.name).toBe('gemini-3.6-flash')
+    expect(merged?.modes?.map((mode) => mode.level)).toEqual(['high', 'low', 'medium'])
+    expect(merged?.modes?.map((mode) => mode.apiModelId)).toEqual([
+      'antigravity/gemini-3.6-flash-high',
+      'antigravity/gemini-3.6-flash-low',
+      'antigravity/gemini-3.6-flash-medium',
+    ])
+    expect(merged?.reasoningEfforts).toEqual(['high', 'low', 'medium'])
+    // The suffixes are removed from the model list
+    expect(savedData.models.some((m) => m.id === 'antigravity/gemini-3.6-flash-high')).toBe(false)
+    expect(savedData.models.some((m) => m.id === 'antigravity/claude-opus-4-6-thinking')).toBe(true)
+  })
+})

--- a/web/src/components/shared/ProviderModal.test.tsx
+++ b/web/src/components/shared/ProviderModal.test.tsx
@@ -942,15 +942,81 @@ describe('ProviderModal - model mode merge', () => {
     })
   }
 
-  it('shows a merge button when models share a base name with mode suffixes', async () => {
+  // Renders the ProviderModal in creation mode (no editProvider), navigates
+  // step1 → step2 with a URL so the catalog is fetched and auto-collapsed into
+  // mode-chip models.
+  async function renderCreate() {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input)
+        if (url.includes('/api/provider-presets')) {
+          return new Response(JSON.stringify({ presets: [] }), { status: 200 })
+        }
+        if (url.includes('/models')) {
+          return new Response(JSON.stringify({ models: omniModels, url: 'https://omniroute.example/v1' }), {
+            status: 200,
+          })
+        }
+        return new Response(JSON.stringify({ models: [], url: 'https://omniroute.example/v1' }), { status: 200 })
+      }),
+    )
+    await new Promise<void>((resolve) => {
+      root.render(
+        <ProviderModal
+          isOpen={true}
+          onClose={vi.fn()}
+          onSave={onSaveMock as (provider: ProviderFormData) => void}
+          initialStep={1}
+        />,
+      )
+      setTimeout(resolve, 200)
+    })
+    const urlInput = document.body.querySelector('[data-testid="provider-modal-url"]') as HTMLInputElement | null
+    expect(urlInput).toBeTruthy()
+    const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!.set!
+    setter.call(urlInput, 'https://omniroute.example/v1')
+    urlInput!.dispatchEvent(new Event('input', { bubbles: true }))
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    ;(document.body.querySelector('[data-testid="provider-modal-next"]') as HTMLButtonElement | null)?.click()
+    await new Promise((resolve) => setTimeout(resolve, 250))
+  }
+
+  it('creating a provider shows raw suffixed variants and a Merge button, no Unmerge', async () => {
+    await renderCreate()
+    // Raw catalog: suffixed variants shown separately.
+    const hasSuffixed = Array.from(document.body.querySelectorAll('span,div')).some((el) =>
+      el.textContent?.includes('gemini-3.6-flash-high'),
+    )
+    expect(hasSuffixed).toBe(true)
+    // Merge button is visible; Unmerge is not (nothing merged yet).
+    const mergeButton = Array.from(document.body.querySelectorAll('button')).find((b) =>
+      b.textContent?.includes('Merge gemini-3.6-flash'),
+    )
+    expect(mergeButton).toBeTruthy()
+    const unmergeButton = Array.from(document.body.querySelectorAll('button')).find((b) =>
+      b.textContent?.includes('Unmerge '),
+    )
+    expect(unmergeButton).toBeUndefined()
+  })
+
+  it('editing keeps the raw catalog: suffixed variants present, Merge button shown', async () => {
     await renderOmni(omniModels)
+    // No auto-merge: the merged id is absent and the suffixed members remain.
+    const saveButton = document.body.querySelector('[data-testid="provider-modal-save"]') as HTMLButtonElement | null
+    saveButton?.click()
+    const savedData: ProviderFormData = onSaveMock.mock.calls[0]![0]!
+    expect(savedData.models.some((m) => m.id === 'antigravity/gemini-3.6-flash' && m.modes?.length)).toBe(false)
+    expect(savedData.models.some((m) => m.id === 'antigravity/gemini-3.6-flash-high')).toBe(true)
+    expect(savedData.models.some((m) => m.id === 'antigravity/gemini-3.6-flash-low')).toBe(true)
+    // Merge button offered for the family.
     const mergeButton = Array.from(document.body.querySelectorAll('button')).find((b) =>
       b.textContent?.includes('Merge gemini-3.6-flash'),
     )
     expect(mergeButton).toBeTruthy()
   })
 
-  it('hides the merge button when there are no mergeable families', async () => {
+  it('shows no Merge button when there are no mergeable families (single model)', async () => {
     await renderOmni([{ id: 'gemini-3.6-flash', name: 'Gemini 3.6 Flash', contextWindow: 1048576 }])
     const anyMergeButton = Array.from(document.body.querySelectorAll('button')).find((b) =>
       b.textContent?.includes('Merge '),
@@ -958,8 +1024,173 @@ describe('ProviderModal - model mode merge', () => {
     expect(anyMergeButton).toBeUndefined()
   })
 
-  it('merges a family into a single model with modes in the save payload', async () => {
-    await renderOmni(omniModels)
+  const mergedOmniModel = {
+    id: 'antigravity/gemini-3.6-flash',
+    name: 'gemini-3.6-flash',
+    apiModelId: 'antigravity/gemini-3.6-flash',
+    contextWindow: 1048576,
+    reasoningEfforts: ['high', 'low', 'medium'],
+    modes: [
+      { level: 'high', apiModelId: 'antigravity/gemini-3.6-flash-high' },
+      { level: 'low', apiModelId: 'antigravity/gemini-3.6-flash-low' },
+      { level: 'medium', apiModelId: 'antigravity/gemini-3.6-flash-medium' },
+    ],
+  } as const
+  const claudeOpusModel = { id: 'antigravity/claude-opus-4-6-thinking', contextWindow: 1048576 }
+  const mergedProviderModels = [mergedOmniModel, claudeOpusModel] as const
+
+  // Ensure at least 2 models so the "Available Models" block (which hosts the
+  // merge/unmerge banner) renders.
+  async function renderWithRawCatalog(editProviderModels: readonly unknown[]) {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input)
+        if (url.includes('/api/provider-presets')) {
+          return new Response(JSON.stringify({ presets: [] }), { status: 200 })
+        }
+        if (url.includes('/models')) {
+          return new Response(JSON.stringify({ models: omniModels, url: 'https://omniroute.example/v1' }), {
+            status: 200,
+          })
+        }
+        return new Response(JSON.stringify({ models: [], url: 'https://omniroute.example/v1' }), { status: 200 })
+      }),
+    )
+    await new Promise<void>((resolve) => {
+      root.render(
+        <ProviderModal
+          isOpen={true}
+          onClose={vi.fn()}
+          onSave={onSaveMock as (provider: ProviderFormData) => void}
+          initialStep={2}
+          editProvider={{
+            id: 'omni-provider',
+            name: 'OmniRoute',
+            url: 'https://omniroute.example/v1',
+            backend: 'openai' as const,
+            models: editProviderModels as never,
+          }}
+        />,
+      )
+      setTimeout(resolve, 200)
+    })
+  }
+
+  it('does not re-fetch raw catalog over saved merged models (no merge button on edit)', async () => {
+    // The fetch mock returns the raw suffixed catalog; if the edit path
+    // re-fetched over the saved merged model, the merged entry would be lost
+    // and Merge buttons would reappear.
+    await renderWithRawCatalog(mergedProviderModels)
+    // The merged model is still present, and no Merge button is shown.
+    const saveButton = document.body.querySelector('[data-testid="provider-modal-save"]') as HTMLButtonElement | null
+    saveButton?.click()
+    const savedData: ProviderFormData = onSaveMock.mock.calls[0]![0]!
+    expect(savedData.models.some((m) => m.id === 'antigravity/gemini-3.6-flash' && m.modes?.length)).toBe(true)
+    const mergeButton = Array.from(document.body.querySelectorAll('button')).find((b) =>
+      b.textContent?.includes('Merge gemini-3.6-flash'),
+    )
+    expect(mergeButton).toBeUndefined()
+  })
+
+  it('shows an Unmerge button for an already-merged model', async () => {
+    await renderWithRawCatalog(mergedProviderModels)
+    const unmergeButton = Array.from(document.body.querySelectorAll('button')).find((b) =>
+      b.textContent?.includes('Unmerge gemini-3.6-flash'),
+    )
+    expect(unmergeButton).toBeTruthy()
+  })
+
+  it('manual merge migrates selection from suffixed members to the merged model', async () => {
+    // Edit provider where one suffixed member was selected; after a manual
+    // Merge the merged model stays selected and the suffixed members are gone.
+    await renderOmni([
+      { id: 'antigravity/gemini-3.6-flash-high', contextWindow: 1048576, selected: true },
+      { id: 'antigravity/gemini-3.6-flash-low', contextWindow: 1048576 },
+      { id: 'antigravity/gemini-3.6-flash-medium', contextWindow: 1048576 },
+    ])
+    const mergeButton = Array.from(document.body.querySelectorAll('button')).find((b) =>
+      b.textContent?.includes('Merge gemini-3.6-flash'),
+    )
+    expect(mergeButton).toBeTruthy()
+    mergeButton?.click()
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    const saveButton = document.body.querySelector('[data-testid="provider-modal-save"]') as HTMLButtonElement | null
+    saveButton?.click()
+    const savedData: ProviderFormData = onSaveMock.mock.calls[0]![0]!
+    const merged = savedData.models.find((m) => m.id === 'antigravity/gemini-3.6-flash')
+    expect(merged?.modes?.length).toBe(3)
+    // Because a member was selected, the merged model is selected in the payload.
+    expect(merged?.selected).toBe(true)
+    expect(savedData.models.some((m) => m.id === 'antigravity/gemini-3.6-flash-high')).toBe(false)
+  })
+
+  it('manual merge on multi-family only selects the family whose member was selected', async () => {
+    // Two families; only a gemini member is selected. After merging the gemini
+    // family the gemini merged model is selected but the claude family is not.
+    await renderOmni([
+      { id: 'antigravity/gemini-3.6-flash-high', contextWindow: 1048576, selected: true },
+      { id: 'antigravity/gemini-3.6-flash-low', contextWindow: 1048576 },
+      { id: 'antigravity/gemini-3.6-flash-medium', contextWindow: 1048576 },
+      { id: 'antigravity/claude-opus-4-6-thinking-low', contextWindow: 1048576 },
+      { id: 'antigravity/claude-opus-4-6-thinking-high', contextWindow: 1048576 },
+    ])
+    const geminiMerge = Array.from(document.body.querySelectorAll('button')).find((b) =>
+      b.textContent?.includes('Merge gemini-3.6-flash'),
+    )
+    expect(geminiMerge).toBeTruthy()
+    geminiMerge?.click()
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    const saveButton = document.body.querySelector('[data-testid="provider-modal-save"]') as HTMLButtonElement | null
+    saveButton?.click()
+    const savedData: ProviderFormData = onSaveMock.mock.calls[0]![0]!
+    const geminiMerged = savedData.models.find((m) => m.id === 'antigravity/gemini-3.6-flash')
+    const claudeMerged = savedData.models.find((m) => m.id === 'antigravity/claude-opus-4-6-thinking')
+    expect(geminiMerged?.modes?.length).toBe(3)
+    // Claude family was not merged, so it stays as separate variants.
+    expect(claudeMerged?.modes?.length).toBeUndefined()
+    // Only the gemini family (which had a selected member) is selected.
+    expect(geminiMerged?.selected).toBe(true)
+    expect(savedData.models.some((m) => m.id === 'antigravity/gemini-3.6-flash-high')).toBe(false)
+  })
+
+  it('unmerges a merged model back into its suffixed members in the save payload', async () => {
+    await renderWithRawCatalog(mergedProviderModels)
+    const unmergeButton = Array.from(document.body.querySelectorAll('button')).find((b) =>
+      b.textContent?.includes('Unmerge gemini-3.6-flash'),
+    )
+    expect(unmergeButton).toBeTruthy()
+    unmergeButton?.click()
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    // After unmerge a Merge button for the re-expanded family must appear
+    // (the suffixed variants are once again present in the list).
+    const mergeButton = Array.from(document.body.querySelectorAll('button')).find((b) =>
+      b.textContent?.includes('Merge gemini-3.6-flash'),
+    )
+    expect(mergeButton).toBeTruthy()
+
+    const saveButton = document.body.querySelector('[data-testid="provider-modal-save"]') as HTMLButtonElement | null
+    saveButton?.click()
+
+    const savedData: ProviderFormData = onSaveMock.mock.calls[0]![0]!
+    // The merged entry is gone; the suffixed members are restored.
+    expect(savedData.models.some((m) => m.id === 'antigravity/gemini-3.6-flash' && m.modes?.length)).toBe(false)
+    const levels = ['high', 'low', 'medium']
+    for (const level of levels) {
+      expect(savedData.models.some((m) => m.id === `antigravity/gemini-3.6-flash-${level}`)).toBe(true)
+    }
+  })
+
+  it('re-merges an unmerged family back into a mode-chip model (Merge button disappears)', async () => {
+    await renderWithRawCatalog(mergedProviderModels)
+    const unmergeButton = Array.from(document.body.querySelectorAll('button')).find((b) =>
+      b.textContent?.includes('Unmerge gemini-3.6-flash'),
+    )
+    expect(unmergeButton).toBeTruthy()
+    unmergeButton?.click()
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
     const mergeButton = Array.from(document.body.querySelectorAll('button')).find((b) =>
       b.textContent?.includes('Merge gemini-3.6-flash'),
     )
@@ -967,23 +1198,19 @@ describe('ProviderModal - model mode merge', () => {
     mergeButton?.click()
     await new Promise((resolve) => setTimeout(resolve, 50))
 
+    // Merge button must disappear again after re-merging.
+    const mergeAfter = Array.from(document.body.querySelectorAll('button')).find((b) =>
+      b.textContent?.includes('Merge gemini-3.6-flash'),
+    )
+    expect(mergeAfter).toBeUndefined()
+
     const saveButton = document.body.querySelector('[data-testid="provider-modal-save"]') as HTMLButtonElement | null
     saveButton?.click()
 
     const savedData: ProviderFormData = onSaveMock.mock.calls[0]![0]!
+    // Family collapsed back into a single mode-chip model.
     const merged = savedData.models.find((m) => m.id === 'antigravity/gemini-3.6-flash')
-    expect(merged).toBeDefined()
-    // Display name is the path-stripped base id, not the full provider path.
-    expect(merged?.name).toBe('gemini-3.6-flash')
-    expect(merged?.modes?.map((mode) => mode.level)).toEqual(['high', 'low', 'medium'])
-    expect(merged?.modes?.map((mode) => mode.apiModelId)).toEqual([
-      'antigravity/gemini-3.6-flash-high',
-      'antigravity/gemini-3.6-flash-low',
-      'antigravity/gemini-3.6-flash-medium',
-    ])
-    expect(merged?.reasoningEfforts).toEqual(['high', 'low', 'medium'])
-    // The suffixes are removed from the model list
+    expect(merged?.modes?.map((mode) => mode.level)).toEqual(['low', 'medium', 'high'])
     expect(savedData.models.some((m) => m.id === 'antigravity/gemini-3.6-flash-high')).toBe(false)
-    expect(savedData.models.some((m) => m.id === 'antigravity/claude-opus-4-6-thinking')).toBe(true)
   })
 })

--- a/web/src/components/shared/ProviderModal.tsx
+++ b/web/src/components/shared/ProviderModal.tsx
@@ -10,7 +10,7 @@ import { formatTokens } from '../../lib/format-stats'
 import { shouldAutofocus } from '../../lib/device'
 import { REASONING_EFFORT_VALUES } from '../../lib/model-value'
 import { isSmallContext } from '../../lib/context-warning'
-import { groupModeFamilies, splitModeSuffix } from '@shared/reasoning-effort.js'
+import { groupModeFamilies, MODE_SUFFIXES, splitModeSuffix } from '@shared/reasoning-effort.js'
 
 const COMMON_PORTS = [8080, 11434, 8000, 1234]
 
@@ -33,6 +33,36 @@ type ModelInfo = Omit<SharedModelConfig, 'source'>
 function defaultReasoningEffort(efforts: string[] | undefined): string | undefined {
   if (!efforts?.length) return undefined
   return efforts.includes('medium') ? 'medium' : efforts[0]
+}
+
+// Build a single merged ModelInfo from a mode-suffix family's base id, its
+// (optionally present) un-suffixed base model, and its members. Shared by the
+// auto-collapse path and the explicit re-merge path so the merged shape stays
+// defined in one place.
+function buildMergedModel(baseId: string, baseModel: ModelInfo | undefined, members: ModelInfo[]): ModelInfo {
+  // Order members by semantic reasoning level (low → medium → high → xhigh →
+  // max) rather than lexically, so displayed chips read predictably.
+  const levelOrder = new Map<string, number>(MODE_SUFFIXES.map((s, i) => [s, i]))
+  const sorted = [...members].sort((a, b) => {
+    const la = splitModeSuffix(a.id)?.level
+    const lb = splitModeSuffix(b.id)?.level
+    const ia = la !== undefined ? (levelOrder.get(la) ?? Number.MAX_SAFE_INTEGER) : Number.MAX_SAFE_INTEGER
+    const ib = lb !== undefined ? (levelOrder.get(lb) ?? Number.MAX_SAFE_INTEGER) : Number.MAX_SAFE_INTEGER
+    return ia - ib || a.id.localeCompare(b.id)
+  })
+  return {
+    id: baseId,
+    name: baseModel?.name ?? sorted[0]?.name ?? baseId.split('/').pop() ?? baseId,
+    apiModelId: baseModel?.apiModelId ?? (baseModel ? baseId : undefined),
+    requestBody: baseModel?.requestBody,
+    contextWindow: baseModel?.contextWindow ?? sorted[0]?.contextWindow ?? 200000,
+    reasoningEfforts: sorted.map((m) => splitModeSuffix(m.id)?.level).filter((l): l is string => Boolean(l)),
+    modes: sorted.map((m) => ({
+      level: splitModeSuffix(m.id)!.level,
+      apiModelId: m.apiModelId ?? m.id,
+      ...(m.name !== undefined ? { name: m.name.split('/').pop() ?? m.name } : {}),
+    })),
+  }
 }
 
 interface ModelConfig {
@@ -668,9 +698,11 @@ export function ProviderModal({
   const urlInputRef = useRef<HTMLInputElement>(null)
   const manualModelInputRef = useRef<HTMLInputElement>(null)
 
-  // Models that share a base id differing only by a mode suffix (e.g. OmniRoute's
-  // "gemini-3.6-flash-low/-medium/-high") can be merged into one model with mode
-  // chips. Derived from the fetched and user-added models.
+  // Models that were already merged into mode chips (have a `modes` map).
+  const mergedModeModels = useMemo(() => models.filter((m) => m.modes?.length), [models])
+  // Families of suffixed variants still present in the list — only non-empty
+  // after an Unmerge re-expands a merged model, so a Merge button appears then
+  // only (auto-collapse clears them at init/fetch).
   const mergeableGroups = useMemo(() => groupModeFamilies(models.filter((m) => splitModeSuffix(m.id))), [models])
 
   useEffect(() => {
@@ -721,39 +753,68 @@ export function ProviderModal({
     return models.filter((m) => terms.every((t) => m.id.toLowerCase().includes(t)))
   }
 
-  // Merge a mode-suffix family into a single model whose `modes` map each level
-  // to the concrete provider id. Keeps the base (un-suffixed) entry's metadata
-  // when present; otherwise derives it from the first member. The un-suffixed
-  // base variant, when it exists, is preserved as the merged model's fallback
-  // apiModelId — selecting the model with no chip active sends the plain id.
+  // Re-merge a detected suffixed family (present after an Unmerge) back into a
+  // single mode-chip model, migrating per-model configs and selection from the
+  // member ids onto the merged id so nothing is lost.
   function mergeModeFamily(baseId: string, members: ModelInfo[]) {
     const baseModel = models.find((m) => m.id === baseId)
-    const ordered = [...members].sort((a, b) => a.id.localeCompare(b.id))
-    const merged: ModelInfo = {
-      id: baseId,
-      // Display the path-stripped base id (e.g. "gemini-3.6-flash" from
-      // "antigravity/gemini-3.6-flash") so the picker never shows the whole
-      // provider path. The full id is still kept for the request.
-      name: baseModel?.name ?? ordered[0]?.name ?? baseId.split('/').pop() ?? baseId,
-      apiModelId: baseModel?.apiModelId ?? (baseModel ? baseId : undefined),
-      requestBody: baseModel?.requestBody,
-      contextWindow: baseModel?.contextWindow ?? ordered[0]?.contextWindow ?? 200000,
-      reasoningEfforts: ordered.map((m) => splitModeSuffix(m.id)?.level).filter((l): l is string => Boolean(l)),
-      modes: ordered.map((m) => ({
-        level: splitModeSuffix(m.id)!.level,
-        apiModelId: m.apiModelId ?? m.id,
-        ...(m.name !== undefined ? { name: m.name.split('/').pop() ?? m.name } : {}),
-      })),
-    }
-    const removedIds = new Set([baseId, ...ordered.map((m) => m.id)])
-    setModels((current) => [merged, ...current.filter((m) => !removedIds.has(m.id))])
-    // Preserve selections/configs on the merged id if any member was selected.
-    const anySelected = ordered.some((m) => selectedModelIds.has(m.id)) || selectedModelIds.has(baseId)
+    const merged = buildMergedModel(baseId, baseModel, members)
+    const removedIds = new Set(members.map((m) => m.id))
+    setModels((current) => [merged, ...current.filter((m) => !removedIds.has(m.id) && m.id !== baseId)])
+    // Migrate member configs onto the merged id.
+    setModelConfigs((current) => {
+      const next = { ...current }
+      for (const memberId of removedIds) {
+        const config = next[memberId]
+        if (config && !next[baseId]) next[baseId] = config
+        delete next[memberId]
+      }
+      return next
+    })
+    // If any member was selected, select the merged model.
+    const anySelected = [...removedIds].some((id) => selectedModelIds.has(id))
     if (anySelected) {
       setSelectedModelIds((current) => {
         const next = new Set(current)
         for (const id of removedIds) next.delete(id)
         next.add(baseId)
+        return next
+      })
+    }
+  }
+
+  // Expand a merged mode model back into its per-level members. Each entry in
+  // the model's `modes` becomes a distinct suffixed model; the merged (base)
+  // entry is removed. Any per-model config keyed on the merged id is cloned
+  // (per-member) onto each expanded member so no user settings are lost on
+  // unmerge and later per-level edits don't leak across members.
+  function unmergeModeFamily(merged: ModelInfo) {
+    if (!merged.modes?.length) return
+    const members: ModelInfo[] = merged.modes.map((mode) => ({
+      id: mode.apiModelId ?? merged.id,
+      ...(mode.name !== undefined ? { name: mode.name } : {}),
+      apiModelId: mode.apiModelId ?? merged.id,
+      contextWindow: merged.contextWindow,
+      ...(merged.requestBody !== undefined ? { requestBody: merged.requestBody } : {}),
+      ...(merged.supportsVision !== undefined ? { supportsVision: merged.supportsVision } : {}),
+    }))
+    setModels((current) => [...members, ...current.filter((m) => m.id !== merged.id)])
+    const mergedConfig = modelConfigs[merged.id]
+    if (mergedConfig) {
+      setModelConfigs((current) => {
+        const next = { ...current }
+        delete next[merged.id]
+        for (const member of members) next[member.id] = { ...mergedConfig }
+        return next
+      })
+    }
+    // If the merged model was selected, select its members; otherwise leave the
+    // selection untouched so the previously selected levels carry over.
+    if (selectedModelIds.has(merged.id)) {
+      setSelectedModelIds((current) => {
+        const next = new Set(current)
+        next.delete(merged.id)
+        for (const member of members) next.add(member.id)
         return next
       })
     }
@@ -869,13 +930,17 @@ export function ProviderModal({
     }
   }, [isOpen, initialStep, editProvider?.id, editModelId])
 
-  // Auto-fetch models when entering step 2
+  // Auto-fetch models when entering step 2. Preserved merged mode-chip models
+  // (from a saved provider) are kept intact by fetchModels — the raw catalog
+  // fetch filters out suffixed variants already claimed by a merged model, so
+  // newly-added catalog models still surface without clobbering merged state.
   useEffect(() => {
     const requiresAuthentication = Boolean(formAuthAdapter)
+    const onlyMergedInList = models.length > 0 && models.every((m) => m.modes?.length)
     if (
       formStep === 2 &&
       formUrl &&
-      models.length === 0 &&
+      (models.length === 0 || onlyMergedInList) &&
       !fetchingModels &&
       !fetchError &&
       (!requiresAuthentication || providerAuthState === 'connected')
@@ -994,7 +1059,10 @@ export function ProviderModal({
   async function fetchModels(url: string) {
     setFetchingModels(true)
     setFetchError(null)
-    setModels([])
+    // Preserve any already-merged mode-chip models and their configs so
+    // newly-fetched raw catalog data doesn't clobber user-collapsed families.
+    const preservedMerged = models.filter((m) => m.modes?.length)
+    setModels(preservedMerged)
     try {
       const params = new URLSearchParams({ url })
       if (formApiKey) params.set('apiKey', formApiKey)
@@ -1005,26 +1073,40 @@ export function ProviderModal({
       if (response.ok) {
         const data = (await response.json()) as { models: ModelInfo[]; url: string }
         if (data.models?.length) {
-          setModels(data.models)
-          setExpandedModelId(data.models[0]?.id ?? null)
-          const configs: Record<string, ModelConfig> = {}
-          for (const m of data.models) {
-            configs[m.id] = {
-              contextWindow: m.contextWindow,
-              supportsVision: m.supportsVision,
-              thinkingEnabled: true,
-              thinkingLevel: defaultReasoningEffort(m.reasoningEfforts),
-              defaultTemperature: (m as { defaultTemperature?: number }).defaultTemperature,
-              defaultTopP: (m as { defaultTopP?: number }).defaultTopP,
-              defaultTopK: (m as { defaultTopK?: number }).defaultTopK,
-              defaultMaxTokens: (m as { defaultMaxTokens?: number }).defaultMaxTokens,
+          // Suffixed catalog variants already represented by a preserved merged
+          // model must not reappear alongside it (mirrors the server-side
+          // `claimedByMergedModes` filter in provider-manager.ts).
+          const claimed = new Set<string>()
+          for (const merged of preservedMerged) {
+            for (const mode of merged.modes ?? []) {
+              if (mode.apiModelId) claimed.add(mode.apiModelId)
             }
           }
-          setModelConfigs(configs)
-          if (data.models.length === 1) {
-            setSelectedModelIds(new Set([data.models[0]!.id]))
-            setExpandedModelId(data.models[0]!.id)
-            runAutoConfig(data.models[0]!.id)
+          const filteredRaw = data.models.filter((m) => !claimed.has(m.id))
+          const combined = [...preservedMerged, ...filteredRaw]
+          setModels(combined)
+          setExpandedModelId(combined[0]?.id ?? null)
+          setModelConfigs((current) => {
+            const next: Record<string, ModelConfig> = { ...current }
+            for (const m of filteredRaw) {
+              if (next[m.id]) continue
+              next[m.id] = {
+                contextWindow: m.contextWindow,
+                supportsVision: m.supportsVision,
+                thinkingEnabled: true,
+                thinkingLevel: defaultReasoningEffort(m.reasoningEfforts),
+                defaultTemperature: (m as { defaultTemperature?: number }).defaultTemperature,
+                defaultTopP: (m as { defaultTopP?: number }).defaultTopP,
+                defaultTopK: (m as { defaultTopK?: number }).defaultTopK,
+                defaultMaxTokens: (m as { defaultMaxTokens?: number }).defaultMaxTokens,
+              }
+            }
+            return next
+          })
+          if (combined.length === 1) {
+            setSelectedModelIds(new Set([combined[0]!.id]))
+            setExpandedModelId(combined[0]!.id)
+            runAutoConfig(combined[0]!.id)
           }
         }
       } else {
@@ -1734,6 +1816,28 @@ export function ProviderModal({
                         </button>
                       )}
                     </div>
+
+                    {mergedModeModels.length > 0 && (
+                      <div className="mb-2 flex flex-wrap items-center gap-2 text-xs">
+                        <span className="text-text-secondary">
+                          {mergedModeModels.length} model
+                          {mergedModeModels.length > 1 ? 's are' : ' is'} merged into mode chips:
+                        </span>
+                        <div className="flex flex-wrap gap-2">
+                          {mergedModeModels.map((model) => (
+                            <button
+                              key={model.id}
+                              type="button"
+                              onClick={() => unmergeModeFamily(model)}
+                              className="px-2.5 py-1 rounded border border-border text-text-secondary hover:border-accent-primary/40 hover:text-accent-primary hover:bg-accent-primary/10 transition-colors"
+                            >
+                              Unmerge {model.name ?? model.id.split('/').pop()} (
+                              {model.modes!.map((mode) => mode.level).join(', ')})
+                            </button>
+                          ))}
+                        </div>
+                      </div>
+                    )}
 
                     {mergeableGroups.length > 0 && (
                       <div className="mb-2 flex flex-wrap items-center gap-2 text-xs">

--- a/web/src/components/shared/ProviderModal.tsx
+++ b/web/src/components/shared/ProviderModal.tsx
@@ -1,6 +1,6 @@
 import { ScrollArea } from './ScrollArea'
 import { Modal } from './Modal'
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef, useMemo } from 'react'
 import { authFetch } from '../../lib/api'
 import type { Backend } from '../../stores/config'
 import type { ModelConfig as SharedModelConfig } from '@shared/types.js'
@@ -10,6 +10,7 @@ import { formatTokens } from '../../lib/format-stats'
 import { shouldAutofocus } from '../../lib/device'
 import { REASONING_EFFORT_VALUES } from '../../lib/model-value'
 import { isSmallContext } from '../../lib/context-warning'
+import { groupModeFamilies, splitModeSuffix } from '@shared/reasoning-effort.js'
 
 const COMMON_PORTS = [8080, 11434, 8000, 1234]
 
@@ -667,6 +668,11 @@ export function ProviderModal({
   const urlInputRef = useRef<HTMLInputElement>(null)
   const manualModelInputRef = useRef<HTMLInputElement>(null)
 
+  // Models that share a base id differing only by a mode suffix (e.g. OmniRoute's
+  // "gemini-3.6-flash-low/-medium/-high") can be merged into one model with mode
+  // chips. Derived from the fetched and user-added models.
+  const mergeableGroups = useMemo(() => groupModeFamilies(models.filter((m) => splitModeSuffix(m.id))), [models])
+
   useEffect(() => {
     if (formStep === 1 && isOpen) {
       // Small delay to ensure the input is mounted
@@ -713,6 +719,44 @@ export function ProviderModal({
     if (!query.trim()) return models
     const terms = query.toLowerCase().split(/\s+/).filter(Boolean)
     return models.filter((m) => terms.every((t) => m.id.toLowerCase().includes(t)))
+  }
+
+  // Merge a mode-suffix family into a single model whose `modes` map each level
+  // to the concrete provider id. Keeps the base (un-suffixed) entry's metadata
+  // when present; otherwise derives it from the first member. The un-suffixed
+  // base variant, when it exists, is preserved as the merged model's fallback
+  // apiModelId — selecting the model with no chip active sends the plain id.
+  function mergeModeFamily(baseId: string, members: ModelInfo[]) {
+    const baseModel = models.find((m) => m.id === baseId)
+    const ordered = [...members].sort((a, b) => a.id.localeCompare(b.id))
+    const merged: ModelInfo = {
+      id: baseId,
+      // Display the path-stripped base id (e.g. "gemini-3.6-flash" from
+      // "antigravity/gemini-3.6-flash") so the picker never shows the whole
+      // provider path. The full id is still kept for the request.
+      name: baseModel?.name ?? ordered[0]?.name ?? baseId.split('/').pop() ?? baseId,
+      apiModelId: baseModel?.apiModelId ?? (baseModel ? baseId : undefined),
+      requestBody: baseModel?.requestBody,
+      contextWindow: baseModel?.contextWindow ?? ordered[0]?.contextWindow ?? 200000,
+      reasoningEfforts: ordered.map((m) => splitModeSuffix(m.id)?.level).filter((l): l is string => Boolean(l)),
+      modes: ordered.map((m) => ({
+        level: splitModeSuffix(m.id)!.level,
+        apiModelId: m.apiModelId ?? m.id,
+        ...(m.name !== undefined ? { name: m.name.split('/').pop() ?? m.name } : {}),
+      })),
+    }
+    const removedIds = new Set([baseId, ...ordered.map((m) => m.id)])
+    setModels((current) => [merged, ...current.filter((m) => !removedIds.has(m.id))])
+    // Preserve selections/configs on the merged id if any member was selected.
+    const anySelected = ordered.some((m) => selectedModelIds.has(m.id)) || selectedModelIds.has(baseId)
+    if (anySelected) {
+      setSelectedModelIds((current) => {
+        const next = new Set(current)
+        for (const id of removedIds) next.delete(id)
+        next.add(baseId)
+        return next
+      })
+    }
   }
 
   function addManualModel() {
@@ -1166,6 +1210,7 @@ export function ProviderModal({
         requestBody: m.requestBody,
         reasoningEfforts: modelConfigs[m.id]?.reasoningEfforts ?? m.reasoningEfforts,
         reasoningEffortOverride: modelConfigs[m.id]?.reasoningEffortOverride ?? m.reasoningEffortOverride,
+        modes: m.modes,
         contextWindow: modelConfigs[m.id]?.contextWindow ?? m.contextWindow,
         selected: selectedModelIds.has(m.id) || undefined,
         supportsVision: modelConfigs[m.id]?.supportsVision,
@@ -1689,6 +1734,38 @@ export function ProviderModal({
                         </button>
                       )}
                     </div>
+
+                    {mergeableGroups.length > 0 && (
+                      <div className="mb-2 flex flex-wrap items-center gap-2 text-xs">
+                        <span className="text-text-secondary">
+                          {mergeableGroups.length} model group{mergeableGroups.length > 1 ? 's' : ''} share the same
+                          base name with different modes:
+                        </span>
+                        <div className="flex flex-wrap gap-2">
+                          {mergeableGroups.map((group) => (
+                            <button
+                              key={group.baseId}
+                              type="button"
+                              onClick={() =>
+                                mergeModeFamily(
+                                  group.baseId,
+                                  group.members
+                                    .map((m) => models.find((x) => x.id === m.id))
+                                    .filter((m): m is ModelInfo => Boolean(m)),
+                                )
+                              }
+                              className="px-2.5 py-1 rounded border border-accent-primary/40 text-accent-primary hover:bg-accent-primary/10 transition-colors"
+                            >
+                              Merge {group.baseId.split('/').pop()}:{' '}
+                              {group.members
+                                .map((m) => splitModeSuffix(m.id)?.level)
+                                .filter(Boolean)
+                                .join(', ')}
+                            </button>
+                          ))}
+                        </div>
+                      </div>
+                    )}
 
                     <div className="flex items-center justify-between mb-2">
                       <p className="text-xs text-text-muted">


### PR DESCRIPTION
### Summary

Providers like OmniRoute expose one model as multiple distinct IDs differing only by a mode suffix (e.g. `gemini-3.6-flash-low`, `-medium`, `-high`). OpenFox previously listed them as separate models. This PR adds an **opt-in merge** action in the provider model config that collapses these into a single model with mode chips, and sends the correct provider ID per selected mode.

**What changed:**
- Added a `modes` field to `ModelConfig` (`{ level, apiModelId, name? }`).
- Shared helpers: `splitModeSuffix()`, `groupModeFamilies()`, `resolveModeModelId()`.
- `ProviderModal`: merge banner in the Available Models step + handler; merged model displays the **path-stripped base id** (e.g. `gemini-3.6-flash`, not `antigravity/gemini-3.6-flash`).
- Server (`provider-manager`, `transport-client`): resolve the active mode to its `apiModelId` at request time, and suppress the duplicated `reasoning_effort` for merged models.
- `model-list`: surface `modes` as `reasoningEfforts` so mode chips render in the provider picker.

**Behavior:**
- Merging is opt-in — unmerged duplicates remain separate until the user merges.
- The un-suffixed base variant is preserved as the merged model's fallback `apiModelId` when no chip is active.
- Selections and `modes` persist across provider re-saves.

### AI-Enhanced Development

Tell what models helped shape this PR:

- **AI Models:** DeepSeek V4 Flash, DeepSeek V4 Flash Vision Exp

_No AI used? Enter 'none'_

### Cache Impact

Does this PR affect anything cached — system prompts, tool definitions, skills, or other context?

- **No**

### Preview
<img width="690" height="813" alt="Screenshot 2026-08-26 at 10 03 22 AM" src="https://github.com/user-attachments/assets/73f2f3cd-682a-47c2-9cac-10404fea4726" />

