### PR TITLE
fix(mcp): inherit project mcp overrides when creating new sessions

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -239,6 +239,10 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
     },
   })
   setMcpManagerForTools(mcpManager)
+  const { setGlobalMcpServersProvider } = await import('./mcp/session-overrides.js')
+  setGlobalMcpServersProvider(() =>
+    mcpManager.getAllServers().map((s) => ({ name: s.name, disabled: s.config.disabled })),
+  )
   setMcpConfigMode(config.mode ?? 'production')
   setMcpConfigPath(config.globalConfigPath)
   setMcpOAuthStoreMode(config.mode ?? 'production')
@@ -866,27 +870,6 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
     // maxTokens is no longer passed - it comes from providerManager.getCurrentModelContext() at query time
     const session = sessionManager.createSession(projectId, title, providerId ?? null, model ?? null)
 
-    // Inherit MCP overrides from project for new sessions
-    try {
-      let disabledServers: string[] = []
-      if (project.mcpOverrides) {
-        disabledServers = Object.entries(project.mcpOverrides)
-          .filter(([, override]) => override.disabled)
-          .map(([name]) => name)
-      } else {
-        // No project overrides — inherit from global config
-        disabledServers = mcpManager
-          .getAllServers()
-          .filter((s) => s.config.disabled)
-          .map((s) => s.name)
-      }
-      if (disabledServers.length > 0) {
-        const { setSessionDisabledServers } = await import('./mcp/session-overrides.js')
-        setSessionDisabledServers(session.id, disabledServers)
-      }
-    } catch {
-      // Non-critical — session works without MCP overrides
-    }
     wssExports.broadcastForProject(projectId, session.id, buildSessionCreatedMessage(session))
     res.status(201).json({ session: toClientSession(session) })
   })

