### PR TITLE
fix: convert OpenAI content arrays to Ollama-native format for vision…

### DIFF
--- a/src/server/llm/ollama-native.test.ts
+++ b/src/server/llm/ollama-native.test.ts
@@ -110,6 +110,52 @@ describe('buildOllamaChatRequest', () => {
     const body = buildOllamaChatRequest(streamParams({ messages }))
     expect(body['messages']).toStrictEqual(messages)
   })
+
+  it('converts OpenAI content array with text and image_url to Ollama-native format', () => {
+    const base64Image =
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=='
+    const messages = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'What is in this image?' },
+          { type: 'image_url', image_url: { url: `data:image/png;base64,${base64Image}` } },
+          { type: 'text', text: 'Please be detailed.' },
+        ],
+      },
+    ] as ChatCompletionMessageParam[]
+    const body = buildOllamaChatRequest(streamParams({ messages }))
+    expect(body['messages']).toEqual([
+      {
+        role: 'user',
+        content: 'What is in this image?\nPlease be detailed.',
+        images: [base64Image],
+      },
+    ])
+  })
+
+  it('converts content array with multiple image_url parts', () => {
+    const img1 = 'img1base64data'
+    const img2 = 'img2base64data'
+    const messages = [
+      {
+        role: 'user',
+        content: [
+          { type: 'image_url', image_url: { url: `data:image/png;base64,${img1}` } },
+          { type: 'text', text: 'and this' },
+          { type: 'image_url', image_url: { url: `data:image/png;base64,${img2}` } },
+        ],
+      },
+    ] as ChatCompletionMessageParam[]
+    const body = buildOllamaChatRequest(streamParams({ messages }))
+    expect(body['messages']).toEqual([
+      {
+        role: 'user',
+        content: 'and this',
+        images: [img1, img2],
+      },
+    ])
+  })
 })
 
 describe('parseOllamaChatResponse', () => {

--- a/src/server/llm/ollama-native.ts
+++ b/src/server/llm/ollama-native.ts
@@ -93,28 +93,81 @@ export function toOllamaThink(effort: string): boolean | string {
  * while OpenAI-shaped history messages carry it as a JSON string. Parse the
  * string back into an object; messages without tool calls pass through
  * untouched.
+ *
+ * Also converts OpenAI-style content arrays to Ollama-native format:
+ * - Text parts are concatenated into the `content` string
+ * - image_url parts are extracted as base64 strings into the `images` array
  */
 function toNativeMessage(message: ChatCompletionMessageParam): Record<string, unknown> {
   const raw = message as unknown as Record<string, unknown>
   const toolCalls = raw['tool_calls']
-  if (!Array.isArray(toolCalls) || toolCalls.length === 0) {
-    return raw
-  }
-  return {
-    ...raw,
-    tool_calls: toolCalls.map((toolCall) => {
-      const fn = (toolCall as { function?: { arguments?: unknown } }).function
-      if (!fn || typeof fn.arguments !== 'string') return toolCall
-      try {
-        return {
-          ...toolCall,
-          function: { ...fn, arguments: JSON.parse(fn.arguments) },
+
+  // Handle content: if it's an array, convert to Ollama-native format
+  const content = raw['content']
+  if (Array.isArray(content)) {
+    const textParts: string[] = []
+    const imageParts: string[] = []
+
+    for (const part of content) {
+      if (part.type === 'text') {
+        textParts.push(part.text)
+      } else if (part.type === 'image_url') {
+        const match = part.image_url.url.match(/^data:image\/[^;]+;base64,(.+)$/)
+        if (match && match[1]) {
+          imageParts.push(match[1])
         }
-      } catch {
-        return toolCall
       }
-    }),
+    }
+
+    const result: Record<string, unknown> = {
+      ...raw,
+      content: textParts.join('\n'),
+    }
+
+    if (imageParts.length > 0) {
+      result['images'] = imageParts
+    }
+
+    // If there are also tool_calls, convert their arguments
+    if (Array.isArray(toolCalls) && toolCalls.length > 0) {
+      result['tool_calls'] = toolCalls.map((toolCall) => {
+        const fn = (toolCall as { function?: { arguments?: unknown } }).function
+        if (!fn || typeof fn.arguments !== 'string') return toolCall
+        try {
+          return {
+            ...toolCall,
+            function: { ...fn, arguments: JSON.parse(fn.arguments) },
+          }
+        } catch {
+          return toolCall
+        }
+      })
+    }
+
+    return result
   }
+
+  // No content array - handle tool calls if present
+  if (Array.isArray(toolCalls) && toolCalls.length > 0) {
+    return {
+      ...raw,
+      tool_calls: toolCalls.map((toolCall) => {
+        const fn = (toolCall as { function?: { arguments?: unknown } }).function
+        if (!fn || typeof fn.arguments !== 'string') return toolCall
+        try {
+          return {
+            ...toolCall,
+            function: { ...fn, arguments: JSON.parse(fn.arguments) },
+          }
+        } catch {
+          return toolCall
+        }
+      }),
+    }
+  }
+
+  // No tool calls and content is not an array - pass through unchanged
+  return raw
 }
 
 /**


### PR DESCRIPTION

### Summary

Fixes image description failures with Ollama backends. The native /api/chat endpoint expects content as a string, but OpenFox was sending OpenAI-style content arrays, causing HTTP 400 errors.

This change converts content arrays to Ollama-native format: text parts → content string, image_url parts → images array.

Closes https://github.com/co-l/openfox/issues/268

### Remarks

#### Sources of truth
- [Ollama Vision Documentation](https://docs.ollama.com/capabilities/vision) - Details on `/api/chat` with `images` field
- [OpenAI Chat Completions API](https://platform.openai.com/docs/api-reference/chat) - Reference for content array format

#### Additional recommended update: docs/screenshots/vision-fallback.png
The outdated config picture lacks 2 fields. Needs the recent information like this:
<img width="1201" height="945" alt="vision-config-2" src="https://github.com/user-attachments/assets/b605cfcc-398e-4d3a-9ad6-463365cfef6d" />

### AI-Enhanced Development

Tell what models helped shape this PR:

**AI Models:** Qwen 3.5 9B (for testing), Qwen 3.5 0.8B (vision fallback)

### Cache Impact

- **No**
