### PR TITLE
feat: add openfox-omniroute-quota plugin to registry and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Restart OpenFox after installing or updating a plugin.
 - To authenticate with an X (xAI) SuperGrok subscription, you can install the [`openfox-xai-supergrok`](https://github.com/Olgean-Group/openfox-xai-supergrok) plugin.
 - To use free OpenRouter models, you can install the [`openfox-openrouter-free`](https://github.com/JamesDAdams/openfox-openrouter-free) plugin.
 - To use free OpenCode models, you can install the [`openfox-opencode-free`](https://github.com/JamesDAdams/openfox-opencode-free) plugin.
+- To use OmniRoute with quota management, you can install the [`openfox-omniroute-quota`](https://github.com/JamesDAdams/openfox-omniroute-quota) plugin.
 
 ## Screenshots
 

--- a/plugins-registry.json
+++ b/plugins-registry.json
@@ -34,5 +34,11 @@
     "displayName": "OpenCode (Free Models)",
     "description": "OpenCode provider filtered to free models only (-free suffix), with automatic hourly model updates (1x/hour) and API key auth.",
     "githubUrl": "https://github.com/JamesDAdams/openfox-opencode-free"
+  },
+  {
+    "name": "openfox-omniroute-quota",
+    "displayName": "OmniRoute Quota",
+    "description": "OmniRoute quota provider plugin for OpenFox.",
+    "githubUrl": "https://github.com/JamesDAdams/openfox-omniroute-quota"
   }
 ]


### PR DESCRIPTION
### Summary

Added the [`openfox-omniroute-quota`](https://github.com/JamesDAdams/openfox-omniroute-quota) plugin to `plugins-registry.json` and documented it in `README.md`.

NEED THE PR : 

- https://github.com/co-l/openfox/pull/287
- https://github.com/co-l/openfox/pull/288

### AI-Enhanced Development

Tell what models helped shape this PR:

- **AI Models:** Gemini 3.6 Flash

### Cache Impact

Does this PR affect anything cached — system prompts, tool definitions, skills, or other context?

- **No**