### PR TITLE
Add openfox-opencode-free plugin to registry and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Restart OpenFox after installing or updating a plugin.
 - To authenticate with a Google Antigravity account, you can install the [`openfox-google-antigravity`](https://github.com/JamesDAdams/openfox-google-antigravity) plugin.
 - To authenticate with an X (xAI) SuperGrok subscription, you can install the [`openfox-xai-supergrok`](https://github.com/Olgean-Group/openfox-xai-supergrok) plugin.
 - To use free OpenRouter models, you can install the [`openfox-openrouter-free`](https://github.com/JamesDAdams/openfox-openrouter-free) plugin.
+- To use free OpenCode models, you can install the [`openfox-opencode-free`](https://github.com/JamesDAdams/openfox-opencode-free) plugin.
 
 ## Screenshots
 

--- a/plugins-registry.json
+++ b/plugins-registry.json
@@ -28,5 +28,11 @@
     "displayName": "OpenRouter (Free Models)",
     "description": "OpenRouter provider filtered to include only free plans, with automatic hourly updates (once per hour) and 1-Click OAuth / API key authentication.",
     "githubUrl": "https://github.com/JamesDAdams/openfox-openrouter-free"
+  },
+  {
+    "name": "openfox-opencode-free",
+    "displayName": "OpenCode (Free Models)",
+    "description": "OpenCode provider filtered to free models only (-free suffix), with automatic hourly model updates (1x/hour) and API key auth.",
+    "githubUrl": "https://github.com/JamesDAdams/openfox-opencode-free"
   }
 ]


### PR DESCRIPTION
### Summary

Add the `openfox-opencode-free` provider plugin to the plugin registry and README:
- **plugins-registry.json**: new entry for `openfox-opencode-free` (displayName "OpenCode (Free Models)", English description, github URL).
- **README.md**: adds the plugin to the Plugins section under "To use free OpenCode models".

### AI-Enhanced Development

Tell what models helped shape this PR:

- **AI Models:** DeepSeek V4 Flash (vision)

### Cache Impact

Does this PR affect anything cached — system prompts, tool definitions, skills, or other context?

- **No**