### PR TITLE
fix(provider): Add sync button and resolve bug merge models

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -22,7 +22,7 @@ import { buildModelsUrl } from './llm/url-utils.js'
 
 import { createMockLLMClient } from './llm/mock.js'
 import { createProviderManager, parseDefaultModelSelection } from './provider-manager.js'
-import { isReasoningEffortValue } from './providers/model-catalog.js'
+import { isReasoningEffortValidForModel } from '../shared/reasoning-effort.js'
 import { createToolRegistry, setMcpTools, getBuiltInToolNames } from './tools/index.js'
 import { ALWAYS_ALLOWED, ALWAYS_ALLOWED_FOR_SUBAGENTS, TOP_LEVEL_ONLY_TOOLS } from './tools/tool-policy.js'
 import { McpManager, createMcpTools } from './mcp/index.js'
@@ -1080,12 +1080,17 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
     if (!providerId) {
       return res.status(400).json({ error: 'providerId is required' })
     }
-    if (reasoningEffort !== undefined && reasoningEffort !== null && !isReasoningEffortValue(reasoningEffort)) {
+    // Resolve model: use provided model, or first model from provider, or fallback
+    const provider = providerManager.getProviders().find((p) => p.id === providerId)
+    const targetModel = provider?.models.find((m) => m.id === model)
+    if (
+      reasoningEffort !== undefined &&
+      reasoningEffort !== null &&
+      !isReasoningEffortValidForModel(reasoningEffort, targetModel)
+    ) {
       return res.status(400).json({ error: `Unsupported reasoningEffort: ${reasoningEffort}` })
     }
 
-    // Resolve model: use provided model, or first model from provider, or fallback
-    const provider = providerManager.getProviders().find((p) => p.id === providerId)
     const resolvedModel = model ?? provider?.models?.[0]?.id ?? 'auto'
 
     // Set provider for session only — does NOT touch global defaultModelSelection.
@@ -1147,7 +1152,12 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
     }
 
     const { effort } = req.body as { effort?: string }
-    if (!effort || !isReasoningEffortValue(effort)) {
+    const sessionModel = session.providerModel
+    const targetModel = providerManager
+      .getProviders()
+      .flatMap((p) => p.models)
+      .find((m) => m.id === sessionModel)
+    if (!effort || !isReasoningEffortValidForModel(effort, targetModel)) {
       return res.status(400).json({ error: `Unsupported reasoningEffort: ${effort}` })
     }
 
@@ -2704,9 +2714,6 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
       thinkingLevel?: string
       thinkingEnabled?: boolean
     }
-    if (thinkingLevel !== undefined && !isReasoningEffortValue(thinkingLevel)) {
-      return res.status(400).json({ error: `Invalid reasoning effort '${thinkingLevel}'` })
-    }
     if (thinkingEnabled !== undefined && typeof thinkingEnabled !== 'boolean') {
       return res.status(400).json({ error: 'thinkingEnabled must be a boolean' })
     }
@@ -2718,8 +2725,12 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
         return res.status(404).json({ error: 'Provider not found' })
       }
       const models = provider.models ?? []
