### PR TITLE
feat(plugins): add plugin settings modal and registration contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,54 @@ Restart OpenFox after installing or updating a plugin.
 - To use free OpenRouter models, you can install the [`openfox-openrouter-free`](https://github.com/JamesDAdams/openfox-openrouter-free) plugin.
 - To use free OpenCode models, you can install the [`openfox-opencode-free`](https://github.com/JamesDAdams/openfox-opencode-free) plugin.
 
+### Plugin Settings
+
+Plugins can expose custom configuration settings in the OpenFox UI by calling `registry.registerSettings` during plugin initialization or specifying `"hasSettings": true` under the `openfox` key in `package.json`:
+
+```typescript
+import type { ProviderPluginRegistry } from 'openfox'
+
+export function register(registry: ProviderPluginRegistry) {
+  registry.registerSettings({
+    title: 'My Plugin Settings',
+    description: 'Configure API options',
+    fields: [
+      {
+        key: 'apiKey',
+        label: 'API Key',
+        type: 'password', // 'text' | 'password' | 'number' | 'boolean' | 'select' | 'textarea'
+        required: true,
+      },
+    ],
+  })
+}
+```
+
+In `package.json`:
+
+```json
+{
+  "name": "my-openfox-plugin",
+  "version": "1.0.0",
+  "openfox": {
+    "apiVersion": 1,
+    "plugin": "dist/index.js",
+    "hasSettings": true
+  }
+}
+```
+
+Or for plugins rendering a custom UI:
+
+```typescript
+export function register(registry: ProviderPluginRegistry) {
+  registry.registerSettings({
+    title: 'Custom Plugin Settings',
+    customUiUrl: 'http://localhost:3000/plugin-settings-ui',
+  })
+}
+```
+
 ## Screenshots
 
 _Homepage — Project overview and session history_

--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -98,6 +98,37 @@ export interface ProviderPluginRuntime {
 }
 
 // ============================================================================
+// Plugin Settings Types
+// ============================================================================
+
+export type PluginSettingFieldType = 'text' | 'password' | 'number' | 'boolean' | 'select' | 'textarea'
+
+export interface PluginSettingOption {
+  label: string
+  value: string
+}
+
+export interface PluginSettingField {
+  key: string
+  label: string
+  type: PluginSettingFieldType
+  description?: string
+  defaultValue?: string | number | boolean
+  options?: PluginSettingOption[]
+  placeholder?: string
+  required?: boolean
+}
+
+export interface PluginSettingsSpec {
+  title?: string
+  description?: string
+  fields?: PluginSettingField[]
+  customUiUrl?: string
+  getSettings?: () => Promise<Record<string, unknown>> | Record<string, unknown>
+  saveSettings?: (values: Record<string, unknown>) => Promise<void> | void
+}
+
+// ============================================================================
 // Plugin Registry (passed to plugins during registration)
 // ============================================================================
 
@@ -105,6 +136,8 @@ export interface ProviderPluginRegistry {
   registerAuth(adapter: ProviderAuthAdapter): void
   registerTransport(adapter: ProviderTransportAdapter): void
   registerPreset(preset: ProviderPreset): void
+  registerSettings(spec: PluginSettingsSpec): void
+  registerSettingsForPlugin(packageName: string, spec: PluginSettingsSpec): void
   readonly runtime: ProviderPluginRuntime
 }
 
@@ -138,6 +171,8 @@ export interface ProviderPluginManifest {
   name: string
   /** Semver version string. */
   version: string
+  /** Whether the plugin provides a settings page / configuration. */
+  hasSettings?: boolean
   /** Auth adapters this plugin provides. */
   authAdapters: PluginAuthDescriptor[]
   /** Transport adapters this plugin provides. */

--- a/src/server/llm/proxy.test.ts
+++ b/src/server/llm/proxy.test.ts
@@ -36,11 +36,18 @@ vi.mock('undici', () => {
   }
 })
 
+const { mockNativeFetch } = vi.hoisted(() => {
+  const fn = vi.fn().mockImplementation(() => Promise.resolve(new Response('native-ok')))
+  globalThis.fetch = fn
+  return { mockNativeFetch: fn }
+})
+
 import { __resetProxyCache } from './proxy.js'
 
 describe('global fetch override', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockNativeFetch.mockImplementation(() => Promise.resolve(new Response('native-ok')))
     mockProxyAgentInstances.length = 0
     __resetProxyCache()
   })
@@ -51,6 +58,7 @@ describe('global fetch override', () => {
     const result = await fetch('http://example.com')
 
     expect(result).toBeInstanceOf(Response)
+    expect(mockNativeFetch).toHaveBeenCalledWith('http://example.com', undefined)
     expect(mockUndiciFetch).not.toHaveBeenCalled()
   })
 
@@ -60,6 +68,7 @@ describe('global fetch override', () => {
     const result = await fetch('http://example.com')
 
     expect(result).toBeInstanceOf(Response)
+    expect(mockNativeFetch).toHaveBeenCalledWith('http://example.com', undefined)
     expect(mockUndiciFetch).not.toHaveBeenCalled()
   })
 

--- a/src/server/providers/plugins/loader.ts
+++ b/src/server/providers/plugins/loader.ts
@@ -14,6 +14,7 @@ export interface ProviderPluginDiagnostic {
   version?: string
   source: string
   loaded: boolean
+  hasSettings?: boolean
   authAdapters: string[]
   transportAdapters: string[]
   presets: string[]
@@ -105,6 +106,13 @@ export async function loadProviderPlugins(options: {
         registerPreset(preset) {
           options.registry.registerPreset(preset)
           diagnostic.presets.push(preset.id)
+        },
+        registerSettings(spec) {
+          diagnostic.hasSettings = true
+          options.registry.registerSettingsForPlugin(packageName, spec)
+        },
+        registerSettingsForPlugin(packageName, spec) {
+          options.registry.registerSettingsForPlugin(packageName, spec)
         },
       }
       try {

--- a/src/server/providers/plugins/registry.ts
+++ b/src/server/providers/plugins/registry.ts
@@ -1,5 +1,6 @@
 import type { Provider } from '../../../shared/types.js'
 import type {
+  PluginSettingsSpec,
   ProviderAuthAdapter,
   ProviderPluginRegistry,
   ProviderPluginRuntime,
@@ -11,6 +12,7 @@ export class ProviderRegistry implements ProviderPluginRegistry {
   private readonly authAdapters = new Map<string, ProviderAuthAdapter>()
   private readonly transportAdapters = new Map<string, ProviderTransportAdapter>()
   private readonly presets = new Map<string, ProviderPreset>()
+  private readonly pluginSettingsSpecs = new Map<string, PluginSettingsSpec>()
 
   constructor(readonly runtime: ProviderPluginRuntime) {}
 
@@ -24,6 +26,19 @@ export class ProviderRegistry implements ProviderPluginRegistry {
 
   registerPreset(preset: ProviderPreset): void {
     this.register(this.presets, preset.id, preset, 'preset')
+  }
+
+  registerSettings(spec: PluginSettingsSpec): void {
+    // Note: registerSettings can be bound to a specific plugin when registered via trackingRegistry
+    this.registerSettingsForPlugin('_global', spec)
+  }
+
+  registerSettingsForPlugin(packageName: string, spec: PluginSettingsSpec): void {
+    this.pluginSettingsSpecs.set(packageName, spec)
+  }
+
+  getPluginSettingsSpec(packageName: string): PluginSettingsSpec | undefined {
+    return this.pluginSettingsSpecs.get(packageName)
   }
 
   getAuth(id?: string): ProviderAuthAdapter | undefined {

--- a/src/server/routes/plugins.test.ts
+++ b/src/server/routes/plugins.test.ts
@@ -6,6 +6,18 @@ import { tmpdir } from 'node:os'
 import { createPluginRoutes } from './plugins.js'
 import { ProviderRegistry } from '../providers/plugins/registry.js'
 import type { ProviderPluginDiagnostic } from '../providers/plugins/index.js'
+import { closeDatabase, initDatabase } from '../db/index.js'
+import { loadConfig } from '../config.js'
+import { SETTINGS_KEYS, setSetting } from '../db/settings.js'
+
+let mockConfigDir = ''
+vi.mock('../../cli/paths.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../cli/paths.js')>()
+  return {
+    ...actual,
+    getGlobalConfigDir: () => mockConfigDir || actual.getGlobalConfigDir('test'),
+  }
+})
 
 function createApp(options?: Partial<Parameters<typeof createPluginRoutes>[0]>) {
   const app = express()
@@ -37,7 +49,12 @@ describe('plugin routes', () => {
   let baseUrl: string
 
   beforeEach(async () => {
+    closeDatabase()
+    const cfg = loadConfig()
+    cfg.database.path = ':memory:'
+    initDatabase(cfg)
     rootDir = await mkdtemp(join(tmpdir(), 'openfox-plugins-'))
+    mockConfigDir = rootDir
     const { app } = createApp({
       config: { mode: 'test', providers: [] } as any,
     })
@@ -118,6 +135,91 @@ describe('plugin routes', () => {
       expect(res.status).toBe(200)
       const body = (await res.json()) as { installed: unknown[] }
       expect(body).toEqual({ installed: [] })
+    })
+  })
+
+  describe('GET /:name/settings and POST /:name/settings', () => {
+    it('returns settings spec and saved values', async () => {
+      const appWithSpec = createApp({
+        config: { mode: 'test', providers: [] } as any,
+      })
+      appWithSpec.providerAdapters.registerSettingsForPlugin('test-plugin', {
+        title: 'Test Plugin Settings',
+        description: 'Configure test plugin options',
+        fields: [
+          { key: 'apiKey', label: 'API Key', type: 'password', required: true },
+          { key: 'enableFeature', label: 'Enable Feature', type: 'boolean', defaultValue: true },
+        ],
+      })
+      const lServer = appWithSpec.app.listen(0)
+      const lUrl = `http://localhost:${(lServer.address() as { port: number }).port}`
+
+      try {
+        const resGet1 = await fetch(`${lUrl}/api/plugins/test-plugin/settings`)
+        expect(resGet1.status).toBe(200)
+        const bodyGet1 = (await resGet1.json()) as {
+          name: string
+          hasSpec: boolean
+          spec: any
+          values: Record<string, unknown>
+        }
+        expect(bodyGet1.hasSpec).toBe(true)
+        expect(bodyGet1.spec.title).toBe('Test Plugin Settings')
+        expect(bodyGet1.values['enableFeature']).toBe(true)
+
+        const resPost = await fetch(`${lUrl}/api/plugins/test-plugin/settings`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ values: { apiKey: 'secret123', enableFeature: false } }),
+        })
+        expect(resPost.status).toBe(200)
+        const bodyPost = (await resPost.json()) as { success: boolean; values: Record<string, unknown> }
+        expect(bodyPost.success).toBe(true)
+        expect(bodyPost.values).toEqual({ apiKey: 'secret123', enableFeature: false })
+
+        const resGet2 = await fetch(`${lUrl}/api/plugins/test-plugin/settings`)
+        const bodyGet2 = (await resGet2.json()) as { values: Record<string, unknown>; configuredKeys: string[] }
+        // password field must not be echoed back on GET
+        expect(bodyGet2.values).toEqual({ enableFeature: false })
+        expect(bodyGet2.configuredKeys).toEqual(['apiKey'])
+
+        // Updating other settings without re-sending password should succeed
+        const resPost2 = await fetch(`${lUrl}/api/plugins/test-plugin/settings`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ values: { enableFeature: true } }),
+        })
+        expect(resPost2.status).toBe(200)
+      } finally {
+        lServer.close()
+      }
+    })
+
+    it('returns translated error message when required field is missing in French locale', async () => {
+      setSetting(SETTINGS_KEYS.DISPLAY_LOCALE, 'fr')
+      const appWithSpec = createApp({
+        config: { mode: 'test', providers: [] } as any,
+      })
+      appWithSpec.providerAdapters.registerSettingsForPlugin('test-fr-plugin', {
+        title: 'Settings FR',
+        fields: [{ key: 'apiKey', label: 'Clé API', type: 'password', required: true }],
+      })
+      const lServer = appWithSpec.app.listen(0)
+      const lUrl = `http://localhost:${(lServer.address() as { port: number }).port}`
+
+      try {
+        const resPost = await fetch(`${lUrl}/api/plugins/test-fr-plugin/settings`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ values: {} }),
+        })
+        expect(resPost.status).toBe(400)
+        const body = (await resPost.json()) as { error: string }
+        expect(body.error).toBe('Clé API est requis')
+      } finally {
+        setSetting(SETTINGS_KEYS.DISPLAY_LOCALE, 'en')
+        lServer.close()
+      }
     })
   })
 

