### PR TITLE
fix(path-security): flag absolute paths nested in quotes

### DIFF
--- a/e2e/path-security.test.ts
+++ b/e2e/path-security.test.ts
@@ -118,6 +118,32 @@ describe('Path Security', () => {
       const payload = confirmationEvent!.payload as PathConfirmationPayload
       expect(payload.paths.some((p: string) => p.includes('home'))).toBe(true)
     })
+
+    it('emits path_confirmation for a path nested in quotes inside run_command', async () => {
+      client.clearEvents()
+
+      // The path lives in single quotes nested inside a double-quoted program
+      // string. Without quote-aware extraction no path is detected at all and
+      // the command would run unconfirmed, so this assertion stays unconditional.
+      await client.send('chat.send', {
+        content: `Run the exact command: python3 -c "print(open('/home/test/nested.txt').read())"`,
+      })
+
+      const confirmationEvent = await client.waitFor('chat.path_confirmation', undefined, 500).catch(() => null)
+
+      expect(confirmationEvent).not.toBeNull()
+
+      const payload = confirmationEvent!.payload as PathConfirmationPayload
+      expect(payload.tool).toBe('run_command')
+      expect(payload.reason).toBe('outside_workdir')
+      expect(payload.paths.some((p: string) => p.includes('/home/test/nested.txt'))).toBe(true)
+
+      // Resolve the confirmation: an unanswered one leaves the tool call
+      // suspended for the rest of the file's shared server.
+      const session = client.getSession()!
+      await answerPathConfirmation(server.url, session.id, payload.callId, false)
+      await client.waitFor('chat.done').catch(() => null)
+    })
   })
 
   describe('Sensitive File Detection', () => {

--- a/src/server/tools/path-security.test.ts
+++ b/src/server/tools/path-security.test.ts
@@ -674,6 +674,30 @@ describe('path-security', () => {
         const paths = extractAbsolutePathsFromCommand('find /var/log -name x 2>/dev/null')
         expect(paths).toContain('/var/log')
       })
+
+      // Nested quotes: a path in single quotes inside a double-quoted argument
+      // (python -c, node -e, bash -c ...). The quote scanner must pair quotes by
+      // type, otherwise the path becomes a delimiter between two pseudo-strings
+      // and is never inspected — an unconfirmed read/write outside the workdir.
+      it('flags a single-quoted path nested in a double-quoted python -c program', () => {
+        const paths = extractAbsolutePathsFromCommand(`python3 -c "print(open('/etc/passwd').read())"`)
+        expect(paths).toContain('/etc/passwd')
+      })
+
+      it('flags a single-quoted path nested in a double-quoted node -e program', () => {
+        const paths = extractAbsolutePathsFromCommand(`node -e "require('fs').readFileSync('/etc/passwd')"`)
+        expect(paths).toContain('/etc/passwd')
+      })
+
+      it('flags a single-quoted path nested in a double-quoted bash -c command', () => {
+        const paths = extractAbsolutePathsFromCommand(`bash -c "cat '/etc/passwd'"`)
+        expect(paths).toContain('/etc/passwd')
+      })
+
+      it('flags a nested-quote write outside the workdir', () => {
+        const paths = extractAbsolutePathsFromCommand(`python3 -c "open('/etc/evil.conf','w').write('x')"`)
+        expect(paths).toContain('/etc/evil.conf')
+      })
     })
 
     describe('sed/awk/perl/ruby regex address false positives', () => {

--- a/src/server/tools/path-security.ts
+++ b/src/server/tools/path-security.ts
@@ -781,7 +781,14 @@ export function extractAbsolutePathsFromCommand(command: string): string[] {
     }
   }
   if (posixShell) {
-    const absolutePattern = /(?:^|[\s=(])(\/[^\s"'|&;<>`()]+)/g
+    // A quote can precede a real path operand. Nested quoting puts the path
+    // right after a quote (python3 -c "open('/etc/passwd')", bash -c "cat
+    // '/etc/passwd'"), and the quoted-string pass above cannot see it: pairing
+    // quotes without regard to type makes the path a delimiter between two
+    // pseudo-strings. The path's own character class stops at the closing quote,
+    // so the captured span stays exact. Regex-tool operands are unaffected: they
+    // are already masked upstream by maskRegexAddresses.
+    const absolutePattern = /(?:^|([\s=('"]))(\/[^\s"'|&;<>`()]+)/g
 
     // A lone `/` token is the root filesystem — flag it (find /, ls /, cd /).
     // `//` comment lines and JSX `/>` self-closing tags are not roots.
@@ -803,7 +810,12 @@ export function extractAbsolutePathsFromCommand(command: string): string[] {
     }
 
     while ((match = absolutePattern.exec(scanCommand)) !== null) {
-      const candidate = match[1]!
+      const opener = match[1] ?? ''
+      const candidate = match[2]!
+
+      // A quoted span that both opens and closes with `/` is a regex address
+      // (grep '/foo/'), never a path — same rule the quoted-string pass applies.
+      if ((opener === "'" || opener === '"') && candidate.endsWith('/')) continue
 
       // Skip placeholder markers left by sanitization
       if (isPlaceholderToken(candidate)) continue


### PR DESCRIPTION
### Summary

An absolute path wrapped in single quotes nested inside double quotes escaped the path-security scan entirely — e.g. `python3 -c "print(open('/etc/passwd').read())"` or `bash -c "cat '/etc/passwd'"`, for reads and writes alike. The quote-pairing pass matched quotes without distinguishing their type, so the path became a boundary between two pseudo-strings and was never examined. The unquoted form was already caught, which masked the gap — and after `checkPathAccess` there is no downstream net in `run_command`.

The fix captures the opening quote in the absolute-path pattern and applies to nested spans the same regex-address rule the quoted-string pass already uses.

Proof by removal: reverting the fix turns 4 unit tests and 1 e2e test red. Locally green on this branch: lint, typecheck, duplicate, unit suite, e2e path-security (13/13). Originally written against 2.0.120, rebased onto current `develop` — the `maskCommandForPathScan` refactor is preserved.

### AI-Enhanced Development

Tell what models helped shape this PR:

- **AI Models:** Claude Fable 5 (via Claude Code) — code and tests, human-reviewed and human-tested before submission.

### Cache Impact

- **No**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HPjMiPd4SeKQL8mKTw2XZ2