-      if (!models.some((m) => m.id === modelId)) {
+      const targetModel = models.find((m) => m.id === modelId)
+      if (!targetModel) {
         return res.status(404).json({ error: 'Model not found' })
+      }
+      if (thinkingLevel !== undefined && !isReasoningEffortValidForModel(thinkingLevel, targetModel)) {
+        return res.status(400).json({ error: `Invalid reasoning effort '${thinkingLevel}'` })
       }
       const updatedModels = models.map((m) =>
         m.id === modelId

--- a/src/server/provider-manager.test.ts
+++ b/src/server/provider-manager.test.ts
@@ -853,6 +853,52 @@ describe('ProviderManager - Model Selection', () => {
       expect(providerManager.resolveModelEffort('provider-1', 'model-a', 'none')).toBe('none')
     })
 
+    it('preserves selected status, requestBody, and modes when updating model settings', async () => {
+      const pm = createProviderManager({
+        ...config,
+        providers: [
+          {
+            id: 'p-custom',
+            name: 'Custom Provider',
+            url: 'https://example.com/v1',
+            backend: 'openai',
+            models: [
+              {
+                id: 'custom-model',
+                contextWindow: 128000,
+                source: 'user',
+                selected: true,
+                requestBody: { custom_param: 123 },
+                modes: [
+                  { level: 'low', apiModelId: 'custom-model-low' },
+                  { level: 'high', apiModelId: 'custom-model-high' },
+                ],
+              },
+            ],
+            isActive: true,
+            createdAt: new Date().toISOString(),
+          },
+        ],
+      })
+
+      const res = await pm.updateModelSettings('p-custom', 'custom-model', {
+        thinkingEnabled: true,
+        thinkingLevel: 'low',
+      })
+
+      expect(res.success).toBe(true)
+      expect(res.model?.selected).toBe(true)
+      expect(res.model?.requestBody).toEqual({ custom_param: 123 })
+      expect(res.model?.modes?.length).toBe(2)
+
+      const provider = pm.getProviders().find((p) => p.id === 'p-custom')
+      const updated = provider?.models.find((m) => m.id === 'custom-model')
+      expect(updated?.selected).toBe(true)
+      expect(updated?.requestBody).toEqual({ custom_param: 123 })
+      expect(updated?.modes?.length).toBe(2)
+      expect(updated?.thinkingLevel).toBe('low')
+    })
+
     it('an explicit in-list effort wins over the model default', async () => {
       await providerManager.updateModelSettings('provider-1', 'model-a', {
         thinkingEnabled: true,

--- a/src/server/provider-manager.ts
+++ b/src/server/provider-manager.ts
@@ -118,6 +118,7 @@ function mergeModelsWithUserOverrides(
   const claimedByMergedModes = new Set<string>()
   for (const userModel of userModels) {
     if (!userModel.modes?.length) continue
+    claimedByMergedModes.add(normalizeModelId(userModel.id))
     for (const mode of userModel.modes) {
       if (mode.apiModelId) claimedByMergedModes.add(normalizeModelId(mode.apiModelId))
     }
@@ -888,7 +889,9 @@ export function createProviderManager(config: Config, options: ProviderManagerOp
         source: 'user',
         ...(existingModel?.name !== undefined && { name: existingModel.name }),
         ...(existingModel?.apiModelId !== undefined && { apiModelId: existingModel.apiModelId }),
+        ...(existingModel?.requestBody !== undefined && { requestBody: existingModel.requestBody }),
         ...(existingModel?.modes !== undefined && { modes: existingModel.modes }),
+        ...(existingModel?.selected !== undefined && { selected: existingModel.selected }),
         ...(finalTemp !== undefined && { temperature: finalTemp }),
         ...(finalTopP !== undefined && { topP: finalTopP }),
         ...(finalTopK !== undefined && { topK: finalTopK }),

--- a/src/shared/reasoning-effort.test.ts
+++ b/src/shared/reasoning-effort.test.ts
@@ -60,9 +60,15 @@ describe('resolveEffortForModel', () => {
 })
 
 describe('splitModeSuffix', () => {
-  it('strips a trailing low/medium/high/xhigh/max suffix from a model id', () => {
+  it('strips a trailing mode suffix generically from a model id', () => {
     expect(splitModeSuffix('gemini-3.6-flash-high')).toEqual({ base: 'gemini-3.6-flash', level: 'high' })
     expect(splitModeSuffix('claude-sonnet-4-6-low')).toEqual({ base: 'claude-sonnet-4-6', level: 'low' })
+  })
+
+  it('rejects models whose suffix is not a recognized mode suffix', () => {
+    expect(splitModeSuffix('custom-model-light')).toBeUndefined()
+    expect(splitModeSuffix('claude-3-5-sonnet')).toBeUndefined()
+    expect(splitModeSuffix('qwen-2.5-coder-7b')).toBeUndefined()
   })
 
   it('handles prefixed ids and keeps the path segment base', () => {
@@ -72,9 +78,11 @@ describe('splitModeSuffix', () => {
     })
   })
 
-  it('returns undefined when there is no trailing mode suffix', () => {
-    expect(splitModeSuffix('gemini-3.6-flash')).toBeUndefined()
-    expect(splitModeSuffix('claude-sonnet-4-6')).toBeUndefined()
+  it('returns undefined when there is no trailing mode suffix or hyphen is at start/end', () => {
+    expect(splitModeSuffix('gemini')).toBeUndefined()
+    expect(splitModeSuffix('antigravity/gemini')).toBeUndefined()
+    expect(splitModeSuffix('provider/-model')).toBeUndefined()
+    expect(splitModeSuffix('provider/model-')).toBeUndefined()
   })
 })
 

--- a/src/shared/reasoning-effort.ts
+++ b/src/shared/reasoning-effort.ts
@@ -15,6 +15,17 @@ export function isReasoningEffortValue(value: string): boolean {
   return (REASONING_EFFORT_VALUES as readonly string[]).includes(value)
 }
 
+export function isReasoningEffortValidForModel(
+  effort: string | undefined | null,
+  model?: { modes?: Array<{ level: string }>; reasoningEfforts?: string[] },
+): boolean {
+  if (!effort) return false
+  if (isReasoningEffortValue(effort)) return true
+  if (model?.modes?.some((m) => m.level === effort)) return true
+  if (model?.reasoningEfforts?.includes(effort)) return true
+  return false
+}
+
 export interface ResolveEffortForModelOptions {
   /** The model's advertised preset list (UI chips). Absent/empty = no constraint. */
   reasoningEfforts?: string[]
@@ -75,14 +86,25 @@ export interface ModeModelSeed {
 }
 
 /**
- * Detect whether a model ID carries a trailing mode suffix, returning the
- * stripped base ID and the suffix, or undefined when the ID is un-suffixed.
+ * Detect whether a model ID carries a trailing mode suffix (e.g. `base-suffix`),
+ * returning the stripped base ID and the suffix, or undefined when the ID has no
+ * trailing hyphen-separated segment.
  */
-const MODE_SUFFIX_REGEX = new RegExp(`-(${MODE_SUFFIXES.join('|')})$`)
 export function splitModeSuffix(id: string): { base: string; level: string } | undefined {
-  const match = id.match(MODE_SUFFIX_REGEX)
-  if (!match) return undefined
-  return { base: id.slice(0, -match[0].length), level: match[1]! }
+  const lastSlashIndex = id.lastIndexOf('/')
+  const searchStart = lastSlashIndex >= 0 ? lastSlashIndex + 1 : 0
+  const lastHyphenIndex = id.lastIndexOf('-')
+  if (lastHyphenIndex <= searchStart || lastHyphenIndex === id.length - 1) {
+    return undefined
+  }
+  const level = id.slice(lastHyphenIndex + 1)
+  if (!MODE_SUFFIXES.includes(level as ModeSuffix)) {
+    return undefined
+  }
+  return {
+    base: id.slice(0, lastHyphenIndex),
+    level,
+  }
 }
 
 /**

--- a/web/src/components/shared/ProviderModal.test.tsx
+++ b/web/src/components/shared/ProviderModal.test.tsx
@@ -1213,4 +1213,301 @@ describe('ProviderModal - model mode merge', () => {
     expect(merged?.modes?.map((mode) => mode.level)).toEqual(['low', 'medium', 'high'])
     expect(savedData.models.some((m) => m.id === 'antigravity/gemini-3.6-flash-high')).toBe(false)
   })
+
+  it('displays merged modes in parentheses in the Available Models list', async () => {
+    await renderWithRawCatalog(mergedProviderModels)
+    const availableModelsList = document.body.querySelectorAll('[role="checkbox"]')
+    const geminiCheckbox = Array.from(availableModelsList).find((el) => el.textContent?.includes('gemini-3.6-flash'))
+    expect(geminiCheckbox).toBeTruthy()
+    expect(geminiCheckbox?.textContent).toContain('(high, low, medium)')
+  })
+
+  it('renders a Sync button next to Select all that refetches models without expanding collapsed models', async () => {
+    await renderWithRawCatalog(mergedProviderModels)
+    // Collapse any expanded model
+    const header = document.body.querySelector(
+      '.bg-bg-primary.border.border-border .cursor-pointer',
+    ) as HTMLElement | null
+    header?.click()
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    const syncButton = Array.from(document.body.querySelectorAll('button')).find((b) =>
+      b.textContent?.trim().includes('Sync'),
+    )
+    expect(syncButton).toBeTruthy()
+    syncButton?.click()
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    expect(global.fetch).toHaveBeenCalled()
+    // ModelConfigPanel should remain collapsed (e.g. no Context window input visible)
+    const contextInput = document.body.querySelector('input[type="number"]')
+    expect(contextInput).toBeNull()
+  })
+
+  it('syncing discovers new models, adding them to Available Models without adding them to Selected Models', async () => {
+    const initialModels = [
+      { id: 'model-a', contextWindow: 128000, selected: true },
+      { id: 'model-b', contextWindow: 200000, selected: false },
+    ]
+    const fetchedCatalog = [
+      { id: 'model-a', contextWindow: 128000 },
+      { id: 'model-b', contextWindow: 200000 },
+      { id: 'model-c-new', contextWindow: 256000 },
+    ]
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input)
+        if (url.includes('/api/provider-presets')) {
+          return new Response(JSON.stringify({ presets: [] }), { status: 200 })
+        }
+        if (url.includes('/models')) {
+          return new Response(JSON.stringify({ models: fetchedCatalog, url: 'http://localhost:8000/v1' }), {
+            status: 200,
+          })
+        }
+        return new Response(JSON.stringify({ models: [], url: 'http://localhost:8000/v1' }), { status: 200 })
+      }),
+    )
+
+    await new Promise<void>((resolve) => {
+      root.render(
+        <ProviderModal
+          isOpen={true}
+          onClose={vi.fn()}
+          onSave={onSaveMock as (provider: ProviderFormData) => void}
+          editProvider={{
+            id: 'test-provider',
+            name: 'Test Provider',
+            url: 'http://localhost:8000/v1',
+            backend: 'vllm',
+            models: initialModels as never,
+          }}
+          initialStep={2}
+        />,
+      )
+      setTimeout(resolve, 200)
+    })
+
+    const syncButton = Array.from(document.body.querySelectorAll('button')).find((b) =>
+      b.textContent?.trim().includes('Sync'),
+    )
+    expect(syncButton).toBeTruthy()
+    syncButton?.click()
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    // Click Save Provider
+    const saveButton = document.body.querySelector('[data-testid="provider-modal-save"]') as HTMLButtonElement | null
+    saveButton?.click()
+
+    const savedData: ProviderFormData = onSaveMock.mock.calls[0]![0]!
+    // model-a remains selected
+    const modelA = savedData.models.find((m) => m.id === 'model-a')
+    expect(modelA?.selected).toBe(true)
+
+    // model-b was not selected and remains unselected
+    const modelB = savedData.models.find((m) => m.id === 'model-b')
+    expect(modelB?.selected).toBeUndefined()
+
+    // model-c-new is added to models but is NOT selected
+    const modelC = savedData.models.find((m) => m.id === 'model-c-new')
+    expect(modelC).toBeDefined()
+    expect(modelC?.selected).toBeUndefined()
+  })
+
+  it('syncing with merged mode models does not duplicate models in Selected Models', async () => {
+    const initialModels = [
+      {
+        id: 'claude-opus-4-6-thinking',
+        contextWindow: 1048576,
+        selected: true,
+        modes: [
+          { level: 'low', apiModelId: 'claude-opus-4-6-thinking-low' },
+          { level: 'high', apiModelId: 'claude-opus-4-6-thinking-high' },
+        ],
+      },
+      { id: 'gemini-3.7-flash', contextWindow: 1048576, selected: true },
+    ]
+    const fetchedCatalog = [
+      { id: 'claude-opus-4-6-thinking', contextWindow: 1048576 },
+      { id: 'gemini-3.7-flash', contextWindow: 1048576 },
+      { id: 'gemini-3.1-pro', contextWindow: 1048576 },
+    ]
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input)
+        if (url.includes('/api/provider-presets')) {
+          return new Response(JSON.stringify({ presets: [] }), { status: 200 })
+        }
+        if (url.includes('/models')) {
+          return new Response(JSON.stringify({ models: fetchedCatalog, url: 'http://localhost:8000/v1' }), {
+            status: 200,
+          })
+        }
+        return new Response(JSON.stringify({ models: [], url: 'http://localhost:8000/v1' }), { status: 200 })
+      }),
+    )
+
+    await new Promise<void>((resolve) => {
+      root.render(
+        <ProviderModal
+          isOpen={true}
+          onClose={vi.fn()}
+          onSave={onSaveMock as (provider: ProviderFormData) => void}
+          editProvider={{
+            id: 'test-provider',
+            name: 'Test Provider',
+            url: 'http://localhost:8000/v1',
+            backend: 'vllm',
+            models: initialModels as never,
+          }}
+          initialStep={2}
+        />,
+      )
+      setTimeout(resolve, 200)
+    })
+
+    const syncButton = Array.from(document.body.querySelectorAll('button')).find((b) =>
+      b.textContent?.trim().includes('Sync'),
+    )
+    expect(syncButton).toBeTruthy()
+    syncButton?.click()
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    const saveButton = document.body.querySelector('[data-testid="provider-modal-save"]') as HTMLButtonElement | null
+    saveButton?.click()
+
+    const savedData: ProviderFormData = onSaveMock.mock.calls[0]![0]!
+    const opusInstances = savedData.models.filter((m) => m.id === 'claude-opus-4-6-thinking')
+    expect(opusInstances.length).toBe(1)
+    expect(opusInstances[0]?.modes).toBeDefined()
+    expect(opusInstances[0]?.selected).toBe(true)
+
+    // gemini-3.1-pro was newly discovered, so it is in available models but NOT selected
+    const geminiPro = savedData.models.find((m) => m.id === 'gemini-3.1-pro')
+    expect(geminiPro).toBeDefined()
+    expect(geminiPro?.selected).toBeUndefined()
+
+    // Total models saved should be 3 (claude-opus, gemini-flash, gemini-pro)
+    expect(savedData.models.length).toBe(3)
+  })
+
+  it('syncing when backend returns a single new model does not auto-select it for an existing provider with multiple models', async () => {
+    const initialModels = [
+      { id: 'model-a', contextWindow: 128000, selected: true },
+      { id: 'model-b', contextWindow: 200000, selected: false },
+    ]
+    const singleModelCatalog = [{ id: 'model-a', contextWindow: 128000 }]
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input)
+        if (url.includes('/api/provider-presets')) {
+          return new Response(JSON.stringify({ presets: [] }), { status: 200 })
+        }
+        if (url.includes('/models')) {
+          return new Response(JSON.stringify({ models: singleModelCatalog, url: 'http://localhost:8000/v1' }), {
+            status: 200,
+          })
+        }
+        return new Response(JSON.stringify({ models: [], url: 'http://localhost:8000/v1' }), { status: 200 })
+      }),
+    )
+
+    await new Promise<void>((resolve) => {
+      root.render(
+        <ProviderModal
+          isOpen={true}
+          onClose={vi.fn()}
+          onSave={onSaveMock as (provider: ProviderFormData) => void}
+          editProvider={{
+            id: 'test-provider',
+            name: 'Test Provider',
+            url: 'http://localhost:8000/v1',
+            backend: 'vllm',
+            models: initialModels as never,
+          }}
+          initialStep={2}
+        />,
+      )
+      setTimeout(resolve, 200)
+    })
+
+    const syncButton = Array.from(document.body.querySelectorAll('button')).find((b) =>
+      b.textContent?.trim().includes('Sync'),
+    )
+    expect(syncButton).toBeTruthy()
+    syncButton?.click()
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    const saveButton = document.body.querySelector('[data-testid="provider-modal-save"]') as HTMLButtonElement | null
+    saveButton?.click()
+
+    const savedData: ProviderFormData = onSaveMock.mock.calls[0]![0]!
+    expect(savedData.models.find((m) => m.id === 'model-a')?.selected).toBe(true)
+    expect(savedData.models.some((m) => m.id === 'model-b')).toBe(false)
+  })
+
+  it('syncing removes deleted models from Available Models and Selected Models', async () => {
+    const initialModels = [
+      { id: 'model-kept', contextWindow: 128000, selected: true },
+      { id: 'model-removed', contextWindow: 200000, selected: true },
+      { id: 'model-unselected-removed', contextWindow: 200000, selected: false },
+    ]
+    const updatedCatalog = [{ id: 'model-kept', contextWindow: 128000 }]
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input)
+        if (url.includes('/api/provider-presets')) {
+          return new Response(JSON.stringify({ presets: [] }), { status: 200 })
+        }
+        if (url.includes('/models')) {
+          return new Response(JSON.stringify({ models: updatedCatalog, url: 'http://localhost:8000/v1' }), {
+            status: 200,
+          })
+        }
+        return new Response(JSON.stringify({ models: [], url: 'http://localhost:8000/v1' }), { status: 200 })
+      }),
+    )
+
+    await new Promise<void>((resolve) => {
+      root.render(
+        <ProviderModal
+          isOpen={true}
+          onClose={vi.fn()}
+          onSave={onSaveMock as (provider: ProviderFormData) => void}
+          editProvider={{
+            id: 'test-provider',
+            name: 'Test Provider',
+            url: 'http://localhost:8000/v1',
+            backend: 'vllm',
+            models: initialModels as never,
+          }}
+          initialStep={2}
+        />,
+      )
+      setTimeout(resolve, 200)
+    })
+
+    const syncButton = Array.from(document.body.querySelectorAll('button')).find((b) =>
+      b.textContent?.trim().includes('Sync'),
+    )
+    expect(syncButton).toBeTruthy()
+    syncButton?.click()
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    const saveButton = document.body.querySelector('[data-testid="provider-modal-save"]') as HTMLButtonElement | null
+    saveButton?.click()
+
+    const savedData: ProviderFormData = onSaveMock.mock.calls[0]![0]!
+    expect(savedData.models.length).toBe(1)
+    expect(savedData.models[0]?.id).toBe('model-kept')
+    expect(savedData.models[0]?.selected).toBe(true)
+  })
 })

--- a/web/src/components/shared/ProviderModal.tsx
+++ b/web/src/components/shared/ProviderModal.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useRef, useMemo } from 'react'
 import { authFetch } from '../../lib/api'
 import type { Backend } from '../../stores/config'
 import type { ModelConfig as SharedModelConfig } from '@shared/types.js'
-import { ChevronDownIcon, EyeIcon, SettingsIcon } from './icons'
+import { ChevronDownIcon, EyeIcon, ReloadIcon, SettingsIcon } from './icons'
 import { QueryParamsInput } from './QueryParamsInput'
 import { formatTokens } from '../../lib/format-stats'
 import { getLocale } from '@shared/i18n/index.js'
@@ -1127,10 +1127,10 @@ export function ProviderModal({
   async function fetchModels(url: string) {
     setFetchingModels(true)
     setFetchError(null)
-    // Preserve any already-merged mode-chip models and their configs so
-    // newly-fetched raw catalog data doesn't clobber user-collapsed families.
+    const isInitialEmpty = !editProvider && models.length === 0 && selectedModelIds.size === 0
+    // Preserve any already-merged mode-chip models so newly-fetched raw catalog
+    // data doesn't clobber user-collapsed families.
     const preservedMerged = models.filter((m) => m.modes?.length)
-    setModels(preservedMerged)
     try {
       const params = new URLSearchParams({ url })
       if (formApiKey) params.set('apiKey', formApiKey)
@@ -1142,19 +1142,26 @@ export function ProviderModal({
       if (response.ok) {
         const data = (await response.json()) as { models: ModelInfo[]; url: string }
         if (data.models?.length) {
-          // Suffixed catalog variants already represented by a preserved merged
+          // Suffixed catalog variants already represented by an existing or merged
           // model must not reappear alongside it (mirrors the server-side
           // `claimedByMergedModes` filter in provider-manager.ts).
           const claimed = new Set<string>()
           for (const merged of preservedMerged) {
+            claimed.add(merged.id)
             for (const mode of merged.modes ?? []) {
               if (mode.apiModelId) claimed.add(mode.apiModelId)
             }
           }
-          const filteredRaw = data.models.filter((m) => !claimed.has(m.id))
+          const filteredRaw: ModelInfo[] = []
+          for (const m of data.models) {
+            if (!claimed.has(m.id)) {
+              claimed.add(m.id)
+              filteredRaw.push(m)
+            }
+          }
           const combined = [...preservedMerged, ...filteredRaw]
           setModels(combined)
-          setExpandedModelId(combined[0]?.id ?? null)
+          setExpandedModelId((current) => (current && combined.some((m) => m.id === current) ? current : null))
           setModelConfigs((current) => {
             const next: Record<string, ModelConfig> = { ...current }
             for (const m of filteredRaw) {
@@ -1172,10 +1179,12 @@ export function ProviderModal({
             }
             return next
           })
-          if (combined.length === 1) {
+          if (isInitialEmpty && combined.length === 1) {
             setSelectedModelIds(new Set([combined[0]!.id]))
             setExpandedModelId(combined[0]!.id)
             runAutoConfig(combined[0]!.id)
+          } else {
+            setSelectedModelIds((current) => new Set([...current].filter((id) => combined.some((m) => m.id === id))))
           }
         }
       } else {
@@ -2058,7 +2067,17 @@ export function ProviderModal({
                           { shown: filterModels(searchQuery).length, total: models.length },
                         )}
                       </p>
-                      <div className="flex gap-2">
+                      <div className="flex items-center gap-3">
+                        <button
+                          type="button"
+                          onClick={() => formUrl && fetchModels(formUrl)}
+                          disabled={fetchingModels || !formUrl}
+                          className="text-xs text-accent-primary hover:underline flex items-center gap-1 disabled:opacity-50"
+                          title="Sync available models from provider"
+                        >
+                          <ReloadIcon className={`w-3 h-3 ${fetchingModels ? 'animate-spin' : ''}`} />
+                          Sync
+                        </button>
                         <button
                           onClick={() => {
                             const next = new Set(selectedModelIds)
@@ -2141,6 +2160,11 @@ export function ProviderModal({
                             />
                             <span className="text-sm text-text-primary flex-1 truncate">
                               {model.name ?? model.id.split('/').pop()}
+                              {model.modes && model.modes.length > 0 && (
+                                <span className="text-text-muted font-normal ml-1">
+                                  ({model.modes.map((m) => m.level).join(', ')})
+                                </span>
+                              )}
                             </span>
                             <span className="text-xs text-text-muted flex flex-shrink-0 items-center gap-1">
                               {(modelConfigs[model.id]?.supportsVision ?? model.supportsVision) && (

--- a/web/src/lib/effort-gate.ts
+++ b/web/src/lib/effort-gate.ts
@@ -7,7 +7,7 @@
  * choice when a warm cache exists.
  */
 
-import { isReasoningEffortValue } from './model-value'
+import { isReasoningEffortValue, REASONING_EFFORT_VALUES } from './model-value'
 import { resolveEffortForModel } from '@shared/reasoning-effort.js'
 
 export interface EffortGateSession {
@@ -67,7 +67,8 @@ export function shouldGateEffortChange(opts: {
   proposedEffort?: string
 }): boolean {
   const { warmCache, currentEffort, proposedEffort } = opts
-  const storableCurrent = currentEffort && isReasoningEffortValue(currentEffort) ? currentEffort : undefined
+  const storableCurrent =
+    currentEffort && (REASONING_EFFORT_VALUES as readonly string[]).includes(currentEffort) ? currentEffort : undefined
   return !!warmCache && !!proposedEffort && !!storableCurrent && proposedEffort !== storableCurrent
 }
 

--- a/web/src/lib/model-value.test.ts
+++ b/web/src/lib/model-value.test.ts
@@ -27,10 +27,12 @@ describe('formatModelValue', () => {
   it('appends the effort suffix when provided and valid', () => {
     expect(formatModelValue('local', 'deepseek-v4-flash', 'high')).toBe('local/deepseek-v4-flash:high')
     expect(formatModelValue('local', 'gpt-5', 'minimal')).toBe('local/gpt-5:minimal')
+    expect(formatModelValue('local', 'gemini-3.7-flash', 'low')).toBe('local/gemini-3.7-flash:low')
   })
 
   it('ignores an invalid effort suffix', () => {
     expect(formatModelValue('local', 'deepseek-v4-flash', '70b')).toBe('local/deepseek-v4-flash')
+    expect(formatModelValue('local', 'deepseek-v4-flash', 'latest')).toBe('local/deepseek-v4-flash')
   })
 })
 
@@ -45,6 +47,11 @@ describe('parseModelValue', () => {
       model: 'deepseek-v4-flash',
       reasoningEffort: 'high',
     })
+    expect(parseModelValue('local/gemini-3.7-flash:low')).toEqual({
+      providerId: 'local',
+      model: 'gemini-3.7-flash',
+      reasoningEffort: 'low',
+    })
   })
 
   it('parses minimal as an effort, not part of the model id', () => {
@@ -55,8 +62,11 @@ describe('parseModelValue', () => {
     })
   })
 
-  it('keeps a colon in the model id when the suffix is not a known effort', () => {
+  it('keeps a colon in the model id for Ollama model tags and non-effort suffixes', () => {
     expect(parseModelValue('local/deepseek-r1:70b')).toEqual({ providerId: 'local', model: 'deepseek-r1:70b' })
+    expect(parseModelValue('ollama/llama3:latest')).toEqual({ providerId: 'ollama', model: 'llama3:latest' })
+    expect(parseModelValue('ollama/codellama:instruct')).toEqual({ providerId: 'ollama', model: 'codellama:instruct' })
+    expect(parseModelValue('ollama/qwen2.5-coder:32b')).toEqual({ providerId: 'ollama', model: 'qwen2.5-coder:32b' })
   })
 
   it('handles provider ids containing slashes (nested model ids)', () => {


### PR DESCRIPTION
### Summary

- Add sync button on add/edit provider for check if a new models is available
- **Fix duplicate models on Sync**: In `ProviderModal.tsx`, `fetchModels` now claims both the merged model's `id` and each member's `apiModelId`. This prevents raw catalog models fetched from the provider backend from duplicating already configured and mode-merged models in the `models` list and in the *Selected Models* view.
- **Preserve model selection during Sync**: Newly discovered models fetched from the provider catalog are added to `models` and displayed in *Available Models* (unselected) without polluting *Selected Models*.
- **Constrain mode suffix detection and parsing**: Constrained `splitModeSuffix` to recognized `MODE_SUFFIXES` to prevent unrelated multi-hyphen model names from being grouped into pseudo-mode families.
- **Fix Ollama tag preservation**: Ensured `parseModelValue` validates against known reasoning effort values before splitting on a colon, preventing Ollama model tags (such as `:latest`, `:instruct`, `:32b`) from being stripped and treated as reasoning efforts.
- **Preserve model metadata on update**: Ensured `updateModelSettings` preserves existing model metadata (`modes`, `requestBody`, `selected`).

### AI-Enhanced Development

Tell what models helped shape this PR:

- **AI Models:** Gemini 3.7 Flash

### Cache Impact

Does this PR affect anything cached — system prompts, tool definitions, skills, or other context?

- **No**