### PR TITLE
feat(server): read Claude Code conventions behind a compatibility setting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,6 +198,8 @@ Every file in `.openfox/` must be **committable** and **meaningful in the projec
 
 **Rationale:** Clean repo, no leaked personal config, reliable source of truth for CI and collaborators.
 
+**Claude Code compatibility:** the `compat.claudeCode` setting (Settings → Advanced, `auto` by default) makes OpenFox also read Claude Code's conventions — skills from `~/.claude/skills` and `<project>/.claude/skills`, memory from `~/.claude/CLAUDE.md` and `<project>/.claude/CLAUDE.md`, and `@file` imports inside instruction files. On `auto` it switches on when the project holds a `.claude/` directory or a `CLAUDE.md`. Identical instruction files (a repo shipping AGENTS.md and CLAUDE.md as copies of each other) are injected once regardless of the setting. Full design: [docs/DESIGN-CLAUDE-CODE-COMPAT.md](DESIGN-CLAUDE-CODE-COMPAT.md).
+
 **Workflows:** When asked to create or edit a workflow, load the built-in `workflows` skill via `load_skill("workflows")` — it is the authoritative reference for workflow file format, storage locations (project `.openfox/workflows/` vs global `{configDir}/workflows/`), the full JSON schema, step types, transition conditions, and template variables ([docs/WORKFLOWS.md](docs/WORKFLOWS.md) is a pointer to it). Project workflows belong in `.openfox/workflows/` and are committable.
 
 ## TDD Workflow

--- a/docs/DESIGN-CLAUDE-CODE-COMPAT.md
+++ b/docs/DESIGN-CLAUDE-CODE-COMPAT.md
@@ -1,0 +1,123 @@
+# Claude Code Compatibility
+
+## Goal
+
+Let OpenFox pick up a project that was set up for Claude Code without asking the user to duplicate anything.
+
+OpenFox already reads `CLAUDE.md` as one of its instruction filenames, which looks like support but stops well short of it. Claude Code keeps skills in `.claude/skills`, memory in `.claude/CLAUDE.md` and `~/.claude/CLAUDE.md`, and composes memory files with `@file` imports. None of that was visible to OpenFox, so a user arriving from Claude Code silently lost most of their setup.
+
+Two concrete failures on a real machine:
+
+- Of 14 skills in `~/.claude/skills`, only the 8 that happened to be symlinks into `~/.agents/skills` were discovered. The 6 real directories were invisible.
+- `~/.claude/CLAUDE.md` was never read at all — and its entire content was `@RTK.md`, so even reading it would have contributed nothing without import expansion.
+
+## User Experience
+
+A single tri-state setting in **Settings → Advanced**, "Claude Code Compatibility":
+
+| Value            | Behaviour                                                         |
+| ---------------- | ----------------------------------------------------------------- |
+| `auto` (default) | on when the project holds a `.claude/` directory or a `CLAUDE.md` |
+| `true`           | always on                                                         |
+| `false`          | always off                                                        |
+
+`auto` is the interesting one: a project that came from Claude Code carries its own marker, so the user configures nothing. A project that uses `AGENTS.md` is untouched, and nothing new enters its prompt.
+
+When compatibility applies:
+
+- Skills from `~/.claude/skills` and `<project>/.claude/skills` appear in the Skills modal under **Shared**, alongside the existing `.agents/skills` entries.
+- `~/.claude/CLAUDE.md` and `<dir>/.claude/CLAUDE.md` join the instruction block.
+- `@file` references inside any instruction file are replaced by the file's content.
+
+## Technical Design
+
+### Resolution
+
+`src/server/shared/claude-compat.ts` owns the decision, so instructions and skills cannot drift apart:
+
+```ts
+readClaudeCompatMode(): 'auto' | 'enabled' | 'disabled'   // reads compat.claudeCode
+isClaudeCodeProject(dir): Promise<boolean>                // .claude/ or CLAUDE.md present
+resolveClaudeCompat(dir?, override?): Promise<boolean>    // override > setting > detection
+```
+
+Detection looks at the directory itself, not its ancestors. Walking up would reach `~/.claude` for any project under the home directory and turn compatibility on everywhere, which is not what "this project came from Claude Code" means.
+
+`override` exists so callers that already resolved the flag can pass it down, and so tests never touch the developer's real `~/.claude`.
+
+### Setting
+
+`compat.claudeCode`, stored in the settings table, default `'auto'`. Tri-state rather than a boolean because a plain toggle cannot express "decide per project", which is the behaviour that makes the feature invisible when it should be.
+
+### Skills
+
+`loadAllSkillsWithDiagnostics` gains two roots, in precedence order (later wins):
+
+```
+bundled defaults
+~/.agents/skills                     global-shared
+~/.claude/skills                     global-claude      ← new
+<configDir>/skills                   global-openfox
+<selected directories>               selected
+<project>/.agents/skills             project-shared
+<project>/.claude/skills             project-claude     ← new
+<project>/.openfox/skills            project-openfox
+```
+
+Claude roots sit just after their `.agents` counterpart and before OpenFox's own, so an OpenFox skill always wins an id collision. No parser work was needed: `loadPortableSkills` already reads `<dir>/SKILL.md` with `name` / `description` frontmatter, which is exactly Claude Code's format.
+
+`EXTERNAL_SKILL_SOURCES` in `skills/types.ts` collects the sources that live outside OpenFox's own config, replacing the three places that each listed them inline (`canModifySkill`, the route's `readOnly` computation, the modal's "Shared" group).
+
+### Instruction files
+
+`findInstructionFiles` keeps its root-to-workdir walk. Compatibility adds:
+
+- `~/.claude/CLAUDE.md` prepended before the walk, so user-level memory has the lowest priority and any project file overrides it.
+- `<dir>/.claude/CLAUDE.md` checked at each level, after `AGENTS.md` and `CLAUDE.md`.
+
+Paths are deduplicated, which matters when the walk reaches the home directory and would otherwise pick up user memory twice.
+
+### `@file` imports
+
+Applied while reading each instruction file:
+
+- Resolved against the importing file's directory; `~/` expands to the home directory.
+- Depth capped at 5, matching Claude Code.
+- Every imported path is canonicalised through `realpath` and recorded, so a file is inlined once and cycles terminate. A repeat import yields an empty string rather than recursing.
+- Skipped inside fenced blocks and inline code spans, so documentation that shows an `@import` example is not expanded.
+- A path that does not resolve to a readable file is left exactly as written. `@mention` and `user@example.com` therefore survive untouched — a token is only an import if it points at something real.
+- Inlined content is prefixed with `Instructions from: <path>`, the same provenance marker the loader already uses for top-level files.
+
+The match rule is `(^|[\s(])@<non-space>`: the `@` must open a word, which is what excludes e-mail addresses without needing to special-case them.
+
+### Deduplication
+
+Instruction files are hashed (SHA-256 over trimmed content) and a file whose content was already collected is dropped. Empty files are dropped too.
+
+This is **not** gated by the setting. Repositories very commonly ship `AGENTS.md` and `CLAUDE.md` as copies or symlinks of each other, and both were being sent to the model — a correctness bug that predates this feature and is unrelated to Claude Code.
+
+`loadInstructionFiles` now reads each file once and returns the content, so `getAllInstructions` no longer re-reads them to populate its file list, and that list reports only what was actually injected.
+
+### Diagnostics
+
+The "reached through multiple paths" skill diagnostic now fires only when a directory the user picked (`selected`) overlaps another root. Two automatic roots symlinked into each other — `.claude/skills` → `.agents/skills` is a common way to share one library between both tools — produced one line of noise per skill and nothing the user could act on.
+
+## Edge Cases
+
+- **Symlinked skill directories.** `loadPortableSkills` resolves `realpath`, so the same package reached from `.agents/skills` and `.claude/skills` collapses to one entry.
+- **Import cycles.** `a.md` importing `b.md` importing `a.md` terminates: the visited set is seeded with the root file's canonical path.
+- **Import inside a code block.** Fence state is tracked line by line; inline spans are handled by splitting on backticks and expanding only the even segments.
+- **Unreadable or missing instruction file.** Skipped silently, as before. It no longer leaves a content-less entry in the injected file list.
+- **Home directory inside the walk.** A workdir under `$HOME` walks through `$HOME` itself, which would match `~/.claude/CLAUDE.md` a second time; path deduplication prevents it.
+- **Prompt cache.** Instruction content and skill ids already feed `computeDynamicContextHash`, so switching the setting or entering a Claude Code project invalidates the cached prompt through the existing mechanism.
+- **Windows.** Discovery uses `path.join` throughout and adds no shell or separator assumptions.
+
+## Out of Scope
+
+Deliberately not covered, and still invisible to OpenFox:
+
+- `.claude/agents/*.md` (sub-agent definitions) — a different frontmatter contract from OpenFox's `.agent.md`
+- `.claude/commands/*.md` (slash commands)
+- `.mcp.json` (project-scoped MCP servers) — OpenFox stores servers in its database
+- `.claude/settings.json` (hooks, permissions, environment)
+- Plugin skills under `~/.claude/plugins`, which use a marketplace layout rather than a plain skills directory