--- a/src/server/mcp/session-overrides.test.ts
+++ b/src/server/mcp/session-overrides.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import {
+  computeDisabledServersForProject,
+  setGlobalMcpServersProvider,
+  initSessionMcpOverrides,
+  getSessionDisabledServers,
+  setSessionDisabledServers,
+  clearSessionOverrides,
+} from './session-overrides.js'
+import { initDatabase, closeDatabase } from '../db/index.js'
+import { loadConfig } from '../config.js'
+import { createProject, updateProject } from '../db/projects.js'
+
+describe('session-overrides', () => {
+  beforeEach(() => {
+    initDatabase(loadConfig())
+    setGlobalMcpServersProvider(null)
+  })
+
+  afterEach(() => {
+    setGlobalMcpServersProvider(null)
+    closeDatabase()
+  })
+
+  describe('computeDisabledServersForProject', () => {
+    it('returns empty array when no servers and no overrides exist', () => {
+      expect(computeDisabledServersForProject(null, [])).toEqual([])
+      expect(computeDisabledServersForProject(undefined, [])).toEqual([])
+      expect(computeDisabledServersForProject({}, [])).toEqual([])
+    })
+
+    it('falls back to global server disabled flag when no project override exists', () => {
+      const globalServers = [
+        { name: 'server1', disabled: false },
+        { name: 'server2', disabled: true },
+        { name: 'server3', disabled: false },
+      ]
+
+      const disabled = computeDisabledServersForProject(null, globalServers)
+      expect(disabled).toEqual(['server2'])
+    })
+
+    it('honors project override disabled: true for a server', () => {
+      const globalServers = [
+        { name: 'server1', disabled: false },
+        { name: 'server2', disabled: false },
+      ]
+      const projectOverrides = {
+        server1: { disabled: true },
+      }
+
+      const disabled = computeDisabledServersForProject(projectOverrides, globalServers)
+      expect(disabled).toEqual(['server1'])
+    })
+
+    it('honors project override disabled: false to re-enable globally disabled server', () => {
+      const globalServers = [
+        { name: 'server1', disabled: true },
+        { name: 'server2', disabled: true },
+      ]
+      const projectOverrides = {
+        server1: { disabled: false },
+      }
+
+      const disabled = computeDisabledServersForProject(projectOverrides, globalServers)
+      expect(disabled).toEqual(['server2'])
+    })
+
+    it('handles servers in project overrides that are not in global server list', () => {
+      const globalServers = [{ name: 'server1', disabled: false }]
+      const projectOverrides = {
+        server2: { disabled: true },
+      }
+
+      const disabled = computeDisabledServersForProject(projectOverrides, globalServers)
+      expect(disabled).toEqual(['server2'])
+    })
+
+    it('disables all servers when all are set to disabled in project overrides', () => {
+      const globalServers = [
+        { name: 'server1', disabled: false },
+        { name: 'server2', disabled: false },
+      ]
+      const projectOverrides = {
+        server1: { disabled: true },
+        server2: { disabled: true },
+      }
+
+      const disabled = computeDisabledServersForProject(projectOverrides, globalServers)
+      expect(disabled.sort()).toEqual(['server1', 'server2'].sort())
+    })
+
+    it('uses globalMcpServersProvider when globalServers argument is omitted', () => {
+      setGlobalMcpServersProvider(() => [
+        { name: 'alpha', disabled: true },
+        { name: 'beta', disabled: false },
+      ])
+
+      const disabled = computeDisabledServersForProject()
+      expect(disabled).toEqual(['alpha'])
+    })
+  })
+
+  describe('initSessionMcpOverrides', () => {
+    it('initializes session overrides from project in database', () => {
+      const project = createProject('Test Project', '/tmp/test')
+      updateProject(project.id, {
+        mcpOverrides: {
+          'project-disabled-server': { disabled: true },
+        },
+      })
+
+      const sessionId = 'session-test-1'
+      initSessionMcpOverrides(sessionId, project.id)
+
+      expect(getSessionDisabledServers(sessionId)).toEqual(['project-disabled-server'])
+    })
+
+    it('initializes session overrides when projectOverrides argument is passed directly', () => {
+      const sessionId = 'session-test-2'
+      initSessionMcpOverrides(sessionId, 'any-project', {
+        'direct-disabled-server': { disabled: true },
+      })
+
+      expect(getSessionDisabledServers(sessionId)).toEqual(['direct-disabled-server'])
+    })
+
+    it('clears session overrides on clearSessionOverrides', () => {
+      const sessionId = 'session-test-3'
+      setSessionDisabledServers(sessionId, ['server1', 'server2'])
+      expect(getSessionDisabledServers(sessionId)).toEqual(['server1', 'server2'])
+
+      clearSessionOverrides(sessionId)
+      expect(getSessionDisabledServers(sessionId)).toEqual([])
+    })
+  })
+})

--- a/src/server/mcp/session-overrides.ts
+++ b/src/server/mcp/session-overrides.ts
@@ -1,5 +1,6 @@
 import { getDatabase } from '../db/index.js'
 import { updateSessionMcpDisabledServers } from '../db/sessions.js'
+import { getProject } from '../db/projects.js'
 
 const sessionOverrides = new Map<string, Set<string>>()
 let initialized = false
@@ -57,7 +58,54 @@ export function clearSessionOverrides(sessionId: string): void {
   }
 }
 