--- a/src/server/routes/plugins.ts
+++ b/src/server/routes/plugins.ts
@@ -12,6 +12,7 @@ import { isDirectoryEntry } from '../utils/fs.js'
 import type { ProviderRegistry } from '../providers/plugins/registry.js'
 import type { Config } from '../../shared/types.js'
 import { serverT } from '../i18n.js'
+import { getSetting, setSetting } from '../db/settings.js'
 
 interface Logger {
   debug: (message: string, context?: Record<string, unknown>) => void
@@ -23,6 +24,29 @@ interface Logger {
 import { openFolder } from '../utils/openFolder.js'
 
 const execFileP = promisify(execFile)
+
+function readPluginSettings(
+  name: string,
+  spec: ReturnType<ProviderRegistry['getPluginSettingsSpec']>,
+): Record<string, unknown> {
+  const raw = getSetting(`plugin_settings:${name}`)
+  if (raw) {
+    try {
+      return JSON.parse(raw) as Record<string, unknown>
+    } catch {
+      return {}
+    }
+  }
+  const defaults: Record<string, unknown> = {}
+  if (spec?.fields) {
+    for (const field of spec.fields) {
+      if (field.defaultValue !== undefined) {
+        defaults[field.key] = field.defaultValue
+      }
+    }
+  }
+  return defaults
+}
 
 async function openFolderRoute(
   dir: string,
@@ -49,6 +73,14 @@ export function createPluginRoutes(options: {
   const { config, providerAdapters, pluginDiagnostics, logger } = options
 
   let registryCache: { data: unknown; ts: number } | null = null
+
+  router.param('name', (_req, res, next, name) => {
+    if (!/^[a-zA-Z0-9_-]+$/.test(name)) {
+      res.status(400).json({ error: serverT({ en: 'Invalid plugin name', fr: 'Nom de plugin invalide' }) })
+      return
+    }
+    next()
+  })
 
   router.get('/registry', async (_req, res) => {
     try {
@@ -135,11 +167,13 @@ export function createPluginRoutes(options: {
         logger.error('Plugin build failed', { repoName, error: String(err) })
       }
 
+      let hasSettings = false
       if (!loadError) {
         try {
           const manifest = JSON.parse(await readFile(join(targetDir, 'package.json'), 'utf8'))
           const pluginEntry = manifest.openfox?.plugin as string | undefined
           const apiVersion = manifest.openfox?.apiVersion as number | undefined
+          if (manifest.openfox?.hasSettings) hasSettings = true
 
           if (!pluginEntry || !manifest.name) {
             loadError = serverT({
@@ -187,6 +221,15 @@ export function createPluginRoutes(options: {
                   providerAdapters.registerPreset(preset)
                   diagnostic.presets.push(preset.id)
                 },
+                registerSettings(spec) {
+                  diagnostic.hasSettings = true
+                  hasSettings = true
+                  providerAdapters.registerSettingsForPlugin(manifest.name, spec)
+                },
+                registerSettingsForPlugin(packageName, spec) {
+                  hasSettings = true
+                  providerAdapters.registerSettingsForPlugin(packageName, spec)
+                },
               }
               await mod.register(trackingRegistry)
               diagnostic.loaded = true
@@ -204,7 +247,7 @@ export function createPluginRoutes(options: {
         }
       }
 
-      res.json({ success: true, loaded, loadError, path: targetDir })
+      res.json({ success: true, loaded, loadError, path: targetDir, hasSettings })
     } catch (err) {
       await rm(tmpDir, { recursive: true, force: true })
       const msg = err instanceof Error ? err.message : serverT({ en: 'Clone failed', fr: 'Échec du clonage' })
@@ -217,23 +260,163 @@ export function createPluginRoutes(options: {
     const pluginsDir = join(getGlobalConfigDir(config.mode ?? 'production'), 'plugins')
     try {
       const entries = await readdir(pluginsDir, { withFileTypes: true })
-      const installed: { name: string; version: string | null }[] = []
+      const installed: { name: string; version: string | null; hasSettings: boolean }[] = []
       for (const entry of entries) {
         if (!(await isDirectoryEntry(pluginsDir, entry))) continue
         const pkgPath = join(pluginsDir, entry.name, 'package.json')
         let version: string | null = null
+        let hasSettingsInPkg = false
         try {
           const pkg = JSON.parse(await readFile(pkgPath, 'utf8'))
           version = (pkg.version as string) ?? null
+          hasSettingsInPkg = Boolean(pkg.openfox?.hasSettings)
         } catch {
           // ignore if package.json not found or invalid
         }
-        installed.push({ name: entry.name, version })
+        const hasRegisteredSettings = Boolean(providerAdapters.getPluginSettingsSpec(entry.name))
+        const diag = pluginDiagnostics.find((d) => d.packageName === entry.name)
+        const hasSettings = hasSettingsInPkg || hasRegisteredSettings || Boolean(diag?.hasSettings)
+        installed.push({ name: entry.name, version, hasSettings })
       }
       res.json({ installed })
     } catch {
       res.json({ installed: [] })
     }
+  })
+
+  router.get('/:name/settings', async (req, res) => {
+    const name = req.params.name as string
+    const spec = providerAdapters.getPluginSettingsSpec(name)
+    let values: Record<string, unknown> = {}
+
+    if (spec?.getSettings) {
+      try {
+        values = (await spec.getSettings()) ?? {}
+      } catch (err) {
+        logger.error('Failed to get plugin settings from plugin callback', { name, error: String(err) })
+      }
+    } else {
+      values = readPluginSettings(name, spec)
+    }
+
+    const clientSpec = spec
+      ? {
+          title: spec.title,
+          description: spec.description,
+          fields: spec.fields,
+          customUiUrl: spec.customUiUrl,
+        }
+      : null
+
+    // Never echo password-type values back to the client. They are stored server-side
+    // and only updated on POST when the client sends a non-empty value.
+    const safeValues: Record<string, unknown> = { ...values }
+    const configuredKeys: string[] = []
+    if (spec?.fields) {
+      for (const field of spec.fields) {
+        if (field.type === 'password') {
+          if (values[field.key]) {
+            configuredKeys.push(field.key)
+          }
+          delete safeValues[field.key]
+        }
+      }
+    }
+
+    res.json({
+      name,
+      hasSpec: Boolean(spec),
+      spec: clientSpec,
+      values: safeValues,
+      configuredKeys,
+    })
+  })
+
+  router.post('/:name/settings', async (req, res) => {
+    const name = req.params.name as string
+    const { values } = req.body as { values?: Record<string, unknown> }
+    if (!values || typeof values !== 'object') {
+      return res
+        .status(400)
+        .json({ error: serverT({ en: 'values object is required', fr: 'L’objet values est requis' }) })
+    }
+
+    const spec = providerAdapters.getPluginSettingsSpec(name)
+
+    let existingValues: Record<string, unknown> = {}
+    const raw = getSetting(`plugin_settings:${name}`)
+    if (raw) {
+      try {
+        existingValues = JSON.parse(raw) as Record<string, unknown>
+      } catch {
+        existingValues = {}
+      }
+    }
+
+    // Server-side required-field validation
+    if (spec?.fields) {
+      for (const field of spec.fields) {
+        if (!field.required) continue
+        const v = values[field.key]
+        if (field.type === 'boolean') {
+          if (v === undefined || v === null) {
+            return res.status(400).json({
+              error: serverT({ en: '{{label}} is required', fr: '{{label}} est requis' }, { label: field.label }),
+            })
+          }
+        } else if (field.type === 'password') {
+          const hasExisting = Boolean(existingValues[field.key])
+          if (!hasExisting && (v === undefined || v === null || v === '')) {
+            return res.status(400).json({
+              error: serverT({ en: '{{label}} is required', fr: '{{label}} est requis' }, { label: field.label }),
+            })
+          }
+        } else {
+          if (v === undefined || v === null || v === '') {
+            return res.status(400).json({
+              error: serverT({ en: '{{label}} is required', fr: '{{label}} est requis' }, { label: field.label }),
+            })
+          }
+        }
+      }
+    }
+
+    // Merge with existing stored values so empty password fields keep their previous secret
+    let mergedValues = values
+    if (spec?.fields && spec.fields.some((f) => f.type === 'password')) {
+      if (raw) {
+        try {
+          mergedValues = { ...existingValues }
+          for (const [k, v] of Object.entries(values)) {
+            // Only overwrite the stored secret when the client sends a non-empty value
+            if (spec.fields.find((f) => f.key === k)?.type === 'password' && (v === '' || v === null)) {
+              continue
+            }
+            mergedValues[k] = v
+          }
+        } catch {
+          mergedValues = values
+        }
+      }
+    }
+
+    setSetting(`plugin_settings:${name}`, JSON.stringify(mergedValues))
+
+    if (spec?.saveSettings) {
+      try {
+        await spec.saveSettings(mergedValues)
+      } catch (err) {
+        logger.error('Failed to save plugin settings via plugin callback', { name, error: String(err) })
+        return res.status(500).json({
+          error:
+            err instanceof Error
+              ? err.message
+              : serverT({ en: 'Save settings failed', fr: 'Échec de l’enregistrement des paramètres' }),
+        })
+      }
+    }
+
+    res.json({ success: true, values: mergedValues })
   })
 
   router.get('/open-folder', async (_req, res) => {
@@ -243,17 +426,12 @@ export function createPluginRoutes(options: {
 
   router.get('/:name/open-folder', async (req, res) => {
     const name = req.params.name as string
-    if (!/^[a-zA-Z0-9_-]+$/.test(name))
-      return res.status(400).json({ error: serverT({ en: 'Invalid plugin name', fr: 'Nom de plugin invalide' }) })
     const targetDir = join(getGlobalConfigDir(config.mode ?? 'production'), 'plugins', name)
     await openFolderRoute(targetDir, res)
   })
 
   router.delete('/:name', async (req, res) => {
     const name = req.params.name as string
-    if (!/^[a-zA-Z0-9_-]+$/.test(name)) {
-      return res.status(400).json({ error: serverT({ en: 'Invalid plugin name', fr: 'Nom de plugin invalide' }) })
-    }
     const targetDir = join(getGlobalConfigDir(config.mode ?? 'production'), 'plugins', name)
     try {
       await rm(targetDir, { recursive: true, force: true })

--- a/web/src/components/settings/PluginSettingsModal.test.tsx
+++ b/web/src/components/settings/PluginSettingsModal.test.tsx
@@ -1,0 +1,234 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { PluginSettingsModal } from './PluginSettingsModal'
+import { setLocale } from '@shared/i18n/index.js'
+
+const mockFetch = vi.fn()
+vi.mock('../../lib/api', () => ({
+  authFetch: (...args: Parameters<typeof fetch>) => mockFetch(...args),
+}))
+
+function createJsonResponse(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+describe('PluginSettingsModal', () => {
+  beforeEach(() => {
+    setLocale('en')
+    mockFetch.mockReset()
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('renders settings fields and saves changes', async () => {
+    mockFetch.mockResolvedValueOnce(
+      createJsonResponse({
+        hasSpec: true,
+        spec: {
+          title: 'ChatGPT Plugin Settings',
+          description: 'Configure API settings',
+          fields: [
+            { key: 'apiKey', label: 'API Key', type: 'password', required: true },
+            { key: 'enableStream', label: 'Stream Responses', type: 'boolean', defaultValue: true },
+          ],
+        },
+        values: { enableStream: true },
+      }),
+    )
+
+    const onClose = vi.fn()
+    render(
+      <PluginSettingsModal isOpen={true} onClose={onClose} pluginName="openfox-chatgpt" pluginDisplayName="ChatGPT" />,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('ChatGPT Plugin Settings')).toBeDefined()
+    })
+    expect(screen.getByText('Configure API settings')).toBeDefined()
+    expect(screen.getByText('API Key')).toBeDefined()
+
+    const passwordInput = screen.getByLabelText('API Key *') as HTMLInputElement
+    expect(passwordInput.value).toBe('')
+
+    await userEvent.setup().type(passwordInput, 'sk-456')
+
+    mockFetch.mockResolvedValueOnce(
+      createJsonResponse({ success: true, values: { apiKey: 'sk-456', enableStream: true } }),
+    )
+
+    const saveButton = screen.getByRole('button', { name: 'Save Settings' })
+    await userEvent.setup().click(saveButton)
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/api/plugins/openfox-chatgpt/settings',
+        expect.objectContaining({
+          method: 'POST',
+        }),
+      )
+    })
+  })
+
+  it('blocks save when a required field is empty', async () => {
+    mockFetch.mockResolvedValueOnce(
+      createJsonResponse({
+        hasSpec: true,
+        spec: {
+          title: 'Required Plugin Settings',
+          fields: [{ key: 'apiKey', label: 'API Key', type: 'password', required: true }],
+        },
+        values: {},
+      }),
+    )
+
+    render(
+      <PluginSettingsModal isOpen={true} onClose={vi.fn()} pluginName="openfox-req" pluginDisplayName="Required" />,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Required Plugin Settings')).toBeDefined()
+    })
+
+    const saveButton = screen.getByRole('button', { name: 'Save Settings' })
+    await userEvent.setup().click(saveButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('API Key is required')).toBeDefined()
+    })
+    expect(mockFetch).not.toHaveBeenCalledWith(
+      '/api/plugins/openfox-req/settings',
+      expect.objectContaining({ method: 'POST' }),
+    )
+  })
+
+  it('renders custom UI iframe when customUiUrl is set', async () => {
+    mockFetch.mockResolvedValueOnce(
+      createJsonResponse({
+        hasSpec: true,
+        spec: {
+          title: 'Custom Plugin Settings',
+          customUiUrl: 'http://localhost:3000/plugin-ui',
+        },
+        values: {},
+      }),
+    )
+
+    render(
+      <PluginSettingsModal isOpen={true} onClose={vi.fn()} pluginName="openfox-custom" pluginDisplayName="Custom" />,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTitle('Custom Custom UI')).toBeDefined()
+    })
+  })
+
+  it('renders translated French labels in fr locale', async () => {
+    setLocale('fr')
+    mockFetch.mockResolvedValueOnce(
+      createJsonResponse({
+        hasSpec: true,
+        spec: {
+          title: 'Paramètres du plugin',
+          fields: [{ key: 'apiKey', label: 'Clé API', type: 'password', required: true }],
+        },
+        values: {},
+      }),
+    )
+
+    render(
+      <PluginSettingsModal isOpen={true} onClose={vi.fn()} pluginName="openfox-fr" pluginDisplayName="MonPlugin" />,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Paramètres du plugin')).toBeDefined()
+    })
+
+    expect(screen.getByRole('button', { name: 'Annuler' })).toBeDefined()
+    expect(screen.getByRole('button', { name: 'Enregistrer les paramètres' })).toBeDefined()
+
+    const saveButton = screen.getByRole('button', { name: 'Enregistrer les paramètres' })
+    await userEvent.setup().click(saveButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('Clé API est requis')).toBeDefined()
+    })
+  })
+
+  it('allows saving when required password was already configured', async () => {
+    mockFetch.mockResolvedValueOnce(
+      createJsonResponse({
+        hasSpec: true,
+        spec: {
+          title: 'Configured Plugin Settings',
+          fields: [
+            { key: 'apiKey', label: 'API Key', type: 'password', required: true },
+            { key: 'port', label: 'Port', type: 'number', required: true },
+          ],
+        },
+        values: { port: 8080 },
+        configuredKeys: ['apiKey'],
+      }),
+    )
+
+    render(
+      <PluginSettingsModal isOpen={true} onClose={vi.fn()} pluginName="openfox-conf" pluginDisplayName="ConfPlugin" />,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('(configured)')).toBeDefined()
+    })
+
+    mockFetch.mockResolvedValueOnce(createJsonResponse({ success: true, values: { port: 9000 } }))
+
+    const saveButton = screen.getByRole('button', { name: 'Save Settings' })
+    await userEvent.setup().click(saveButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('Settings saved successfully!')).toBeDefined()
+      expect(screen.getByText('Close')).toBeDefined()
+    })
+  })
+
+  it('allows saving when required boolean field is false', async () => {
+    mockFetch.mockResolvedValueOnce(
+      createJsonResponse({
+        hasSpec: true,
+        spec: {
+          title: 'Boolean Plugin Settings',
+          fields: [{ key: 'enabled', label: 'Enable Feature', type: 'boolean', required: true }],
+        },
+        values: { enabled: false },
+      }),
+    )
+
+    render(
+      <PluginSettingsModal isOpen={true} onClose={vi.fn()} pluginName="openfox-bool" pluginDisplayName="BoolPlugin" />,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Enable Feature')).toBeDefined()
+    })
+
+    mockFetch.mockResolvedValueOnce(createJsonResponse({ success: true, values: { enabled: false } }))
+
+    const saveButton = screen.getByRole('button', { name: 'Save Settings' })
+    await userEvent.setup().click(saveButton)
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/api/plugins/openfox-bool/settings',
+        expect.objectContaining({ method: 'POST' }),
+      )
+    })
+  })
+})

--- a/web/src/components/settings/PluginSettingsModal.tsx
+++ b/web/src/components/settings/PluginSettingsModal.tsx
@@ -1,0 +1,340 @@
+import { useState, useEffect, useCallback } from 'react'
+import { authFetch } from '../../lib/api'
+import { useT } from '../../hooks/useT'
+import { Modal } from '../shared/Modal'
+import { Button } from '../shared/Button'
+import type { PluginSettingField, PluginSettingsSpec } from '../../lib/pluginSettings'
+
+export interface PluginSettingsModalProps {
+  isOpen: boolean
+  onClose: () => void
+  pluginName: string
+  pluginDisplayName: string
+}
+
+export function PluginSettingsModal({ isOpen, onClose, pluginName, pluginDisplayName }: PluginSettingsModalProps) {
+  const t = useT()
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [successMsg, setSuccessMsg] = useState<string | null>(null)
+  const [spec, setSpec] = useState<PluginSettingsSpec | null>(null)
+  const [values, setValues] = useState<Record<string, unknown>>({})
+  const [configuredKeys, setConfiguredKeys] = useState<string[]>([])
+  const [rawJson, setRawJson] = useState<string>('{}')
+
+  const fetchSettings = useCallback(async () => {
+    if (!isOpen || !pluginName) return
+    setLoading(true)
+    setError(null)
+    setSuccessMsg(null)
+    try {
+      const res = await authFetch(`/api/plugins/${encodeURIComponent(pluginName)}/settings`)
+      if (!res.ok) {
+        throw new Error(
+          t(
+            {
+              en: 'Failed to load settings (HTTP {{status}})',
+              fr: 'Échec du chargement des paramètres (HTTP {{status}})',
+            },
+            { status: String(res.status) },
+          ),
+        )
+      }
+      const data = (await res.json()) as {
+        hasSpec: boolean
+        spec: PluginSettingsSpec | null
+        values: Record<string, unknown>
+        configuredKeys?: string[]
+      }
+      setSpec(data.spec)
+      setValues(data.values ?? {})
+      setConfiguredKeys(data.configuredKeys ?? [])
+      setRawJson(JSON.stringify(data.values ?? {}, null, 2))
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : t({ en: 'Error loading plugin settings', fr: 'Erreur lors du chargement des paramètres du plugin' }),
+      )
+    } finally {
+      setLoading(false)
+    }
+  }, [isOpen, pluginName, t])
+
+  useEffect(() => {
+    if (isOpen) {
+      fetchSettings()
+    }
+  }, [isOpen, fetchSettings])
+
+  const handleFieldValueChange = (key: string, val: unknown) => {
+    setValues((prev) => ({ ...prev, [key]: val }))
+  }
+
+  const validateRequired = (): string | null => {
+    if (!spec?.fields) return null
+    for (const field of spec.fields) {
+      if (!field.required) continue
+      const v = values[field.key]
+      if (field.type === 'password') {
+        const hasNew = v !== undefined && v !== null && v !== ''
+        const hasExisting = configuredKeys.includes(field.key)
+        if (!hasNew && !hasExisting) {
+          return t({ en: '{{label}} is required', fr: '{{label}} est requis' }, { label: field.label })
+        }
+      } else if (field.type === 'boolean') {
+        if (typeof v !== 'boolean' && v !== true && v !== false) {
+          return t({ en: '{{label}} is required', fr: '{{label}} est requis' }, { label: field.label })
+        }
+      } else if (v === undefined || v === null || v === '') {
+        return t({ en: '{{label}} is required', fr: '{{label}} est requis' }, { label: field.label })
+      }
+    }
+    return null
+  }
+
+  const handleSave = async () => {
+    setSaving(true)
+    setError(null)
+    setSuccessMsg(null)
+    try {
+      let payloadValues = values
+      if (!spec?.fields || spec.fields.length === 0) {
+        try {
+          payloadValues = JSON.parse(rawJson)
+        } catch {
+          throw new Error(t({ en: 'Invalid JSON settings format', fr: 'Format JSON des paramètres invalide' }))
+        }
+      } else {
+        const requiredError = validateRequired()
+        if (requiredError) throw new Error(requiredError)
+      }
+
+      const res = await authFetch(`/api/plugins/${encodeURIComponent(pluginName)}/settings`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ values: payloadValues }),
+      })
+      const data = await res.json()
+      if (!res.ok) {
+        throw new Error(
+          data.error ?? t({ en: 'Failed to save settings', fr: 'Échec de l’enregistrement des paramètres' }),
+        )
+      }
+      setValues(payloadValues)
+      const newConfigured = [...configuredKeys]
+      if (spec?.fields) {
+        for (const field of spec.fields) {
+          if (field.type === 'password' && payloadValues[field.key]) {
+            if (!newConfigured.includes(field.key)) newConfigured.push(field.key)
+          }
+        }
+      }
+      setConfiguredKeys(newConfigured)
+      setSuccessMsg(t({ en: 'Settings saved successfully!', fr: 'Paramètres enregistrés avec succès !' }))
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : t({ en: 'Failed to save settings', fr: 'Échec de l’enregistrement des paramètres' }),
+      )
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const renderField = (field: PluginSettingField) => {
+    const val = values[field.key] ?? field.defaultValue ?? ''
+
+    switch (field.type) {
+      case 'boolean':
+        return (
+          <label className="flex items-center gap-2 cursor-pointer mt-1">
+            <input
+              type="checkbox"
+              checked={Boolean(val)}
+              onChange={(e) => handleFieldValueChange(field.key, e.target.checked)}
+              className="rounded bg-bg-tertiary border-border text-accent-primary focus:ring-accent-primary"
+            />
+            <span className="text-sm text-text-primary font-medium">{field.label}</span>
+          </label>
+        )
+      case 'select':
+        return (
+          <div>
+            <label className="text-xs font-medium text-text-primary block mb-1">
+              {field.label} {field.required && <span className="text-accent-error">*</span>}
+            </label>
+            <select
+              value={String(val)}
+              onChange={(e) => handleFieldValueChange(field.key, e.target.value)}
+              className="w-full px-3 py-1.5 text-sm text-text-primary bg-bg-tertiary border border-border rounded focus:outline-none focus:border-accent-primary"
+            >
+              {field.options?.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        )
+      case 'textarea':
+        return (
+          <div>
+            <label className="text-xs font-medium text-text-primary block mb-1">
+              {field.label} {field.required && <span className="text-accent-error">*</span>}
+            </label>
+            <textarea
+              rows={3}
+              value={String(val)}
+              placeholder={field.placeholder}
+              onChange={(e) => handleFieldValueChange(field.key, e.target.value)}
+              className="w-full px-3 py-1.5 text-sm text-text-primary bg-bg-tertiary border border-border rounded focus:outline-none focus:border-accent-primary"
+            />
+          </div>
+        )
+      case 'number':
+        return (
+          <div>
+            <label className="text-xs font-medium text-text-primary block mb-1">
+              {field.label} {field.required && <span className="text-accent-error">*</span>}
+            </label>
+            <input
+              type="number"
+              value={val === '' ? '' : Number(val)}
+              placeholder={field.placeholder}
+              onChange={(e) => handleFieldValueChange(field.key, e.target.value === '' ? '' : Number(e.target.value))}
+              className="w-full px-3 py-1.5 text-sm text-text-primary bg-bg-tertiary border border-border rounded focus:outline-none focus:border-accent-primary"
+            />
+          </div>
+        )
+      case 'password': {
+        const isConfigured = configuredKeys.includes(field.key)
+        return (
+          <div>
+            <div className="flex items-center justify-between mb-1">
+              <label htmlFor={`field-${field.key}`} className="text-xs font-medium text-text-primary block">
+                {field.label} {field.required && <span className="text-accent-error">*</span>}
+              </label>
+              {isConfigured && !val && (
+                <span className="text-xs text-text-muted">{t({ en: '(configured)', fr: '(configuré)' })}</span>
+              )}
+            </div>
+            <input
+              id={`field-${field.key}`}
+              type="password"
+              value={String(val)}
+              placeholder={
+                isConfigured && !val
+                  ? t({ en: '•••••••• (leave blank to keep current)', fr: '•••••••• (laisser vide pour conserver)' })
+                  : field.placeholder
+              }
+              onChange={(e) => handleFieldValueChange(field.key, e.target.value)}
+              className="w-full px-3 py-1.5 text-sm text-text-primary bg-bg-tertiary border border-border rounded focus:outline-none focus:border-accent-primary"
+            />
+          </div>
+        )
+      }
+      case 'text':
+      default:
+        return (
+          <div>
+            <label className="text-xs font-medium text-text-primary block mb-1">
+              {field.label} {field.required && <span className="text-accent-error">*</span>}
+            </label>
+            <input
+              type="text"
+              value={String(val)}
+              placeholder={field.placeholder}
+              onChange={(e) => handleFieldValueChange(field.key, e.target.value)}
+              className="w-full px-3 py-1.5 text-sm text-text-primary bg-bg-tertiary border border-border rounded focus:outline-none focus:border-accent-primary"
+            />
+          </div>
+        )
+    }
+  }
+
+  const title = spec?.title ?? t({ en: '{{name}} Settings', fr: 'Paramètres de {{name}}' }, { name: pluginDisplayName })
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={title}
+      size="lg"
+      footer={
+        <div className="flex justify-end gap-2">
+          <Button variant="secondary" onClick={onClose} disabled={saving}>
+            {successMsg ? t({ en: 'Close', fr: 'Fermer' }) : t({ en: 'Cancel', fr: 'Annuler' })}
+          </Button>
+          <Button variant="primary" onClick={handleSave} disabled={saving || loading}>
+            {saving
+              ? t({ en: 'Saving…', fr: 'Enregistrement…' })
+              : t({ en: 'Save Settings', fr: 'Enregistrer les paramètres' })}
+          </Button>
+        </div>
+      }
+    >
+      <div className="space-y-4 p-1">
+        {error && (
+          <div className="text-sm text-accent-error bg-accent-error/10 border border-accent-error/30 rounded p-2.5">
+            {error}
+          </div>
+        )}
+        {successMsg && (
+          <div className="text-sm text-accent-success bg-accent-success/10 border border-accent-success/30 rounded p-2.5">
+            {successMsg}
+          </div>
+        )}
+
+        {loading ? (
+          <div className="text-sm text-text-muted py-4">
+            {t({ en: 'Loading settings…', fr: 'Chargement des paramètres…' })}
+          </div>
+        ) : spec?.customUiUrl ? (
+          <div className="w-full h-80 border border-border rounded overflow-hidden">
+            <iframe
+              src={spec.customUiUrl}
+              title={t(
+                { en: '{{name}} Custom UI', fr: 'Interface personnalisée de {{name}}' },
+                { name: pluginDisplayName },
+              )}
+              className="w-full h-full border-none"
+            />
+          </div>
+        ) : spec?.fields && spec.fields.length > 0 ? (
+          <div className="space-y-3">
+            {spec.description && <p className="text-xs text-text-muted mb-2">{spec.description}</p>}
+            {spec.fields.map((field) => (
+              <div key={field.key} className="space-y-1">
+                {renderField(field)}
+                {field.description && field.type !== 'boolean' && (
+                  <p className="text-xs text-text-muted">{field.description}</p>
+                )}
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="space-y-2">
+            <p className="text-xs text-text-muted">
+              {t(
+                {
+                  en: 'Configure JSON settings for {{name}}:',
+                  fr: 'Configurer les paramètres JSON pour {{name}} :',
+                },
+                { name: pluginDisplayName },
+              )}
+            </p>
+            <textarea
+              rows={8}
+              value={rawJson}
+              onChange={(e) => setRawJson(e.target.value)}
+              className="w-full font-mono text-xs px-3 py-2 text-text-primary bg-bg-tertiary border border-border rounded focus:outline-none focus:border-accent-primary"
+            />
+          </div>
+        )}
+      </div>
+    </Modal>
+  )
+}

--- a/web/src/components/settings/tabs/PluginsTab.test.tsx
+++ b/web/src/components/settings/tabs/PluginsTab.test.tsx
@@ -29,7 +29,7 @@ const REGISTRY_RESPONSE = {
 }
 
 const INSTALLED_RESPONSE = {
-  installed: [{ name: 'openfox-chatgpt', version: 'v1.0.0' }],
+  installed: [{ name: 'openfox-chatgpt', version: 'v1.0.0', hasSettings: true }],
 }
 
 function createJsonResponse(data: unknown, status = 200): Response {
@@ -130,10 +130,10 @@ describe('PluginsTab', () => {
     })
   })
 
-  it('can install a plugin via the install button', async () => {
+  it('can install a plugin and updates hasSettings immediately', async () => {
     mockFetch
       .mockResolvedValueOnce(createJsonResponse(REGISTRY_RESPONSE))
-      .mockResolvedValueOnce(createJsonResponse(INSTALLED_RESPONSE))
+      .mockResolvedValueOnce(createJsonResponse({ installed: [] }))
 
     render(<PluginsTab />)
 
@@ -141,7 +141,7 @@ describe('PluginsTab', () => {
       expect(screen.getByText('GitHub Copilot')).toBeDefined()
     })
 
-    mockFetch.mockResolvedValueOnce(createJsonResponse({ success: true, loaded: true }))
+    mockFetch.mockResolvedValueOnce(createJsonResponse({ success: true, loaded: true, hasSettings: true }))
 
     const installButtons = screen.getAllByRole('button', { name: 'Install' })
     await userEvent.setup().click(installButtons[0]!)
@@ -153,6 +153,37 @@ describe('PluginsTab', () => {
           method: 'POST',
         }),
       )
+    })
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Settings/i })).toBeDefined()
+    })
+  })
+
+  it('shows Settings button for installed plugins and opens settings modal', async () => {
+    mockFetch
+      .mockResolvedValueOnce(createJsonResponse(REGISTRY_RESPONSE))
+      .mockResolvedValueOnce(createJsonResponse(INSTALLED_RESPONSE))
+
+    render(<PluginsTab />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Settings/i })).toBeDefined()
+    })
+
+    mockFetch.mockResolvedValueOnce(
+      createJsonResponse({
+        hasSpec: true,
+        spec: { title: 'ChatGPT Settings' },
+        values: {},
+      }),
+    )
+
+    const settingsButton = screen.getByRole('button', { name: /Settings/i })
+    await userEvent.setup().click(settingsButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('ChatGPT Settings')).toBeDefined()
     })
   })
 