--- a/src/server/context/instructions.test.ts
+++ b/src/server/context/instructions.test.ts
@@ -11,6 +11,7 @@ import {
   findInstructionFiles,
   getAllInstructions,
   getInstructionsForWorkdir,
+  loadInstructionFiles,
   loadInstructions,
   type InstructionFile,
 } from './instructions.js'
@@ -26,6 +27,9 @@ describe('instructions', () => {
     // Create a unique temp directory for each test
     testDir = join(tmpdir(), `openfox-test-${Date.now()}-${Math.random().toString(36).slice(2)}`)
     await mkdir(testDir, { recursive: true })
+    // Claude Code compatibility defaults to auto-detection; pin it off so the
+    // suite never reaches into the developer's own ~/.claude.
+    setSetting(SETTINGS_KEYS.COMPAT_CLAUDE_CODE, 'false')
   })
 
   afterEach(async () => {
@@ -243,6 +247,183 @@ describe('instructions', () => {
 
       expect(result.content).toBe('')
       expect(result.files).toEqual([])
+    })
+  })
+  describe('deduplication', () => {
+    it('injects duplicated AGENTS.md / CLAUDE.md content only once', async () => {
+      await writeFile(join(testDir, 'AGENTS.md'), '# Same rules')
+      await writeFile(join(testDir, 'CLAUDE.md'), '# Same rules')
+
+      const files = await findInstructionFiles(testDir)
+      expect(files).toHaveLength(2)
+
+      const loaded = await loadInstructionFiles(files)
+      expect(loaded.map((file) => file.path)).toEqual([join(testDir, 'AGENTS.md')])
+    })
+
+    it('keeps files whose content differs', async () => {
+      await writeFile(join(testDir, 'AGENTS.md'), '# Agent rules')
+      await writeFile(join(testDir, 'CLAUDE.md'), '# Claude rules')
+
+      const loaded = await loadInstructionFiles(await findInstructionFiles(testDir))
+      expect(loaded).toHaveLength(2)
+    })
+
+    it('drops empty instruction files', async () => {
+      await writeFile(join(testDir, 'AGENTS.md'), '   \n')
+
+      const loaded = await loadInstructionFiles(await findInstructionFiles(testDir))
+      expect(loaded).toEqual([])
+    })
+
+    it('reports only the injected files', async () => {
+      const project = createProject('OpenFox', testDir)
+      await writeFile(join(testDir, 'AGENTS.md'), '# Same rules')
+      await writeFile(join(testDir, 'CLAUDE.md'), '# Same rules')
+
+      const result = await getAllInstructions(testDir, project.id)
+
+      expect(result.files).toEqual([{ path: join(testDir, 'AGENTS.md'), source: 'agents-md', content: '# Same rules' }])
+    })
+  })
+
+  describe('claude code compatibility', () => {
+    let homeDir: string
+    let projectDir: string
+
+    beforeEach(async () => {
+      homeDir = join(testDir, 'home')
+      projectDir = join(testDir, 'project')
+      await mkdir(join(homeDir, '.claude'), { recursive: true })
+      await mkdir(projectDir, { recursive: true })
+    })
+
+    it('reads ~/.claude/CLAUDE.md before project files', async () => {
+      await writeFile(join(homeDir, '.claude', 'CLAUDE.md'), '# User memory')
+      await writeFile(join(projectDir, 'AGENTS.md'), '# Project rules')
+
+      const files = await findInstructionFiles(projectDir, { claudeCompat: true, homeDir })
+
+      expect(files.map((file) => file.path)).toEqual([
+        join(homeDir, '.claude', 'CLAUDE.md'),
+        join(projectDir, 'AGENTS.md'),
+      ])
+    })
+
+    it('reads .claude/CLAUDE.md inside the project', async () => {
+      await mkdir(join(projectDir, '.claude'))
+      await writeFile(join(projectDir, '.claude', 'CLAUDE.md'), '# Project memory')
+
+      const files = await findInstructionFiles(projectDir, { claudeCompat: true, homeDir })
+
+      expect(files.map((file) => file.path)).toEqual([join(projectDir, '.claude', 'CLAUDE.md')])
+    })
+
+    it('ignores .claude locations when compatibility is off', async () => {
+      await mkdir(join(projectDir, '.claude'))
+      await writeFile(join(projectDir, '.claude', 'CLAUDE.md'), '# Project memory')
+      await writeFile(join(homeDir, '.claude', 'CLAUDE.md'), '# User memory')
+
+      const files = await findInstructionFiles(projectDir, { claudeCompat: false, homeDir })
+
+      expect(files).toEqual([])
+    })
+
+    it('auto-enables for a project carrying a .claude directory', async () => {
+      setSetting(SETTINGS_KEYS.COMPAT_CLAUDE_CODE, 'auto')
+      await mkdir(join(projectDir, '.claude'))
+      await writeFile(join(projectDir, '.claude', 'CLAUDE.md'), '# Project memory')
+
+      const files = await findInstructionFiles(projectDir, { homeDir })
+
+      expect(files.map((file) => file.path)).toContain(join(projectDir, '.claude', 'CLAUDE.md'))
+    })
+
+    it('stays off in auto mode for a project without Claude Code markers', async () => {
+      setSetting(SETTINGS_KEYS.COMPAT_CLAUDE_CODE, 'auto')
+      await writeFile(join(homeDir, '.claude', 'CLAUDE.md'), '# User memory')
+      await writeFile(join(projectDir, 'AGENTS.md'), '# Project rules')
+
+      const files = await findInstructionFiles(projectDir, { homeDir })
+
+      expect(files.map((file) => file.path)).toEqual([join(projectDir, 'AGENTS.md')])
+    })
+
+    it('expands @file imports relative to the importing file', async () => {
+      await writeFile(join(projectDir, 'RTK.md'), '# RTK rules')
+      await writeFile(join(projectDir, 'CLAUDE.md'), '@RTK.md')
+
+      const content = await loadInstructions([{ path: join(projectDir, 'CLAUDE.md'), source: 'agents-md' }], {
+        claudeCompat: true,
+        homeDir,
+      })
+
+      expect(content).toContain('# RTK rules')
+      expect(content).toContain(`Instructions from: ${join(projectDir, 'RTK.md')}`)
+    })
+
+    it('expands ~/ imports against the home directory', async () => {
+      await writeFile(join(homeDir, '.claude', 'RTK.md'), '# Home rules')
+      await writeFile(join(projectDir, 'CLAUDE.md'), 'See @~/.claude/RTK.md for details.')
+
+      const content = await loadInstructions([{ path: join(projectDir, 'CLAUDE.md'), source: 'agents-md' }], {
+        claudeCompat: true,
+        homeDir,
+      })
+
+      expect(content).toContain('# Home rules')
+      expect(content).toContain('for details.')
+    })
+
+    it('leaves unresolved tokens and e-mail addresses untouched', async () => {
+      await writeFile(join(projectDir, 'CLAUDE.md'), 'Ping @nobody and mail@example.com')
+
+      const content = await loadInstructions([{ path: join(projectDir, 'CLAUDE.md'), source: 'agents-md' }], {
+        claudeCompat: true,
+        homeDir,
+      })
+
+      expect(content).toContain('Ping @nobody and mail@example.com')
+    })
+
+    it('does not expand imports inside code fences or code spans', async () => {
+      await writeFile(join(projectDir, 'RTK.md'), '# RTK rules')
+      await writeFile(join(projectDir, 'CLAUDE.md'), ['```', '@RTK.md', '```', 'Inline `@RTK.md` stays.'].join('\n'))
+
+      const content = await loadInstructions([{ path: join(projectDir, 'CLAUDE.md'), source: 'agents-md' }], {
+        claudeCompat: true,
+        homeDir,
+      })
+
+      expect(content).not.toContain('# RTK rules')
+      expect(content).toContain('Inline `@RTK.md` stays.')
+    })
+
+    it('imports each file once even when imports form a cycle', async () => {
+      await writeFile(join(projectDir, 'a.md'), 'A-marker\n@b.md')
+      await writeFile(join(projectDir, 'b.md'), 'B-marker\n@a.md')
+      await writeFile(join(projectDir, 'CLAUDE.md'), '@a.md')
+
+      const content = await loadInstructions([{ path: join(projectDir, 'CLAUDE.md'), source: 'agents-md' }], {
+        claudeCompat: true,
+        homeDir,
+      })
+
+      expect(content.match(/A-marker/g)).toHaveLength(1)
+      expect(content.match(/B-marker/g)).toHaveLength(1)
+    })
+
+    it('does not expand imports when compatibility is off', async () => {
+      await writeFile(join(projectDir, 'RTK.md'), '# RTK rules')
+      await writeFile(join(projectDir, 'CLAUDE.md'), '@RTK.md')
+
+      const content = await loadInstructions([{ path: join(projectDir, 'CLAUDE.md'), source: 'agents-md' }], {
+        claudeCompat: false,
+        homeDir,
+      })
+
+      expect(content).not.toContain('# RTK rules')
+      expect(content).toContain('@RTK.md')
     })
   })
 })

