### PR TITLE
Feat/add apple & android ico img, for mobile compatiblity

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -3,9 +3,13 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/assets/openfox.png" />
+    <link rel="icon" type="image/png" sizes="192x192" href="/assets/openfox-192.png" />
+    <link rel="icon" type="image/png" sizes="512x512" href="/assets/openfox-512.png" />
+    <link rel="apple-touch-icon" href="/assets/openfox-512.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, height=device-height" />
     <title>OpenFox</title>
   </head>
+
   <body class="bg-bg-primary text-text-primary font-mono">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>


### PR DESCRIPTION
### Summary

Add apple-touch-icon to 512x512 image
Add an android compatible header. (Vite auto generate the manifest.

It allows to use openfox as an "installed website" as an app, with a nice logo.
It also allow a better mobile browser integration in case the app is added in favorite.

### AI-Enhanced Development

Tell what models helped shape this PR:

none

### Cache Impact

Does this PR affect anything cached — system prompts, tool definitions, skills, or other context?

- **No**


Before / After : 
<img width="200" alt="IMG_2596" src="https://github.com/user-attachments/assets/c46f974e-9bbf-4403-8029-fea5f7a3cdbb" /> <img width="200" alt="IMG_2596" src="https://github.com/user-attachments/assets/f269eb0c-b417-48ba-913e-395a75299b34" />