--- a/web/src/components/settings/tabs/PluginsTab.tsx
+++ b/web/src/components/settings/tabs/PluginsTab.tsx
@@ -3,6 +3,8 @@ import { authFetch } from '../../../lib/api'
 import { useT } from '../../../hooks/useT'
 import { Button } from '../../shared/Button'
 import { ConfirmModal } from '../../shared/ConfirmModal'
+import { SettingsIcon } from '../../shared/icons/SettingsIcon'
+import { PluginSettingsModal } from '../PluginSettingsModal'
 
 const STORAGE_KEY = 'openfox_user_plugins'
 
@@ -107,12 +109,16 @@ function PluginCard({
   plugin,
   initiallyInstalled,
   installedVersion,
+  hasSettings = false,
+  onInstalled,
   onRemove,
   onOpenFolder,
 }: {
   plugin: PluginWithVersion
   initiallyInstalled: boolean
   installedVersion: string | null
+  hasSettings?: boolean
+  onInstalled?: (name: string, hasSettings: boolean) => void
   onRemove: (name: string) => void
   onOpenFolder: (name: string) => void
 }) {
@@ -123,6 +129,7 @@ function PluginCard({
   const [localVersion, setLocalVersion] = useState<string | null>(installedVersion)
   const [showRemoveConfirm, setShowRemoveConfirm] = useState(false)
   const [removing, setRemoving] = useState(false)
+  const [showSettingsModal, setShowSettingsModal] = useState(false)
 
   useEffect(() => {
     setLocalVersion(installedVersion)
@@ -138,6 +145,9 @@ function PluginCard({
     if (res.ok) {
       setInstallState('installed')
       if (plugin.latestVersion) setLocalVersion(plugin.latestVersion)
+      if (onInstalled) {
+        onInstalled(plugin.name, Boolean(data.hasSettings))
+      }
       if (!data.loaded)
         setErrorMsg(
           data.loadError ??
@@ -146,7 +156,7 @@ function PluginCard({
     } else {
       throw new Error(data.error ?? t({ en: 'Install failed', fr: 'Échec de l’installation' }))
     }
-  }, [plugin.githubUrl, plugin.name, t])
+  }, [plugin.githubUrl, plugin.name, plugin.latestVersion, onInstalled, t])
 
   const handleInstall = async () => {
     setInstallState('installing')
@@ -252,6 +262,17 @@ function PluginCard({
                 {t({ en: 'Update', fr: 'Mettre à jour' })}
               </Button>
             )}
+            {installState === 'installed' && hasSettings && (
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={() => setShowSettingsModal(true)}
+                className="flex items-center gap-1"
+              >
+                <SettingsIcon className="w-3.5 h-3.5" />
+                {t({ en: 'Settings', fr: 'Paramètres' })}
+              </Button>
+            )}
             {installState === 'installed' && (
               <Button variant="danger" size="sm" onClick={handleRemove}>
                 {t({ en: 'Remove', fr: 'Supprimer' })}
@@ -282,6 +303,15 @@ function PluginCard({
         confirmVariant="danger"
         disabled={removing}
       />
+
+      {showSettingsModal && (
+        <PluginSettingsModal
+          isOpen={showSettingsModal}
+          onClose={() => setShowSettingsModal(false)}
+          pluginName={plugin.name}
+          pluginDisplayName={plugin.displayName}
+        />
+      )}
     </div>
   )
 }
@@ -291,6 +321,7 @@ export function PluginsTab() {
   const [registryPlugins, setRegistryPlugins] = useState<PluginWithVersion[]>([])
   const [userPlugins, setUserPlugins] = useState<PluginWithVersion[]>([])
   const [installedVersions, setInstalledVersions] = useState<Record<string, string | null>>({})
+  const [installedSettings, setInstalledSettings] = useState<Record<string, boolean>>({})
   const [loading, setLoading] = useState(true)
   const [fetchError, setFetchError] = useState('')
   const [duplicateWarning, setDuplicateWarning] = useState('')
@@ -312,11 +343,18 @@ export function PluginsTab() {
       .then(([registryData, installedData]) => {
         if (cancelled) return
         const versions: Record<string, string | null> = {}
-        const installedList = installedData.installed as { name: string; version: string | null }[]
+        const settingsMap: Record<string, boolean> = {}
+        const installedList = installedData.installed as {
+          name: string
+          version: string | null
+          hasSettings?: boolean
+        }[]
         for (const p of installedList) {
           versions[p.name] = p.version
+          settingsMap[p.name] = Boolean(p.hasSettings)
         }
         setInstalledVersions(versions)
+        setInstalledSettings(settingsMap)
 
         const items = (registryData.plugins as RegistryPlugin[]).map((p) => ({
           ...p,
@@ -428,6 +466,10 @@ export function PluginsTab() {
     [registryPlugins],
   )
 
+  const handleInstalled = useCallback((name: string, hasSettings: boolean) => {
+    setInstalledSettings((prev) => ({ ...prev, [name]: hasSettings }))
+  }, [])
+
   const seen = new Set<string>()
   const allPlugins = [...registryPlugins, ...userPlugins].filter((p) => {
     if (seen.has(p.name)) return false
@@ -473,6 +515,8 @@ export function PluginsTab() {
           plugin={plugin}
           initiallyInstalled={plugin.name in installedVersions}
           installedVersion={installedVersions[plugin.name] ?? null}
+          hasSettings={installedSettings[plugin.name] ?? false}
+          onInstalled={handleInstalled}
           onRemove={handleRemovePlugin}
           onOpenFolder={handleOpenFolder}
         />

--- a/web/src/lib/pluginSettings.ts
+++ b/web/src/lib/pluginSettings.ts
@@ -1,0 +1,24 @@
+export type PluginSettingFieldType = 'text' | 'password' | 'number' | 'boolean' | 'select' | 'textarea'
+
+export interface PluginSettingOption {
+  label: string
+  value: string
+}
+
+export interface PluginSettingField {
+  key: string
+  label: string
+  type: PluginSettingFieldType
+  description?: string
+  defaultValue?: string | number | boolean
+  options?: PluginSettingOption[]
+  placeholder?: string
+  required?: boolean
+}
+
+export interface PluginSettingsSpec {
+  title?: string
+  description?: string
+  fields?: PluginSettingField[]
+  customUiUrl?: string
+}


### PR DESCRIPTION
### Summary

Adds plugin settings modal and registration capability to OpenFox. Plugins can now register custom configuration options (via dynamic form fields or a hosted custom UI iframe) using `registry.registerSettings()` or by specifying `"hasSettings": true` in `package.json` under `openfox`.

- **Backend (`src/server/routes/plugins.ts`, `src/server/providers/plugins/`)**:
  - Extended `ProviderPluginRegistry` and `ProviderRegistry` with `registerSettings` and `registerSettingsForPlugin`.
  - Added `GET /api/plugins/:name/settings` and `POST /api/plugins/:name/settings` endpoints for reading and saving plugin configuration.
  - Implemented password field sanitization (secrets are never echoed in GET responses and are merged server-side when updated).
  - Server-side required-field validation.
- **Frontend (`web/src/components/settings/`)**:
  - Created `PluginSettingsModal` supporting dynamic input types (`text`, `password`, `number`, `boolean`, `select`, `textarea`) and custom UI URL embeds.
  - Added a conditional **Settings** button to installed plugin cards in `PluginsTab` (only displayed when settings are available).
  - Client-side required-field validation before submitting.
- **Documentation**:
  - Updated `README.md` with examples for registering plugin settings and declaring `openfox.hasSettings`.
 
<img width="914" height="145" alt="image" src="https://github.com/user-attachments/assets/13a5bc6b-a5c9-4a08-a7da-a3d628114b53" />

<img width="904" height="928" alt="image" src="https://github.com/user-attachments/assets/246d8eab-942a-47b6-bed3-e1d89045ece8" />


### AI-Enhanced Development

Tell what models helped shape this PR:

- **AI Models:** Gemini 3.6 Flash / hy3

### Cache Impact

Does this PR affect anything cached — system prompts, tool definitions, skills, or other context?

- **No**