--- a/src/server/context/instructions.ts
+++ b/src/server/context/instructions.ts
@@ -1,8 +1,11 @@
-import { readFile, access } from 'node:fs/promises'
-import { join, dirname } from 'node:path'
+import { readFile, access, realpath } from 'node:fs/promises'
+import { join, dirname, resolve, isAbsolute } from 'node:path'
+import { homedir } from 'node:os'
+import { createHash } from 'node:crypto'
 import { constants } from 'node:fs'
 import { getSetting, SETTINGS_KEYS } from '../db/settings.js'
 import { getProject } from '../db/projects.js'
+import { CLAUDE_DIR, CLAUDE_MEMORY_FILENAME, resolveClaudeCompat } from '../shared/claude-compat.js'
 import type { InjectedFile } from '../../shared/types.js'
 
 // ============================================================================
@@ -15,9 +18,19 @@ export interface InstructionFile {
   content?: string
 }
 
+export interface LoadedInstructionFile extends InstructionFile {
+  content: string
+}
+
 export interface AllInstructions {
   content: string
   files: InstructionFile[]
+}
+
+/** Overrides for discovery and loading; without them the settings decide. */
+export interface InstructionOptions {
+  claudeCompat?: boolean
+  homeDir?: string
 }
 
 export function buildLanguageInstruction(language: string | null | undefined): string | null {
@@ -30,6 +43,12 @@ export function buildLanguageInstruction(language: string | null | undefined): s
 // Filenames to look for (in order of priority within same directory)
 const INSTRUCTION_FILENAMES = ['AGENTS.md', 'CLAUDE.md']
 
+/** `@path/to/file.md` — the `@` must open a word so emails never match. */
+const IMPORT_PATTERN = /(^|[\s(])@([^\s@`'"()[\]]+)/g
+
+/** Claude Code stops at five levels of nested imports. */
+const MAX_IMPORT_DEPTH = 5
+
 // ============================================================================
 // Discovery
 // ============================================================================
@@ -38,9 +57,29 @@ const INSTRUCTION_FILENAMES = ['AGENTS.md', 'CLAUDE.md']
  * Find instruction files by walking up the directory tree from workdir.
  * Returns files ordered from root to workdir (parent directories first),
  * so that files closer to the working directory can override parent instructions.
+ *
+ * With Claude Code compatibility on, `~/.claude/CLAUDE.md` (user memory) comes
+ * first and each directory is also checked for `.claude/CLAUDE.md`.
  */
-export async function findInstructionFiles(workdir: string): Promise<InstructionFile[]> {
+export async function findInstructionFiles(
+  workdir: string,
+  options: InstructionOptions = {},
+): Promise<InstructionFile[]> {
+  const compat = await resolveClaudeCompat(workdir, options.claudeCompat)
+  const home = options.homeDir ?? homedir()
   const foundFiles: InstructionFile[] = []
+  const seenPaths = new Set<string>()
+
+  const addIfReadable = async (filePath: string): Promise<void> => {
+    if (seenPaths.has(filePath)) return
+    if (!(await fileExists(filePath))) return
+    seenPaths.add(filePath)
+    foundFiles.push({ path: filePath, source: 'agents-md' })
+  }
+
+  // User-level Claude Code memory applies before anything found on disk.
+  if (compat) await addIfReadable(join(home, CLAUDE_DIR, CLAUDE_MEMORY_FILENAME))
+
   const pathsToCheck: string[] = []
 
   // Walk up the directory tree
@@ -59,49 +98,199 @@ export async function findInstructionFiles(workdir: string): Promise<Instruction
   // Check each directory for instruction files
   for (const dir of pathsToCheck) {
     for (const filename of INSTRUCTION_FILENAMES) {
-      const filePath = join(dir, filename)
-      if (await fileExists(filePath)) {
-        foundFiles.push({
-          path: filePath,
-          source: 'agents-md',
-        })
-      }
+      await addIfReadable(join(dir, filename))
     }
+    if (compat) await addIfReadable(join(dir, CLAUDE_DIR, CLAUDE_MEMORY_FILENAME))
   }
 
   return foundFiles
+}
+
+// ============================================================================
+// Loading
+// ============================================================================
+
+/**
+ * Read instruction files, expanding `@file` imports when compatibility is on
+ * and dropping files whose content was already collected — repositories often
+ * ship AGENTS.md and CLAUDE.md as copies (or symlinks) of one another.
+ */
+export async function loadInstructionFiles(
+  files: InstructionFile[],
+  options: InstructionOptions = {},
+): Promise<LoadedInstructionFile[]> {
+  const home = options.homeDir ?? homedir()
+  const loaded: LoadedInstructionFile[] = []
+  const seenContent = new Set<string>()
+  // Callers pass the resolved flag; standalone calls fall back to the directory
+  // of the innermost file, which is the one closest to the working directory.
+  const deepest = files[files.length - 1]
+  const compat = await resolveClaudeCompat(deepest ? dirname(deepest.path) : undefined, options.claudeCompat)
+
+  for (const file of files) {
+    const content = await readInstructionFile(file.path, compat, home)
+    if (content === null) continue
+
+    const normalized = content.trim()
+    if (!normalized) continue
+
+    const fingerprint = createHash('sha256').update(normalized).digest('hex')
+    if (seenContent.has(fingerprint)) continue
+    seenContent.add(fingerprint)
+
+    loaded.push({ ...file, content })
+  }
+
+  return loaded
 }
 
 /**
  * Load instruction content from files.
  * Each file's content is prefixed with a comment showing its source path.
  */
-export async function loadInstructions(files: InstructionFile[]): Promise<string> {
-  const contents: string[] = []
+export async function loadInstructions(files: InstructionFile[], options: InstructionOptions = {}): Promise<string> {
+  return formatInstructions(await loadInstructionFiles(files, options))
+}
 
-  for (const file of files) {
-    try {
-      const content = await readFile(file.path, 'utf-8')
-      contents.push(`Instructions from: ${file.path}\n${content}`)
-    } catch {
-      // File doesn't exist or can't be read - skip silently
+function formatInstructions(files: LoadedInstructionFile[]): string {
+  return files.map((file) => `Instructions from: ${file.path}\n${file.content}`).join('\n')
+}
+
+async function readInstructionFile(path: string, compat: boolean, home: string): Promise<string | null> {
+  let raw: string
+  try {
+    raw = await readFile(path, 'utf-8')
+  } catch {
+    // File doesn't exist or can't be read - skip silently
+    return null
+  }
+  if (!compat) return raw
+  return expandImports(raw, dirname(path), home, new Set([await canonicalPath(path)]), 1)
+}
+
+// ============================================================================
+// `@file` imports (Claude Code compatibility)
+// ============================================================================
+
+/**
+ * Inline `@path` imports the way Claude Code does: paths resolve relative to
+ * the importing file, `~/` expands to the home directory, and anything that
+ * does not resolve to a readable file is left untouched.
+ */
+async function expandImports(
+  content: string,
+  baseDir: string,
+  home: string,
+  visited: Set<string>,
+  depth: number,
+): Promise<string> {
+  if (depth > MAX_IMPORT_DEPTH || !content.includes('@')) return content
+
+  const lines: string[] = []
+  let inFence = false
+
+  for (const line of content.split('\n')) {
+    if (/^\s*(```|~~~)/.test(line)) {
+      inFence = !inFence
+      lines.push(line)
       continue
     }
+    if (inFence || !line.includes('@')) {
+      lines.push(line)
+      continue
+    }
+    lines.push(await expandLine(line, baseDir, home, visited, depth))
   }
 
-  return contents.join('\n')
+  return lines.join('\n')
 }