-export function getAllSessionOverrides(): Map<string, Set<string>> {
-  ensureInitialized()
-  return sessionOverrides
+export type GlobalMcpServersProvider = () => Array<{ name: string; disabled?: boolean | undefined }>
+
+let globalMcpServersProvider: GlobalMcpServersProvider | null = null
+
+export function setGlobalMcpServersProvider(provider: GlobalMcpServersProvider | null): void {
+  globalMcpServersProvider = provider
+}
+
+export function computeDisabledServersForProject(
+  projectOverrides?: Record<string, { disabled?: boolean; disabledTools?: string[] }> | null,
+  globalServers?: Array<{ name: string; disabled?: boolean }>,
+): string[] {
+  const servers = globalServers ?? globalMcpServersProvider?.() ?? []
+  const disabledSet = new Set<string>()
+
+  // 1. Process known global servers with project overrides or fallback to global disabled
+  for (const server of servers) {
+    const override = projectOverrides?.[server.name]
+    const isDisabled = override?.disabled !== undefined ? override.disabled : !!server.disabled
+    if (isDisabled) {
+      disabledSet.add(server.name)
+    }
+  }
+
+  // 2. Also process any project overrides for servers not present in globalServers
+  if (projectOverrides) {
+    for (const [name, override] of Object.entries(projectOverrides)) {
+      if (override.disabled) {
+        disabledSet.add(name)
+      }
+    }
+  }
+
+  return Array.from(disabledSet)
+}
+
+export function initSessionMcpOverrides(
+  sessionId: string,
+  projectId: string,
+  projectOverrides?: Record<string, { disabled?: boolean; disabledTools?: string[] }> | null,
+): void {
+  try {
+    const project = projectOverrides !== undefined ? { mcpOverrides: projectOverrides } : getProject(projectId)
+    const disabledServers = computeDisabledServersForProject(project?.mcpOverrides)
+    if (disabledServers.length > 0) {
+      setSessionDisabledServers(sessionId, disabledServers)
+    }
+  } catch {
+    // Non-critical — session works without MCP overrides
+  }
 }

--- a/src/server/routes/workspace-config.ts
+++ b/src/server/routes/workspace-config.ts
@@ -6,7 +6,7 @@ import { loadWorkspaceConfig, saveWorkspaceConfig } from '../git/workspace-confi
 import { getGlobalDataDir } from '../git/workspace.js'
 import { isDirectoryEntry } from '../utils/fs.js'
 import { getProjectByWorkdir, updateProject } from '../db/projects.js'
-import { setSessionDisabledServers } from '../mcp/session-overrides.js'
+import { setSessionDisabledServers, computeDisabledServersForProject } from '../mcp/session-overrides.js'
 import { logger } from '../utils/logger.js'
 import type { WorkspaceConfig } from '../../shared/workspace.js'
 import { formatRootDir, getRootDirBlockReason, suggestRootDirChild } from '../../shared/workspace.js'
@@ -195,12 +195,14 @@ export function createWorkspaceConfigRoutes(sessionManager: SessionManager): Rou
       if (mcpOverrides !== undefined) {
         const project = getProjectByWorkdir(workdir)
         if (project) {
+          const overridesObj =
+            Object.keys(mcpOverrides).length > 0
+              ? (mcpOverrides as Record<string, { disabled?: boolean; disabledTools?: string[] }>)
+              : null
           updateProject(project.id, {
-            mcpOverrides: Object.keys(mcpOverrides).length > 0 ? mcpOverrides : null,
+            mcpOverrides: overridesObj,
           })
-          const disabledServers = Object.entries(mcpOverrides as Record<string, { disabled?: boolean }>)
-            .filter(([, override]) => override.disabled)
-            .map(([name]) => name)
+          const disabledServers = computeDisabledServersForProject(overridesObj)
           const allSessions = sessionManager.listSessions()
           for (const s of allSessions) {
             if (s.projectId === project.id) {

--- a/src/server/session/manager.test.ts
+++ b/src/server/session/manager.test.ts
@@ -176,6 +176,25 @@ describe('SessionManager', () => {
     expect(sessionEvents).toContain('phase_changed')
   })
 
+  it('inherits project MCP overrides on createSession and cleans up on deleteSession', async () => {
+    const { updateProject } = await import('../db/projects.js')
+    const { getSessionDisabledServers } = await import('../mcp/session-overrides.js')
+
+    updateProject(projectId, {
+      mcpOverrides: {
+        'server-disabled-1': { disabled: true },
+        'server-disabled-2': { disabled: true },
+        'server-enabled': { disabled: false },
+      },
+    })
+
+    const session = manager.createSession(projectId, 'MCP Project Session')
+    expect(getSessionDisabledServers(session.id)).toEqual(['server-disabled-1', 'server-disabled-2'])
+
+    manager.deleteSession(session.id)
+    expect(getSessionDisabledServers(session.id)).toEqual([])
+  })
+
   it('uses database is_running as source of truth for session state', () => {
     const session = manager.createSession(projectId)
 
@@ -797,6 +816,17 @@ describe('SessionManager', () => {
       expect(forked.messages).toHaveLength(2)
       expect(forked.messages[0]?.content).toBe('Hello')
       expect(forked.messages[1]?.content).toBe('Hi there!')
+    })
+
+    it('preserves disabled MCP servers from original session on fork', async () => {
+      const { setSessionDisabledServers, getSessionDisabledServers } = await import('../mcp/session-overrides.js')
+      const original = manager.createSession(projectId)
+      setSessionDisabledServers(original.id, ['server-a', 'server-b'])
+
+      const msg = manager.addMessage(original.id, { role: 'user', content: 'Hello', tokenCount: 10 })
+      const forked = manager.forkSession(original.id, msg.id)
+
+      expect(getSessionDisabledServers(forked.id)).toEqual(['server-a', 'server-b'])
     })
 
     it('throws error for non-existent messageId', () => {

--- a/src/server/session/manager.ts
+++ b/src/server/session/manager.ts
@@ -47,6 +47,12 @@ import {
 } from '../db/sessions.js'
 import { getProject } from '../db/projects.js'
 import {
+  initSessionMcpOverrides,
+  clearSessionOverrides,
+  getSessionDisabledServers,
+  setSessionDisabledServers,
+} from '../mcp/session-overrides.js'
+import {
   ensureWorkspace,
   resolveAndValidateSourceBranch,
   validateRef,
@@ -406,6 +412,13 @@ export class SessionManager {
     // Build full session object
     const session = this.buildSessionFromDb(dbSession)
 
+    // Initialize MCP overrides from project settings / global defaults
+    try {
+      initSessionMcpOverrides(session.id, projectId, project.mcpOverrides)
+    } catch {
+      // Non-critical — session works without MCP overrides
+    }
+
     // Persist the current branch asynchronously — the session is valid without it.
     getGitBranch(effectiveWorkdir)
       .then((branch) => {
@@ -504,6 +517,12 @@ export class SessionManager {
     if (cached) {
       updateSessionCachedPrompt(newSession.id, cached.systemPrompt, cached.tools, cached.hash, cached.promptHash)
       this.markWarmedUp(newSession.id)
+    }
+
+    // Preserve parent session MCP disabled servers in the forked session
+    const parentDisabledServers = getSessionDisabledServers(originalSessionId)
+    if (parentDisabledServers.length > 0) {
+      setSessionDisabledServers(newSession.id, parentDisabledServers)
     }
 
     this.emit({ type: 'session_updated', session: this.requireSession(newSession.id) })
@@ -712,6 +731,9 @@ export class SessionManager {
     this.announcedPromptHashStore.delete(id)
     this.announcedToolFingerprintStore.delete(id)
     this.unknownProviderWarned.delete(id)
+
+    // Clean up session MCP overrides
+    clearSessionOverrides(id)
 
     // Delete session from DB
     dbDeleteSession(id)

--- a/web/src/components/settings/ProjectSettingsModal.tsx
+++ b/web/src/components/settings/ProjectSettingsModal.tsx
@@ -207,7 +207,7 @@ export function ProjectSettingsModal({ isOpen, onClose, project }: ProjectSettin
       const wsConfigPayload: WorkspaceConfigResponse = {}
       if (setupDirty) wsConfigPayload.setup = setup
       if (rootDirDirty) wsConfigPayload.rootDir = rootDir.trim()
-      if (Object.keys(mcpOverrides).length > 0) wsConfigPayload.mcpOverrides = mcpOverrides
+      if (mcpDirty) wsConfigPayload.mcpOverrides = mcpOverrides
       await saveWorkspaceConfig(project.workdir, wsConfigPayload)
     }
     setInstructionsDirty(false)


### PR DESCRIPTION
### Summary

- Fix MCP session override inheritance: new sessions now properly inherit project-level disabled MCP servers and global MCP defaults.
- Centralize MCP override calculation in `session-overrides.ts` (`computeDisabledServersForProject`, `initSessionMcpOverrides`).
- Preserve disabled MCP servers when forking sessions (`forkSession`) and cleanup on delete (`deleteSession`).
- Fix `ProjectSettingsModal` payload to send empty overrides when dirty so settings can be cleared.

### AI-Enhanced Development

Tell what models helped shape this PR:

- **AI Models:** Gemini 3.7 Flash

### Cache Impact

Does this PR affect anything cached — system prompts, tool definitions, skills, or other context?

- **Yes** tool definitions and dynamic context now correctly reflect project MCP configuration on session start.