### PR TITLE
fix(llm): apply OpenCode Go Responses routing on unknown backends too

### DIFF
--- a/src/server/llm/responses-routing.test.ts
+++ b/src/server/llm/responses-routing.test.ts
@@ -15,6 +15,15 @@ describe('resolveApiProtocol', () => {
     expect(resolveApiProtocol({ model: 'muse-spark-1.2-contributor', backend: 'opencode-go' })).toBe('responses')
   })
 
+  it('routes curated OpenCode Go models to responses on an unknown backend', () => {
+    // Providers created before the curated table existed (or added as "Other")
+    // carry backend 'unknown'; none of the local inference engines serve these
+    // ids, so the curated match still applies.
+    expect(resolveApiProtocol({ model: 'gpt-5.6-luna', backend: 'unknown' })).toBe('responses')
+    expect(resolveApiProtocol({ model: 'grok-4.6', backend: 'unknown' })).toBe('responses')
+    expect(resolveApiProtocol({ model: 'muse-spark-1.2-contributor', backend: 'unknown' })).toBe('responses')
+  })
+
   it('does NOT route responses-class models on backends that only speak chat completions', () => {
     expect(resolveApiProtocol({ model: 'gpt-5.6-luna', backend: 'vllm', profileApiProtocol: 'responses' })).toBe(
       'chat-completions',

--- a/src/server/llm/responses-routing.ts
+++ b/src/server/llm/responses-routing.ts
@@ -10,8 +10,10 @@
  *   `openai` backend, the gpt-5 family's profile marks it `responses`.
  * - OpenCode Go (https://opencode.ai/docs/go/) serves a subset of its catalog
  *   (gpt-5.6-luna, grok-4.6, muse-spark-1.2-contributor) only through the
- *   Responses API — the curated table below covers those, scoped to the
- *   `opencode-go` backend.
+ *   Responses API — the curated table below covers those, on the `opencode-go`
+ *   backend and, as a fallback, on `unknown` (providers created before the
+ *   backend was picked or added as "Other" still work; local inference engines
+ *   never serve these curated ids, so the fallback cannot mis-route them).
  *
  * The `/v1/responses` endpoint is OpenAI-specific: vLLM, Ollama, llama.cpp and
  * friends only speak chat completions, so a global model-name match would
@@ -68,14 +70,16 @@ function matchesRules(modelId: string, rules: ProtocolRule[]): ApiProtocol | und
 
 /**
  * Resolve the API protocol for a model on a given backend.
- * Explicit override > openai backend + profile protocol > opencode-go curated
- * table > chat completions.
+ * Explicit override > openai backend + profile protocol > OpenCode Go curated
+ * table (also applied on the 'unknown' backend, so providers created before the
+ * curated table existed keep working — local inference engines never serve
+ * these ids) > chat completions.
  */
 export function resolveApiProtocol(input: ProtocolResolutionInput): ApiProtocol {
   const { model, backend, profileApiProtocol, explicitApiProtocol } = input
   if (explicitApiProtocol) return explicitApiProtocol
   if (backend === 'openai' && profileApiProtocol) return profileApiProtocol
-  if (backend === 'opencode-go') {
+  if (backend === 'opencode-go' || backend === 'unknown') {
     const matched = matchesRules(model, OPENCODE_GO_RESPONSES_RULES)
     if (matched) return matched
   }


### PR DESCRIPTION
### Summary

Apply the OpenCode Go Responses-API routing table on `backend === 'unknown'` too.

The backend-aware refactor (c104613c) scoped the curated table to `opencode-go`, but providers created before it — or added with the backend left at its default — persist `backend: 'unknown'`. Their Responses-only models (`gpt-5.6-luna`, `grok-4.6`, `muse-spark-1.2-contributor`) then silently fell back to `/v1/chat/completions` and were rejected by the gateway (HTTP 400). Reproduced on a live Go subscription: same config, only `backend` differs → working / broken.

The curated ids are cloud-only model names that vLLM / SGLang / Ollama / llama.cpp / LM Studio never serve, so the fallback cannot mis-route a local model. `openai`, `anthropic` and explicit per-model overrides keep their precedence.

TDD: failing test `routes curated OpenCode Go models to responses on an unknown backend` first, then green.

### AI-Enhanced Development

Tell what models helped shape this PR:

- **AI Models:** GLM 5.3 Flash and GPT 5.6 Luna (via OpenFox agent sessions, OpenCode Go)

### Cache Impact

Does this PR affect anything cached — system prompts, tool definitions, skills, or other context?

- **No** — routing decision only; request payloads and prompts are unchanged.

## Testing

- `src/server/llm`: 240/240 pass, typecheck + lint + prettier clean
- Live OpenCode Go subscription: `createLLMClient` with `backend: 'opencode-go'` reports `usesResponsesApi: true` and Luna answers with correct usage; the fix restores this without requiring the config change