+
+/** Backtick-delimited segments alternate; only even indexes sit outside code spans. */
+async function expandLine(
+  line: string,
+  baseDir: string,
+  home: string,
+  visited: Set<string>,
+  depth: number,
+): Promise<string> {
+  const segments = line.split('`')
+  for (let i = 0; i < segments.length; i += 2) {
+    segments[i] = await expandSegment(segments[i]!, baseDir, home, visited, depth)
+  }
+  return segments.join('`')
+}
+
+async function expandSegment(
+  segment: string,
+  baseDir: string,
+  home: string,
+  visited: Set<string>,
+  depth: number,
+): Promise<string> {
+  const matches = [...segment.matchAll(IMPORT_PATTERN)]
+  if (matches.length === 0) return segment
+
+  let result = ''
+  let cursor = 0
+
+  for (const match of matches) {
+    const start = match.index
+    const prefix = match[1] ?? ''
+    const rawPath = match[2] ?? ''
+    const imported = await importFile(rawPath, baseDir, home, visited, depth)
+    const replacement = imported ?? match[0].slice(prefix.length)
+    result += segment.slice(cursor, start) + prefix + replacement
+    cursor = start + match[0].length
+  }
+
+  return result + segment.slice(cursor)
+}
+
+/** Returns the imported text, `''` when already imported, or null when unresolvable. */
+async function importFile(
+  rawPath: string,
+  baseDir: string,
+  home: string,
+  visited: Set<string>,
+  depth: number,
+): Promise<string | null> {
+  const expanded = rawPath === '~' ? home : rawPath.startsWith('~/') ? join(home, rawPath.slice(2)) : rawPath
+  const absolute = isAbsolute(expanded) ? expanded : resolve(baseDir, expanded)
+
+  const key = await canonicalPath(absolute)
+  // Already inlined somewhere in this file: drop the token instead of recursing.
+  if (visited.has(key)) return ''
+
+  let raw: string
+  try {
+    raw = await readFile(absolute, 'utf-8')
+  } catch {
+    return null
+  }
+
+  visited.add(key)
+  const nested = await expandImports(raw, dirname(absolute), home, visited, depth + 1)
+  return `\nInstructions from: ${absolute}\n${nested}\n`
+}
+
+// ============================================================================
+// High-level helpers
+// ============================================================================
 
 /**
  * Convenience function to find and load all instruction files for a workdir.
  * Only includes AGENTS.md files, not global or project instructions.
  */
-export async function getInstructionsForWorkdir(workdir: string): Promise<{
+export async function getInstructionsForWorkdir(
+  workdir: string,
+  options: InstructionOptions = {},
+): Promise<{
   content: string
   files: InstructionFile[]
 }> {
-  const files = await findInstructionFiles(workdir)
-  const content = await loadInstructions(files)
+  const resolved = { ...options, claudeCompat: await resolveClaudeCompat(workdir, options.claudeCompat) }
+  const files = await findInstructionFiles(workdir, resolved)
+  const content = await loadInstructions(files, resolved)
   return { content, files }
 }
 
@@ -110,7 +299,11 @@ export async function getInstructionsForWorkdir(workdir: string): Promise<{
  * Order: language → global → project → AGENTS.md files
  * This is the primary function that should be used when building prompts.
  */
-export async function getAllInstructions(workdir: string, projectId: string): Promise<AllInstructions> {
+export async function getAllInstructions(
+  workdir: string,
+  projectId: string,
+  options: InstructionOptions = {},
+): Promise<AllInstructions> {
   const sections: string[] = []
   const allFiles: InstructionFile[] = []
 
@@ -134,21 +327,14 @@ export async function getAllInstructions(workdir: string, projectId: string): Pr
     allFiles.push({ path: `Project: ${project.name}`, source: 'project', content: project.customInstructions })
   }
 
-  // 3. AGENTS.md files (from filesystem)
-  const agentFiles = await findInstructionFiles(workdir)
+  // 3. AGENTS.md / CLAUDE.md files (from filesystem)
+  const resolved = { ...options, claudeCompat: await resolveClaudeCompat(workdir, options.claudeCompat) }
+  const agentFiles = await findInstructionFiles(workdir, resolved)
   if (agentFiles.length > 0) {
-    const agentContent = await loadInstructions(agentFiles)
-    if (agentContent) {
-      sections.push(`## FILE INSTRUCTIONS\n\n${agentContent}`)
-      // Load content for each file
-      for (const file of agentFiles) {
-        try {
-          const content = await readFile(file.path, 'utf-8')
-          allFiles.push({ ...file, content })
-        } catch {
-          allFiles.push(file)
-        }
-      }
+    const loaded = await loadInstructionFiles(agentFiles, resolved)
+    if (loaded.length > 0) {
+      sections.push(`## FILE INSTRUCTIONS\n\n${formatInstructions(loaded)}`)
+      allFiles.push(...loaded)
     }
   }
 
@@ -168,6 +354,15 @@ async function fileExists(path: string): Promise<boolean> {
     return true
   } catch {
     return false
+  }
+}
+
+/** Resolves symlinks so the same file reached through two paths counts once. */
+async function canonicalPath(path: string): Promise<string> {
+  try {
+    return await realpath(path)
+  } catch {
+    return path
   }
 }
 

--- a/src/server/db/settings.ts
+++ b/src/server/db/settings.ts
@@ -40,6 +40,7 @@ export const SETTINGS_KEYS = {
   TOOLS_SHELL: 'tools.shell',
   CONFIRM_ON_WORKSPACE_ACTIONS: 'tools.confirmOnWorkspaceActions',
   FEATURES_PER_SESSION_MCP: 'features.perSessionMcp',
+  COMPAT_CLAUDE_CODE: 'compat.claudeCode',
   MAINTENANCE_SNAPSHOT_STREAMS_MIGRATED: 'maintenance.snapshotStreamsMigratedV1',
   PROXY_URL: 'network.proxyUrl',
   DEFAULT_AGENT: 'agent.defaultAgent',
@@ -85,6 +86,7 @@ export const SETTINGS_DEFAULTS: Record<string, string> = {
   [SETTINGS_KEYS.TOOLS_SHELL]: 'cmd',
   [SETTINGS_KEYS.CONFIRM_ON_WORKSPACE_ACTIONS]: 'false',
   [SETTINGS_KEYS.FEATURES_PER_SESSION_MCP]: 'false',
+  [SETTINGS_KEYS.COMPAT_CLAUDE_CODE]: 'auto',
   [SETTINGS_KEYS.MAINTENANCE_SNAPSHOT_STREAMS_MIGRATED]: 'false',
 }
 

--- a/src/server/routes/skills.ts
+++ b/src/server/routes/skills.ts
@@ -25,7 +25,7 @@ import {
 } from '../skills/registry.js'
 import { installSkillPackage, SkillInstallError } from '../skills/installer.js'
 import { deleteSetting, getSetting, setSetting } from '../db/settings.js'
-import type { SkillDefinition } from '../skills/types.js'
+import { EXTERNAL_SKILL_SOURCES, type SkillDefinition } from '../skills/types.js'
 import { createCrudRoutes, validateNameIdPrompt, resolveProjectDir, type CrudRouteConfig } from './crud-helpers.js'
 import { serverT } from '../i18n.js'
 
@@ -74,9 +74,7 @@ function mapToResponse(skill: SkillDefinition) {
     source,
     path: skill.entrypoint ?? null,
     legacy: skill.legacy ?? true,
-    readOnly:
-      source === 'bundled' ||
-      ((source === 'global-shared' || source === 'selected' || source === 'project-shared') && (skill.legacy ?? true)),
+    readOnly: source === 'bundled' || (EXTERNAL_SKILL_SOURCES.includes(source) && (skill.legacy ?? true)),
     warnings: skill.warnings ?? [],
   }
 }

--- a/src/server/shared/claude-compat.test.ts
+++ b/src/server/shared/claude-compat.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+vi.mock('../db/settings.js', () => {
+  const store = new Map<string, string>()
+  return {
+    getSetting: (key: string) => store.get(key) ?? null,
+    setSetting: (key: string, value: string) => {
+      store.set(key, value)
+    },
+    deleteSetting: (key: string) => {
+      store.delete(key)
+    },
+    __store: store,
+  }
+})
+
+import { isClaudeCodeProject, readClaudeCompatMode, resolveClaudeCompat } from './claude-compat.js'
+
+const mockStore = ((await import('../db/settings.js')) as unknown as { __store: Map<string, string> }).__store
+
+let tempDir: string
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), 'claude-compat-test-'))
+  mockStore.clear()
+})
+
+afterEach(async () => {
+  await rm(tempDir, { recursive: true, force: true })
+})
+
+describe('isClaudeCodeProject', () => {
+  it('returns false for a directory without Claude Code markers', async () => {
+    expect(await isClaudeCodeProject(tempDir)).toBe(false)
+  })
+
+  it('detects a .claude directory', async () => {
+    await mkdir(join(tempDir, '.claude'))
+    expect(await isClaudeCodeProject(tempDir)).toBe(true)
+  })
+
+  it('detects a CLAUDE.md file', async () => {
+    await writeFile(join(tempDir, 'CLAUDE.md'), '# memory')
+    expect(await isClaudeCodeProject(tempDir)).toBe(true)
+  })
+
+  it('returns false for a directory that does not exist', async () => {
+    expect(await isClaudeCodeProject(join(tempDir, 'missing'))).toBe(false)
+  })
+})
+
+describe('readClaudeCompatMode', () => {
+  it('defaults to auto', () => {
+    expect(readClaudeCompatMode()).toBe('auto')
+  })
+
+  it('maps the stored booleans', () => {
+    mockStore.set('compat.claudeCode', 'true')
+    expect(readClaudeCompatMode()).toBe('enabled')
+    mockStore.set('compat.claudeCode', 'false')
+    expect(readClaudeCompatMode()).toBe('disabled')
+  })
+
+  it('falls back to auto for unknown values', () => {
+    mockStore.set('compat.claudeCode', 'yes-please')
+    expect(readClaudeCompatMode()).toBe('auto')
+  })
+})
+
+describe('resolveClaudeCompat', () => {
+  it('honours an explicit override over the setting', async () => {
+    mockStore.set('compat.claudeCode', 'false')
+    expect(await resolveClaudeCompat(tempDir, true)).toBe(true)
+    mockStore.set('compat.claudeCode', 'true')
+    expect(await resolveClaudeCompat(tempDir, false)).toBe(false)
+  })
+
+  it('stays on for a plain project when forced on', async () => {
+    mockStore.set('compat.claudeCode', 'true')
+    expect(await resolveClaudeCompat(tempDir)).toBe(true)
+  })
+
+  it('stays off for a Claude Code project when forced off', async () => {
+    await mkdir(join(tempDir, '.claude'))
+    mockStore.set('compat.claudeCode', 'false')
+    expect(await resolveClaudeCompat(tempDir)).toBe(false)
+  })
+
+  it('auto-enables for a Claude Code project', async () => {
+    await mkdir(join(tempDir, '.claude'))
+    expect(await resolveClaudeCompat(tempDir)).toBe(true)
+  })
+
+  it('stays off in auto mode for a plain project', async () => {
+    expect(await resolveClaudeCompat(tempDir)).toBe(false)
+  })
+
+  it('stays off in auto mode when no directory is known', async () => {
+    expect(await resolveClaudeCompat(undefined)).toBe(false)
+  })
+})

--- a/src/server/shared/claude-compat.ts
+++ b/src/server/shared/claude-compat.ts
@@ -1,0 +1,63 @@
+/**
+ * Claude Code Compatibility
+ *
+ * Claude Code stores its project configuration under `.claude/` and its memory
+ * in `CLAUDE.md`. When compatibility is on, OpenFox also reads those locations
+ * (skills, memory files, `@file` imports) instead of only its own conventions.
+ *
+ * The `compat.claudeCode` setting is tri-state:
+ *   - `auto` (default) — enabled when the project looks like a Claude Code project
+ *   - `true`           — always enabled
+ *   - `false`          — always disabled
+ */
+
+import { access } from 'node:fs/promises'
+import { constants } from 'node:fs'
+import { join } from 'node:path'
+import { getSetting } from '../db/settings.js'
+
+const CLAUDE_COMPAT_SETTING = 'compat.claudeCode'
+
+/** Directory Claude Code keeps its project configuration in. */
+export const CLAUDE_DIR = '.claude'
+
+/** Claude Code memory filename, both at the project root and inside `.claude/`. */
+export const CLAUDE_MEMORY_FILENAME = 'CLAUDE.md'
+
+/** Presence of any of these in a directory marks it as a Claude Code project. */
+const PROJECT_MARKERS = [CLAUDE_DIR, CLAUDE_MEMORY_FILENAME]
+
+export type ClaudeCompatMode = 'auto' | 'enabled' | 'disabled'
+
+export function readClaudeCompatMode(): ClaudeCompatMode {
+  const raw = getSetting(CLAUDE_COMPAT_SETTING)
+  if (raw === 'true') return 'enabled'
+  if (raw === 'false') return 'disabled'
+  return 'auto'
+}
+
+/** True when the directory carries a Claude Code marker (`.claude/` or `CLAUDE.md`). */
+export async function isClaudeCodeProject(dir: string): Promise<boolean> {
+  const checks = await Promise.all(
+    PROJECT_MARKERS.map(async (marker) => {
+      try {
+        await access(join(dir, marker), constants.R_OK)
+        return true
+      } catch {
+        return false
+      }
+    }),
+  )
+  return checks.includes(true)
+}
+
+/**
+ * Resolve whether Claude Code compatibility applies for a directory.
+ * `override` short-circuits the setting entirely (used by callers and tests).
+ */
+export async function resolveClaudeCompat(dir?: string, override?: boolean): Promise<boolean> {
+  if (override !== undefined) return override
+  const mode = readClaudeCompatMode()
+  if (mode !== 'auto') return mode === 'enabled'
+  return dir ? isClaudeCodeProject(dir) : false
+}

--- a/src/server/skills/registry.test.ts
+++ b/src/server/skills/registry.test.ts
@@ -561,3 +561,85 @@ describe('getDefaultSkillIds', () => {
     expect(ids).toContain('workflows')
   })
 })
+
+describe('claude code compatibility', () => {
+  let homeDir: string
+  let configDir: string
+  let projectDir: string
+
+  beforeEach(() => {
+    homeDir = join(tempDir, 'home')
+    configDir = join(tempDir, 'config')
+    projectDir = join(tempDir, 'project')
+  })
+
+  it('discovers global and project .claude/skills when enabled', async () => {
+    await createPortableInRoot(join(homeDir, '.claude', 'skills'), 'user-claude', 'User claude skill.')
+    await createPortableInRoot(join(projectDir, '.claude', 'skills'), 'project-claude', 'Project claude skill.')
+
+    const skills = await loadAllSkills(configDir, projectDir, { homeDir, claudeCompat: true })
+
+    expect(skills.find((skill) => skill.metadata.id === 'user-claude')).toMatchObject({ source: 'global-claude' })
+    expect(skills.find((skill) => skill.metadata.id === 'project-claude')).toMatchObject({ source: 'project-claude' })
+  })
+
+  it('ignores .claude/skills when disabled', async () => {
+    await createPortableInRoot(join(homeDir, '.claude', 'skills'), 'user-claude', 'User claude skill.')
+    await createPortableInRoot(join(projectDir, '.claude', 'skills'), 'project-claude', 'Project claude skill.')
+
+    const skills = await loadAllSkills(configDir, projectDir, { homeDir, claudeCompat: false })
+
+    expect(skills.find((skill) => skill.metadata.id === 'user-claude')).toBeUndefined()
+    expect(skills.find((skill) => skill.metadata.id === 'project-claude')).toBeUndefined()
+  })
+
+  it('auto-enables discovery for a project holding a .claude directory', async () => {
+    await createPortableInRoot(join(projectDir, '.claude', 'skills'), 'auto-claude', 'Auto discovered.')
+
+    const skills = await loadAllSkills(configDir, projectDir, { homeDir })
+
+    expect(skills.find((skill) => skill.metadata.id === 'auto-claude')).toMatchObject({ source: 'project-claude' })
+  })
+
+  it('stays off in auto mode for a project without Claude Code markers', async () => {
+    await createPortableInRoot(join(homeDir, '.claude', 'skills'), 'user-claude', 'User claude skill.')
+    await createPortableInRoot(join(projectDir, '.openfox', 'skills'), 'openfox-only', 'OpenFox skill.')
+
+    const skills = await loadAllSkills(configDir, projectDir, { homeDir })
+
+    expect(skills.find((skill) => skill.metadata.id === 'user-claude')).toBeUndefined()
+    expect(skills.find((skill) => skill.metadata.id === 'openfox-only')).toBeDefined()
+  })
+
+  it('lets a project OpenFox skill override the Claude one', async () => {
+    await createPortableInRoot(join(projectDir, '.claude', 'skills'), 'shared', 'claude version')
+    await createPortableInRoot(join(projectDir, '.openfox', 'skills'), 'shared', 'openfox version')
+
+    const result = await loadAllSkillsWithDiagnostics(configDir, projectDir, { homeDir, claudeCompat: true })
+
+    expect(result.skills.find((skill) => skill.metadata.id === 'shared')).toMatchObject({
+      prompt: 'openfox version',
+      source: 'project-openfox',
+    })
+    expect(result.diagnostics).toContain('Skill "shared" from project-openfox overrides project-claude')
+  })
+})
+
+describe('overlap diagnostics', () => {
+  it.skipIf(!CAN_SYMLINK)('stays quiet when two automatic roots point at the same package', async () => {
+    const homeDir = join(tempDir, 'home')
+    const agentsRoot = join(homeDir, '.agents', 'skills')
+    const claudeRoot = join(homeDir, '.claude', 'skills')
+    await createPortableInRoot(agentsRoot, 'linked-skill', 'Linked once.')
+    await mkdir(join(homeDir, '.claude'), { recursive: true })
+    await symlink(agentsRoot, claudeRoot, 'dir')
+
+    const result = await loadAllSkillsWithDiagnostics(join(tempDir, 'config'), undefined, {
+      homeDir,
+      claudeCompat: true,
+    })
+
+    expect(result.skills.filter((skill) => skill.metadata.id === 'linked-skill')).toHaveLength(1)
+    expect(result.diagnostics).toEqual([])
+  })
+})

--- a/src/server/skills/registry.ts
+++ b/src/server/skills/registry.ts
@@ -14,7 +14,8 @@ import { homedir } from 'node:os'
 import matter from 'gray-matter'
 import { pathExists, loadItemsFromDir, deleteItemFromDir } from '../shared/item-loader.js'
 import { getSetting, setSetting, deleteSetting } from '../db/settings.js'
-import type { SkillDefinition, SkillSource } from './types.js'
+import { EXTERNAL_SKILL_SOURCES, type SkillDefinition, type SkillSource } from './types.js'
+import { CLAUDE_DIR, resolveClaudeCompat } from '../shared/claude-compat.js'
 
 const __bundleDir = dirname(fileURLToPath(import.meta.url))
 const DEFAULTS_DIR = join(__bundleDir, 'defaults')
@@ -31,9 +32,14 @@ function getProjectSkillsDir(projectDir: string): string {
   return join(projectDir, '.openfox', 'skills')
 }
 
+function getClaudeSkillsDir(baseDir: string): string {
+  return join(baseDir, CLAUDE_DIR, 'skills')
+}
+
 export interface SkillDiscoveryOptions {
   homeDir?: string
   selectedDirectories?: string[]
+  claudeCompat?: boolean
 }
 
 function portableDisplayName(data: Record<string, unknown>, id: string): string {
@@ -185,13 +191,19 @@ export async function loadAllSkillsWithDiagnostics(
   const selected = (options.selectedDirectories ?? getSelectedSkillDirectories()).map((dir) =>
     dir === '~' ? home : dir.startsWith('~/') ? join(home, dir.slice(2)) : dir,
   )
+  const claudeCompat = await resolveClaudeCompat(projectDir, options.claudeCompat)
   const locations: Array<Promise<SkillDefinition[]>> = [
     loadDefaultSkills(),
     loadSkillsDirectory(join(home, '.agents', 'skills'), 'global-shared'),
+    ...(claudeCompat ? [loadSkillsDirectory(getClaudeSkillsDir(home), 'global-claude')] : []),
     loadUserSkills(configDir),
     ...selected.map((dir) => loadSkillsDirectory(dir, 'selected')),
     ...(projectDir
-      ? [loadSkillsDirectory(join(projectDir, '.agents', 'skills'), 'project-shared'), loadProjectSkills(projectDir)]
+      ? [
+          loadSkillsDirectory(join(projectDir, '.agents', 'skills'), 'project-shared'),
+          ...(claudeCompat ? [loadSkillsDirectory(getClaudeSkillsDir(projectDir), 'project-claude')] : []),
+          loadProjectSkills(projectDir),
+        ]
       : []),
   ]
   const groups = await Promise.all(locations)
@@ -202,7 +214,12 @@ export async function loadAllSkillsWithDiagnostics(
       const previous = skillMap.get(skill.metadata.id)
       if (previous) {
         if (previous.directory === skill.directory && previous.legacy === skill.legacy) {
-          diagnostics.push(`Skill "${skill.metadata.id}" reached through multiple paths`)
+          // Same package on disk, reached twice. Only actionable when a directory the
+          // user picked overlaps another root — automatic roots that symlink into each
+          // other (a common `.claude/skills` -> `.agents/skills` setup) are not.
+          if (previous.source === 'selected' || skill.source === 'selected') {
+            diagnostics.push(`Skill "${skill.metadata.id}" reached through multiple paths`)
+          }
         } else {
           diagnostics.push(
             `Skill "${skill.metadata.id}" from ${skill.source ?? 'unknown'} overrides ${previous.source ?? 'unknown'}`,
@@ -317,10 +334,7 @@ function updatedPortableFrontmatter(
 
 function canModifySkill(existing: SkillDefinition): boolean {
   if (existing.source === 'global-openfox' || existing.source === 'project-openfox') return true
-  return (
-    !existing.legacy &&
-    (existing.source === 'global-shared' || existing.source === 'selected' || existing.source === 'project-shared')
-  )
+  return !existing.legacy && EXTERNAL_SKILL_SOURCES.includes(existing.source ?? 'bundled')
 }
 
 export async function updateOwnedSkill(

--- a/src/server/skills/types.ts
+++ b/src/server/skills/types.ts
@@ -11,7 +11,23 @@ export interface SkillMetadata {
 }
 
 export type SkillSource =
-  'bundled' | 'global-shared' | 'global-openfox' | 'selected' | 'project-shared' | 'project-openfox'
+  | 'bundled'
+  | 'global-shared'
+  | 'global-claude'
+  | 'global-openfox'
+  | 'selected'
+  | 'project-shared'
+  | 'project-claude'
+  | 'project-openfox'
+
+/** Sources discovered outside OpenFox's own config; editable only in portable format. */
+export const EXTERNAL_SKILL_SOURCES: readonly SkillSource[] = [
+  'global-shared',
+  'global-claude',
+  'selected',
+  'project-shared',
+  'project-claude',
+]
 
 export interface SkillDefinition {
   metadata: SkillMetadata

--- a/web/src/components/settings/SkillsModal.tsx
+++ b/web/src/components/settings/SkillsModal.tsx
@@ -8,6 +8,7 @@ import {
   selectDirectory,
   removeDirectory,
   installSkill,
+  EXTERNAL_SKILL_SOURCES,
   type SkillFull,
   type SkillInfo,
 } from '../../lib/skills-actions'
@@ -43,6 +44,7 @@ export function SkillsContent({ isOpen }: { isOpen: boolean }) {
   const userItems = data?.userItems ?? []
   const projectItems = data?.projectItems ?? []
   const items = data?.items ?? []
+  const sharedItems = items.filter((skill) => EXTERNAL_SKILL_SOURCES.includes(skill.source))
   const selectedDirectory = data?.selectedDirectory ?? null
   const diagnostics = data?.diagnostics ?? []
   const [pendingDelete, setPendingDelete] = useState<SkillInfo | null>(null)
@@ -377,12 +379,10 @@ export function SkillsContent({ isOpen }: { isOpen: boolean }) {
           </ItemsHeader>
         )}
 
-        {items.some((skill) => ['global-shared', 'selected', 'project-shared'].includes(skill.source)) && (
+        {sharedItems.length > 0 && (
           <div className="mt-4">
             <ItemsHeader label={t({ en: 'Shared', fr: 'Partagées' })}>
-              <EditableSkillItems
-                items={items.filter((skill) => ['global-shared', 'selected', 'project-shared'].includes(skill.source))}
-              />
+              <EditableSkillItems items={sharedItems} />
             </ItemsHeader>
           </div>
         )}

--- a/web/src/components/settings/tabs/AdvancedTab.tsx
+++ b/web/src/components/settings/tabs/AdvancedTab.tsx
@@ -25,6 +25,9 @@ export function AdvancedTab({ onClose }: { onClose: () => void }) {
   const proxyUrlSetting = useSetting(SETTINGS_KEYS.PROXY_URL).value
   const defaultAgentSetting = useSetting(SETTINGS_KEYS.DEFAULT_AGENT).value
   const showChangelogSetting = useSetting(SETTINGS_KEYS.DISPLAY_SHOW_CHANGELOG_ON_UPDATE, 'true').value
+  const claudeCompatSetting = useSetting(SETTINGS_KEYS.COMPAT_CLAUDE_CODE, 'auto').value
+  const claudeCompatMode =
+    claudeCompatSetting === 'true' || claudeCompatSetting === 'false' ? claudeCompatSetting : 'auto'
 
   const [localToggles, setLocalToggles] = useState({
     openInEditor: showOpenInEditor,
@@ -268,6 +271,32 @@ export function AdvancedTab({ onClose }: { onClose: () => void }) {
         onToggle={handleToggleCacheWarming}
         boldTitle
       />
+      <hr className="border-border" />
+      <div>
+        <h3 className="text-sm font-medium text-text-primary mb-1">
+          {t({ en: 'Claude Code Compatibility', fr: 'Compatibilité Claude Code' })}
+        </h3>
+        <p className="text-sm text-text-muted mb-3">
+          {t({
+            en: 'Also read Claude Code conventions: skills from .claude/skills, memory from .claude/CLAUDE.md and ~/.claude/CLAUDE.md, and @file imports inside instruction files.',
+            fr: 'Lit aussi les conventions Claude Code : skills de .claude/skills, mémoire de .claude/CLAUDE.md et ~/.claude/CLAUDE.md, et imports @fichier dans les fichiers d’instructions.',
+          })}
+        </p>
+        <select
+          value={claudeCompatMode}
+          onChange={(e) => void setSetting(SETTINGS_KEYS.COMPAT_CLAUDE_CODE, e.target.value)}
+          className="w-full px-3 py-2 text-sm bg-bg-primary border border-border rounded-lg text-text-primary focus:outline-none focus:ring-2 focus:ring-accent-primary"
+        >
+          <option value="auto">
+            {t({
+              en: 'Automatic — on when the project has .claude/ or CLAUDE.md',
+              fr: 'Automatique — activé si le projet a .claude/ ou CLAUDE.md',
+            })}
+          </option>
+          <option value="true">{t({ en: 'Always on', fr: 'Toujours activé' })}</option>
+          <option value="false">{t({ en: 'Always off', fr: 'Toujours désactivé' })}</option>
+        </select>
+      </div>
       <hr className="border-border" />
       <div>
         <h3 className="text-sm font-medium text-text-primary mb-3">{t({ en: 'Network', fr: 'Réseau' })}</h3>

--- a/web/src/lib/resources.ts
+++ b/web/src/lib/resources.ts
@@ -605,6 +605,7 @@ export const SETTINGS_KEYS = {
   TOOLS_SHELL: 'tools.shell',
   CONFIRM_ON_WORKSPACE_ACTIONS: 'tools.confirmOnWorkspaceActions',
   FEATURES_PER_SESSION_MCP: 'features.perSessionMcp',
+  COMPAT_CLAUDE_CODE: 'compat.claudeCode',
   PROXY_URL: 'network.proxyUrl',
   DEFAULT_AGENT: 'agent.defaultAgent',
 } as const

--- a/web/src/lib/skills-actions.ts
+++ b/web/src/lib/skills-actions.ts
@@ -3,7 +3,23 @@ import { saveEntity, duplicateEntity } from './entity-mutations'
 import { skillsResource, skillResource, scopedUrl } from './resources'
 
 export type SkillSource =
-  'bundled' | 'global-shared' | 'global-openfox' | 'selected' | 'project-shared' | 'project-openfox'
+  | 'bundled'
+  | 'global-shared'
+  | 'global-claude'
+  | 'global-openfox'
+  | 'selected'
+  | 'project-shared'
+  | 'project-claude'
+  | 'project-openfox'
+
+/** Sources discovered outside OpenFox's own config, grouped as "Shared" in the UI. */
+export const EXTERNAL_SKILL_SOURCES: SkillSource[] = [
+  'global-shared',
+  'global-claude',
+  'selected',
+  'project-shared',
+  'project-claude',
+]
 
 export interface SelectedSkillDirectory {
   configuredPath: string


### PR DESCRIPTION
### Summary

OpenFox reads `CLAUDE.md` as one of its instruction filenames, which looks like Claude Code support but stops well short of it. Claude Code keeps skills in `.claude/skills`, memory in `.claude/CLAUDE.md` and `~/.claude/CLAUDE.md`, and composes memory files with `@file` imports. None of that was visible, so someone arriving from Claude Code silently lost most of their setup.

Measured on a real machine before this PR:

- Of 14 skills in `~/.claude/skills`, only the 8 that happened to be symlinks into `~/.agents/skills` were discovered. The 6 real directories were invisible.
- `~/.claude/CLAUDE.md` was never read — and its entire content was `@RTK.md`, so even reading it would have contributed nothing without import expansion.

Full design rationale, precedence tables and edge cases: **[docs/DESIGN-CLAUDE-CODE-COMPAT.md](https://github.com/nfertigsw/openfox/blob/feat/claude-code-compat/docs/DESIGN-CLAUDE-CODE-COMPAT.md)** (added by this PR).

### The setting

`compat.claudeCode`, tri-state, in **Settings → Advanced** (sits between "Speculative Cache Warming" and "Network"):

| Value | Behaviour |
| --- | --- |
| `auto` (default) | on when the project holds a `.claude/` directory or a `CLAUDE.md` |
| `true` | always on |
| `false` | always off |

Tri-state rather than a toggle because a boolean cannot express "decide per project" — which is the behaviour that makes the feature invisible when it should be. A project using `AGENTS.md` is untouched and nothing new enters its prompt.

### What it turns on

- **Skills** from `~/.claude/skills` and `<project>/.claude/skills`, as new sources `global-claude` / `project-claude`. No parser work was needed — `loadPortableSkills` already reads `<dir>/SKILL.md` with `name` / `description` frontmatter, which is exactly Claude Code's format; only the paths were missing. Each Claude root sits just after its `.agents` counterpart and before OpenFox's own, so an OpenFox skill always wins an id collision.
- **Memory files**: `~/.claude/CLAUDE.md` prepended before the tree walk (so user-level memory has the lowest priority and any project file overrides it) and `<dir>/.claude/CLAUDE.md` at each level of the existing walk.
- **`@file` imports** inside instruction files: resolved against the importing file, `~/` expanded, depth capped at 5, each path canonicalised through `realpath` and inlined once so cycles terminate, skipped inside fenced blocks and inline code spans, and left exactly as written when the path does not resolve — so `@mention` and `user@example.com` survive untouched.

### Always on, regardless of the setting

Instruction files are deduplicated by content hash (SHA-256 over trimmed content). Repositories very commonly ship `AGENTS.md` and `CLAUDE.md` as copies or symlinks of one another, and both were being sent to the model. That is a correctness bug predating this feature and unrelated to Claude Code, so it is not gated. `loadInstructionFiles` now reads each file once and returns its content, so `getAllInstructions` no longer re-reads them and its injected-file list reports only what was actually injected.

### One drive-by

The "reached through multiple paths" skill diagnostic now fires only when a directory the *user picked* (`selected`) overlaps another root. Sharing one library between both tools by symlinking `.claude/skills` → `.agents/skills` is common, and it produced one diagnostic line per skill that named a real overlap the user cannot act on — 8 lines of noise on the machine above. The existing test covering a user-selected symlinked directory still passes unchanged.

### Deliberately out of scope

Still invisible to OpenFox, and called out as such in the design doc: `.claude/agents/*.md`, `.claude/commands/*.md`, `.mcp.json`, `.claude/settings.json`, and plugin skills under `~/.claude/plugins`.

### What to test

- **Nothing changes on an ordinary project.** Open a repo with only `AGENTS.md`, leave the setting on `auto`. Settings → Skills shows the same list as before; the prompt gains nothing. (OpenFox's own repo is such a project — it has no `.claude/` and no `CLAUDE.md`.)
- **Auto-detection.** Open a project that has a `.claude/` directory or a `CLAUDE.md`, still on `auto`. Skills from `.claude/skills` now appear under **Shared** in the Skills modal, and `~/.claude/CLAUDE.md` shows up among the injected instruction files.
- **Forcing it.** Settings → Advanced → set "Always on". Your `~/.claude/skills` entries appear on any project. Set "Always off" on a Claude Code project and they disappear again.
- **Imports.** Put `@some-file.md` on its own line in a `CLAUDE.md` and confirm the file's content is inlined, prefixed with `Instructions from: <path>`. Then check that `@notafile`, an e-mail address, and an `@import` written inside a fenced code block are all left alone.
- **Deduplication.** Put identical content in `AGENTS.md` and `CLAUDE.md` at a project root — the text should reach the model once, not twice, whatever the setting is.
- **Precedence.** Give a skill the same id in `.claude/skills` and `.openfox/skills`; the OpenFox one must win.

### Tests

25 added, covering detection and all three tri-state modes, both `.claude` memory locations, import resolution / cycles / depth / code-span exclusion, content deduplication, and `.claude` skill discovery with precedence and diagnostics. Existing instruction tests now pin the compat flag off so the suite never reaches into the developer's own `~/.claude`.

<sub>Local run on WSL: `npm run typecheck` ✅, `eslint src/ web/src/` ✅ (0 issues), `npm run duplicate` ✅ (0 clones), `prettier --check` ✅, e2e suite ✅ (335 passed), unit suite 4992 passed with one failure — `inspect-proxy.test.ts > handles unreachable target gracefully`. That test proxies to `http://127.0.0.1:1` and expects a refused connection; on this machine the connect hangs instead (verified independently: a raw TCP connect to port 1 times out rather than being refused), so the proxy never answers and the test hits its 15s cap. It fails identically on a clean checkout without this branch. CI on ubuntu-latest should be unaffected.</sub>

### AI-Enhanced Development

Tell what models helped shape this PR:

- **AI Models:** Claude Opus 5 (1M context), via Claude Code

### Cache Impact

Does this PR affect anything cached — system prompts, tool definitions, skills, or other context?

- **Yes.** Both cached inputs change when compatibility is active: the instruction block can gain `~/.claude/CLAUDE.md` plus any inlined `@file` imports and loses duplicated `AGENTS.md`/`CLAUDE.md` text, and the skill metadata list can gain `.claude` skills. Both already feed `computeDynamicContextHash` (instruction content + sorted skill ids), so flipping the setting or opening a Claude Code project invalidates the prompt cache through the existing mechanism — no new cache key was needed. With the default `auto` on a project without `.claude/` or `CLAUDE.md`, the only reachable change is the deduplication, which fires solely when two instruction files carry byte-identical content.
