### PR TITLE
add button export conversation

### DIFF
--- a/web/src/components/plan/ContextPopover.test.tsx
+++ b/web/src/components/plan/ContextPopover.test.tsx
@@ -4,14 +4,19 @@ import { render, screen, cleanup, fireEvent } from '@testing-library/react'
 import { ContextPopover } from './ContextPopover'
 import { SessionScopeProvider } from '../../stores/session/session-scope'
 
-const { sendMock } = vi.hoisted(() => ({
+const { sendMock, exportConversationMock } = vi.hoisted(() => ({
   sendMock: vi.fn(),
+  exportConversationMock: vi.fn(),
 }))
 
 let storeState: Record<string, unknown> = {}
 
 vi.mock('../../stores/session', () => ({
   useSessionStore: (selector: (state: unknown) => unknown) => selector(storeState),
+}))
+
+vi.mock('../../lib/export-conversation', () => ({
+  exportConversation: (...args: unknown[]) => exportConversationMock(...args),
 }))
 
 vi.mock('../../lib/ws', () => ({
@@ -184,5 +189,30 @@ describe('ContextPopover', () => {
       </SessionScopeProvider>,
     )
     expect(screen.queryByText('Update system prompt')).toBeNull()
+  })
+
+  it('renders "Export all conversation" button and triggers export on click (popover variant)', () => {
+    render(
+      <SessionScopeProvider value="s1">
+        <ContextPopover />
+      </SessionScopeProvider>,
+    )
+    const exportBtn = screen.getByText('Export all conversation')
+    expect(exportBtn).toBeDefined()
+    fireEvent.click(exportBtn)
+    expect(exportConversationMock).toHaveBeenCalledWith('s1', expect.anything())
+  })
+
+  it('renders "Export all conversation" button in sidebar menu and triggers export on click', () => {
+    render(
+      <SessionScopeProvider value="s1">
+        <ContextPopover variant="sidebar" />
+      </SessionScopeProvider>,
+    )
+    fireEvent.click(screen.getByTitle('More options'))
+    const exportBtn = screen.getByText('Export all conversation')
+    expect(exportBtn).toBeDefined()
+    fireEvent.click(exportBtn)
+    expect(exportConversationMock).toHaveBeenCalledWith('s1', expect.anything())
   })
 })

--- a/web/src/components/plan/ContextPopover.tsx
+++ b/web/src/components/plan/ContextPopover.tsx
@@ -3,6 +3,7 @@ import { useSessionStore } from '../../stores/session'
 import { useT } from '../../hooks/useT'
 import { ProgressBar, LowTokenWarning } from '../shared/ProgressBar'
 import { formatTokens } from '../../lib/format-stats'
+import { exportConversation } from '../../lib/export-conversation'
 import { MoreIcon } from '../shared/icons'
 import { getTextColor } from './token-utils'
 import { DynamicContextPreviewModal } from './DynamicContextPreviewModal'
@@ -113,6 +114,16 @@ export function ContextPopover({ variant = 'popover', onUpdateSystemPrompt }: Co
               </span>
               {needsRebase && <RebaseIndicator />}
             </button>
+            <button
+              onClick={() => {
+                if (sessionId) exportConversation(sessionId, currentSession)
+                setMenuOpen(false)
+              }}
+              className="w-full px-3 py-1.5 text-left text-sm hover:bg-bg-tertiary transition-colors"
+              title="Export all conversation history"
+            >
+              <span>Export all conversation</span>
+            </button>
           </div>
         </>
       )}
@@ -180,6 +191,15 @@ export function ContextPopover({ variant = 'popover', onUpdateSystemPrompt }: Co
             {t({ en: 'Rebase system prompt', fr: 'Redéfinir le prompt système' })}
           </span>
           {needsRebase && <RebaseIndicator />}
+        </button>
+        <button
+          onClick={() => {
+            if (sessionId) exportConversation(sessionId, currentSession)
+          }}
+          className="w-full px-3 py-1.5 text-left text-sm hover:bg-bg-tertiary transition-colors rounded"
+          title="Export all conversation history"
+        >
+          <span>Export all conversation</span>
         </button>
       </div>
       {applyModal}

--- a/web/src/components/plan/ContextPopover.tsx
+++ b/web/src/components/plan/ContextPopover.tsx
@@ -120,9 +120,12 @@ export function ContextPopover({ variant = 'popover', onUpdateSystemPrompt }: Co
                 setMenuOpen(false)
               }}
               className="w-full px-3 py-1.5 text-left text-sm hover:bg-bg-tertiary transition-colors"
-              title="Export all conversation history"
+              title={t({
+                en: 'Export all conversation history',
+                fr: 'Exporter tout l’historique de conversation',
+              })}
             >
-              <span>Export all conversation</span>
+              <span>{t({ en: 'Export all conversation', fr: 'Exporter toute la conversation' })}</span>
             </button>
           </div>
         </>
@@ -197,9 +200,12 @@ export function ContextPopover({ variant = 'popover', onUpdateSystemPrompt }: Co
             if (sessionId) exportConversation(sessionId, currentSession)
           }}
           className="w-full px-3 py-1.5 text-left text-sm hover:bg-bg-tertiary transition-colors rounded"
-          title="Export all conversation history"
+          title={t({
+            en: 'Export all conversation history',
+            fr: 'Exporter tout l’historique de conversation',
+          })}
         >
-          <span>Export all conversation</span>
+          <span>{t({ en: 'Export all conversation', fr: 'Exporter toute la conversation' })}</span>
         </button>
       </div>
       {applyModal}

--- a/web/src/components/plan/SubAgentContainer.test.tsx
+++ b/web/src/components/plan/SubAgentContainer.test.tsx
@@ -1,11 +1,12 @@
 // @vitest-environment happy-dom
 import '@testing-library/jest-dom/vitest'
-import { cleanup, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { ContextState, Message } from '@shared/types.js'
 
-const { contextStateFixture } = vi.hoisted(() => ({
+const { contextStateFixture, exportSubAgentConversationMock } = vi.hoisted(() => ({
   contextStateFixture: { subAgentContextStates: {} as Record<string, ContextState | undefined> },
+  exportSubAgentConversationMock: vi.fn(),
 }))
 
 vi.mock('../../hooks/useAgents', () => ({
@@ -16,6 +17,14 @@ vi.mock('../../stores/session', () => ({
   useSessionStore: (
     selector: (state: { subAgentContextStates: Record<string, ContextState | undefined> }) => unknown,
   ) => selector(contextStateFixture),
+}))
+
+vi.mock('../../stores/session/session-scope', () => ({
+  useScopedContext: () => ({ sessionId: 'sess-123', currentSession: { id: 'sess-123' } }),
+}))
+
+vi.mock('../../lib/export-conversation', () => ({
+  exportSubAgentConversation: (...args: unknown[]) => exportSubAgentConversationMock(...args),
 }))
 
 vi.mock('../../hooks/useDisplaySettings', () => ({
@@ -114,5 +123,23 @@ describe('SubAgentContainer', () => {
     renderContainer()
 
     expect(screen.getByText('4x')).toBeInTheDocument()
+  })
+
+  it('renders the export button and triggers exportSubAgentConversation on click', () => {
+    exportSubAgentConversationMock.mockClear()
+    renderContainer()
+
+    const exportButton = screen.getByTitle('Export sub-agent conversation')
+    expect(exportButton).toBeInTheDocument()
+
+    fireEvent.click(exportButton)
+    expect(exportSubAgentConversationMock).toHaveBeenCalledTimes(1)
+    expect(exportSubAgentConversationMock).toHaveBeenCalledWith({
+      session: { id: 'sess-123' },
+      subAgentType: 'code_reviewer',
+      subAgentId: 'code-reviewer-run-1',
+      subAgentName: 'Code Reviewer',
+      messages,
+    })
   })
 })

--- a/web/src/components/plan/SubAgentContainer.tsx
+++ b/web/src/components/plan/SubAgentContainer.tsx
@@ -6,6 +6,7 @@ import { useT } from '../../hooks/useT'
 import { useAgents } from '../../hooks/useAgents'
 import { getAgentColor } from '../../lib/agents-actions'
 import { useSessionStore } from '../../stores/session'
+import { useScopedContext } from '../../stores/session/session-scope'
 import { useDisplaySettings } from '../../hooks/useDisplaySettings'
 import { formatTokens } from '../../lib/format-stats'
 import { useAutoScroll } from '../../hooks/useAutoScroll'
@@ -13,6 +14,8 @@ import { useViewport } from '../../hooks/useViewport'
 import { ScrollArea } from '../shared/ScrollArea'
 import type { OverlayScrollbarsComponentRef } from 'overlayscrollbars-react'
 import { ProgressBar } from '../shared/ProgressBar'
+import { exportSubAgentConversation } from '../../lib/export-conversation'
+import { DownloadIcon } from '../shared/icons'
 
 interface SubAgentContainerProps {
   messages: Message[]
@@ -74,8 +77,24 @@ export const SubAgentContainer = memo(function SubAgentContainer({
   const scrollRef = useRef<OverlayScrollbarsComponentRef<'div'>>(null)
   const [expanded, setExpanded] = useState(false)
   const { agents } = useAgents()
+  const { currentSession } = useScopedContext()
   const contextState = useSessionStore((state) => state.subAgentContextStates[subAgentId])
   const { showThinking, showVerboseToolOutput } = useDisplaySettings()
+
+  const agentInfo = agents.find((a) => a.id === subAgentType)
+  const label = agentInfo?.name ?? (LABELS[subAgentType] ? t(LABELS[subAgentType]) : subAgentType)
+  const color = getAgentColor(agents, subAgentType)
+  const hStyle = headerStyle(color)
+
+  const handleExport = useCallback(() => {
+    exportSubAgentConversation({
+      session: currentSession,
+      subAgentType,
+      subAgentId,
+      subAgentName: typeof label === 'string' ? label : subAgentType,
+      messages,
+    })
+  }, [currentSession, subAgentType, subAgentId, label, messages])
 
   const getViewport = useViewport(scrollRef)
 
@@ -91,11 +110,6 @@ export const SubAgentContainer = memo(function SubAgentContainer({
       }, 220)
     }
   }, [expanded])
-
-  const agentInfo = agents.find((a) => a.id === subAgentType)
-  const label = agentInfo?.name ?? (LABELS[subAgentType] ? t(LABELS[subAgentType]) : subAgentType)
-  const color = getAgentColor(agents, subAgentType)
-  const hStyle = headerStyle(color)
 
   const displayMessages = messages.filter((m) => m.role !== 'tool')
 
@@ -127,6 +141,18 @@ export const SubAgentContainer = memo(function SubAgentContainer({
               className={`w-1 h-1 rounded-full ${isAutoScrollActive ? 'bg-accent-success' : 'border border-text-muted'}`}
             />
             {t({ en: 'live', fr: 'direct' })}
+          </button>
+          <button
+            type="button"
+            className="text-[10px] px-1.5 py-0.5 rounded bg-bg-tertiary flex items-center gap-1 text-text-muted hover:text-text-primary transition-colors"
+            onClick={handleExport}
+            title={t({
+              en: 'Export sub-agent conversation',
+              fr: 'Exporter la conversation du sous-agent',
+            })}
+          >
+            <DownloadIcon className="w-3 h-3" />
+            <span>{t({ en: 'Export', fr: 'Exporter' })}</span>
           </button>
           <button
             type="button"

--- a/web/src/components/tasks/TaskEditor.test.tsx
+++ b/web/src/components/tasks/TaskEditor.test.tsx
@@ -511,7 +511,10 @@ describe('TaskEditor', () => {
       fireEvent.click(screen.getByRole('button', { name: /repeat/i }))
       fireEvent.change(screen.getByLabelText(/first run/i), { target: { value: '2030-01-01T09:00' } })
       fireEvent.change(screen.getByLabelText(/repeat unit/i), { target: { value: 'week' } })
-      fireEvent.click(screen.getByRole('button', { name: /^thu$/i }))
+      const thuBtn = screen.getByRole('button', { name: /^thu$/i })
+      if (thuBtn.getAttribute('aria-pressed') !== 'true') {
+        fireEvent.click(thuBtn)
+      }
       typePrompt()
       await save()
       await waitFor(() => expect(postedBody()).toBeTruthy())

--- a/web/src/lib/export-conversation.test.ts
+++ b/web/src/lib/export-conversation.test.ts
@@ -1,0 +1,157 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { sanitizeFilename, formatConversationMarkdown, downloadFile, exportConversation } from './export-conversation'
+import type { Message, Session } from '@shared/types.js'
+
+describe('export-conversation', () => {
+  describe('sanitizeFilename', () => {
+    it('cleans invalid characters', () => {
+      expect(sanitizeFilename('My / Great : File * Name?')).toBe('My_Great_File_Name_')
+      expect(sanitizeFilename('SimpleName')).toBe('SimpleName')
+    })
+  })
+
+  describe('formatConversationMarkdown', () => {
+    it('formats metadata, user message, assistant message with thinking, tool calls, and sub-agents', () => {
+      const session: Partial<Session> = {
+        id: 'sess-123',
+        projectId: 'proj-abc',
+        workdir: '/dev/app',
+        providerId: 'provider-1',
+        providerModel: 'gpt-4o',
+        mode: 'build',
+        createdAt: '2026-09-01T10:00:00.000Z',
+        metadata: {
+          title: 'Fix issue with login',
+          totalTokensUsed: 100,
+          totalToolCalls: 2,
+          iterationCount: 1,
+        },
+      }
+
+      const messages: Message[] = [
+        {
+          id: 'm1',
+          role: 'user',
+          content: 'Hello, please inspect the files.',
+          timestamp: '2026-09-01T10:01:00.000Z',
+        },
+        {
+          id: 'm2',
+          role: 'assistant',
+          content: 'I will explore the codebase.',
+          thinkingContent: 'Need to run ls tool.',
+          timestamp: '2026-09-01T10:02:00.000Z',
+          toolCalls: [
+            {
+              id: 'tc1',
+              name: 'run_command',
+              arguments: { command: 'ls' },
+              result: {
+                success: true,
+                output: 'src\npackage.json',
+                durationMs: 12,
+                truncated: false,
+              },
+            },
+          ],
+        },
+        {
+          id: 'm3',
+          role: 'assistant',
+          subAgentId: 'sub-1',
+          subAgentType: 'explorer',
+          content: 'Explorer found files.',
+          timestamp: '2026-09-01T10:03:00.000Z',
+          toolCalls: [
+            {
+              id: 'tc2',
+              name: 'read_file',
+              arguments: { path: 'src/index.ts' },
+              result: {
+                success: false,
+                error: 'File not found',
+                durationMs: 5,
+                truncated: false,
+              },
+            },
+          ],
+        },
+      ]
+
+      const md = formatConversationMarkdown(session, messages)
+
+      expect(md).toContain('# Fix issue with login')
+      expect(md).toContain('**Session ID:** `sess-123`')
+      expect(md).toContain('**Model:** `gpt-4o` (provider-1)')
+      expect(md).toContain('### 👤 User')
+      expect(md).toContain('Hello, please inspect the files.')
+      expect(md).toContain('### 🤖 Assistant')
+      expect(md).toContain('> **Thinking:**')
+      expect(md).toContain('Need to run ls tool.')
+      expect(md).toContain('#### 🛠️ Tool: `run_command`')
+      expect(md).toContain('"command": "ls"')
+      expect(md).toContain('src\npackage.json')
+      expect(md).toContain('### 🤖 Sub-Agent [explorer] (`sub-1`)')
+      expect(md).toContain('Explorer found files.')
+      expect(md).toContain('#### 🛠️ Tool: `read_file`')
+      expect(md).toContain('Error: File not found')
+    })
+  })
+
+  describe('downloadFile & exportConversation', () => {
+    let createObjectURLMock: ReturnType<typeof vi.fn>
+    let revokeObjectURLMock: ReturnType<typeof vi.fn>
+    let clickMock: ReturnType<typeof vi.fn>
+
+    beforeEach(() => {
+      createObjectURLMock = vi.fn(() => 'blob:mock-url')
+      revokeObjectURLMock = vi.fn()
+      global.URL.createObjectURL = createObjectURLMock as unknown as typeof URL.createObjectURL
+      global.URL.revokeObjectURL = revokeObjectURLMock as unknown as typeof URL.revokeObjectURL
+
+      clickMock = vi.fn()
+      vi.spyOn(document, 'createElement').mockImplementation((tagName: string) => {
+        if (tagName === 'a') {
+          return {
+            href: '',
+            download: '',
+            click: clickMock,
+          } as unknown as HTMLAnchorElement
+        }
+        return document.createElement(tagName)
+      })
+      vi.spyOn(document.body, 'appendChild').mockImplementation((node) => node)
+      vi.spyOn(document.body, 'removeChild').mockImplementation((node) => node)
+    })
+
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
+    it('downloads file correctly via DOM anchor element', () => {
+      downloadFile('test content', 'file.md')
+      expect(createObjectURLMock).toHaveBeenCalled()
+      expect(clickMock).toHaveBeenCalled()
+      expect(revokeObjectURLMock).toHaveBeenCalledWith('blob:mock-url')
+    })
+
+    it('fetches full session data and exports conversation', async () => {
+      const mockSession = { id: 's1', metadata: { title: 'Test Session' } }
+      const mockMessages = [{ id: 'm1', role: 'user', content: 'test' }] as Message[]
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ session: mockSession, messages: mockMessages }),
+      })
+
+      await exportConversation('s1')
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/sessions/s1?full=true'),
+        expect.anything(),
+      )
+      expect(clickMock).toHaveBeenCalled()
+    })
+  })
+})

--- a/web/src/lib/export-conversation.test.ts
+++ b/web/src/lib/export-conversation.test.ts
@@ -1,6 +1,13 @@
 // @vitest-environment happy-dom
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
-import { sanitizeFilename, formatConversationMarkdown, downloadFile, exportConversation } from './export-conversation'
+import {
+  sanitizeFilename,
+  formatConversationMarkdown,
+  formatSubAgentConversationMarkdown,
+  exportSubAgentConversation,
+  downloadFile,
+  exportConversation,
+} from './export-conversation'
 import type { Message, Session } from '@shared/types.js'
 
 describe('export-conversation', () => {
@@ -97,6 +104,62 @@ describe('export-conversation', () => {
       expect(md).toContain('#### 🛠️ Tool: `read_file`')
       expect(md).toContain('Error: File not found')
     })
+
+    it('formats sub-agent conversation markdown with header, thinking, tool calls', () => {
+      const session: Partial<Session> = {
+        id: 'sess-123',
+        projectId: 'proj-abc',
+        workdir: '/dev/app',
+        metadata: {
+          title: 'Fix issue with login',
+          totalTokensUsed: 100,
+          totalToolCalls: 2,
+          iterationCount: 1,
+        },
+      }
+
+      const subAgentMessages: Message[] = [
+        {
+          id: 'm1',
+          role: 'assistant',
+          subAgentId: 'explorer-1',
+          subAgentType: 'explorer',
+          thinkingContent: 'Let me list files in directory.',
+          content: 'Here are the files found in src.',
+          timestamp: '2026-09-01T10:05:00.000Z',
+          toolCalls: [
+            {
+              id: 'tc1',
+              name: 'run_command',
+              arguments: { command: 'ls -la' },
+              result: {
+                success: true,
+                output: 'total 0\n-rw-r--r-- index.ts',
+                durationMs: 10,
+                truncated: false,
+              },
+            },
+          ],
+        },
+      ]
+
+      const md = formatSubAgentConversationMarkdown(session, {
+        subAgentType: 'explorer',
+        subAgentId: 'explorer-1',
+        subAgentName: 'Explorer Agent',
+        messages: subAgentMessages,
+      })
+
+      expect(md).toContain('# Sub-Agent: Explorer Agent')
+      expect(md).toContain('- **Sub-Agent ID:** `explorer-1`')
+      expect(md).toContain('- **Sub-Agent Type:** `explorer`')
+      expect(md).toContain('- **Session Title:** Fix issue with login')
+      expect(md).toContain('### 🤖 Explorer Agent')
+      expect(md).toContain('> **Thinking:**\n> Let me list files in directory.')
+      expect(md).toContain('Here are the files found in src.')
+      expect(md).toContain('#### 🛠️ Tool: `run_command`')
+      expect(md).toContain('"command": "ls -la"')
+    })
   })
 
   describe('downloadFile & exportConversation', () => {
@@ -151,6 +214,30 @@ describe('export-conversation', () => {
         expect.stringContaining('/api/sessions/s1?full=true'),
         expect.anything(),
       )
+      expect(clickMock).toHaveBeenCalled()
+    })
+
+    it('exports sub-agent conversation directly without network fetch', () => {
+      const mockSession = { id: 's1', metadata: { title: 'Test Session' } } as unknown as Session
+      const mockMessages = [
+        {
+          id: 'm1',
+          role: 'assistant',
+          subAgentId: 'sub-1',
+          subAgentType: 'verifier',
+          content: 'Verification passed',
+        },
+      ] as Message[]
+
+      exportSubAgentConversation({
+        session: mockSession,
+        subAgentType: 'verifier',
+        subAgentId: 'sub-1',
+        subAgentName: 'Verifier Agent',
+        messages: mockMessages,
+      })
+
+      expect(createObjectURLMock).toHaveBeenCalled()
       expect(clickMock).toHaveBeenCalled()
     })
   })

--- a/web/src/lib/export-conversation.ts
+++ b/web/src/lib/export-conversation.ts
@@ -1,0 +1,160 @@
+import type { Message, Session, ToolCall } from '@shared/types.js'
+import { authFetch } from './api'
+
+export function sanitizeFilename(name: string): string {
+  return name
+    .replace(/[^a-zA-Z0-9._-]/g, '_')
+    .replace(/_+/g, '_')
+    .slice(0, 80)
+}
+
+function formatToolCalls(toolCalls: ToolCall[]): string[] {
+  const result: string[] = []
+  for (const tc of toolCalls) {
+    result.push(`#### 🛠️ Tool: \`${tc.name}\``)
+    if (tc.arguments && Object.keys(tc.arguments).length > 0) {
+      result.push('```json\n' + JSON.stringify(tc.arguments, null, 2) + '\n```')
+    }
+    if (tc.result) {
+      if (tc.result.success) {
+        result.push('**Result (Success):**\n```\n' + (tc.result.output ?? '') + '\n```')
+      } else {
+        result.push(
+          '**Result (Error):**\n```\n' +
+            (tc.result.error ? `Error: ${tc.result.error}\n` : '') +
+            (tc.result.output ?? '') +
+            '\n```',
+        )
+      }
+    }
+    result.push('')
+  }
+  return result
+}
+
+function formatThinking(thinking: string): string {
+  return (
+    '> **Thinking:**\n' +
+    thinking
+      .split('\n')
+      .map((l) => `> ${l}`)
+      .join('\n') +
+    '\n'
+  )
+}
+
+export function formatConversationMarkdown(session: Partial<Session> | null, messages: Message[]): string {
+  const lines: string[] = []
+
+  // Header
+  const title = session?.metadata?.title || session?.id || 'Conversation'
+  lines.push(`# ${title}\n`)
+  if (session?.id) lines.push(`- **Session ID:** \`${session.id}\``)
+  if (session?.createdAt) lines.push(`- **Created:** ${session.createdAt}`)
+  if (session?.projectId) lines.push(`- **Project:** \`${session.projectId}\``)
+  if (session?.workdir) lines.push(`- **Workdir:** \`${session.workdir}\``)
+  if (session?.providerModel) {
+    lines.push(`- **Model:** \`${session.providerModel}\`${session.providerId ? ` (${session.providerId})` : ''}`)
+  }
+  if (session?.mode) lines.push(`- **Mode:** \`${session.mode}\``)
+  lines.push(`- **Exported At:** ${new Date().toISOString()}`)
+  lines.push('\n---\n')
+
+  let currentWindowId: string | undefined
+
+  for (const msg of messages) {
+    if (msg.role === 'tool') continue
+
+    // Context window divider
+    if (msg.contextWindowId && currentWindowId && msg.contextWindowId !== currentWindowId) {
+      lines.push('\n---\n*Context Compaction / Window Transition*\n---\n')
+    }
+    currentWindowId = msg.contextWindowId
+
+    const time = msg.timestamp ? ` *(${msg.timestamp})*` : ''
+
+    if (msg.role === 'user') {
+      lines.push(`### 👤 User${time}\n`)
+      if (msg.content) {
+        lines.push(msg.content)
+      }
+      if (msg.attachments && msg.attachments.length > 0) {
+        lines.push('\n**Attachments:**')
+        for (const att of msg.attachments) {
+          lines.push(`- ${att.filename || 'Attachment'} (${att.mimeType || 'unknown'})`)
+        }
+      }
+      lines.push('\n')
+    } else if (msg.subAgentId || msg.subAgentType) {
+      const agentLabel = msg.subAgentType ? `Sub-Agent [${msg.subAgentType}]` : 'Sub-Agent'
+      lines.push(`### 🤖 ${agentLabel}${msg.subAgentId ? ` (\`${msg.subAgentId}\`)` : ''}${time}\n`)
+
+      if (msg.thinkingContent) {
+        lines.push(formatThinking(msg.thinkingContent))
+      }
+      if (msg.content) {
+        lines.push(msg.content + '\n')
+      }
+      if (msg.toolCalls && msg.toolCalls.length > 0) {
+        lines.push(...formatToolCalls(msg.toolCalls))
+      }
+    } else if (msg.role === 'assistant') {
+      lines.push(`### 🤖 Assistant${time}\n`)
+      if (msg.thinkingContent) {
+        lines.push(formatThinking(msg.thinkingContent))
+      }
+      if (msg.content) {
+        lines.push(msg.content + '\n')
+      }
+      if (msg.toolCalls && msg.toolCalls.length > 0) {
+        lines.push(...formatToolCalls(msg.toolCalls))
+      }
+    } else if (msg.role === 'system' || msg.isSystemGenerated) {
+      lines.push(`### ⚙️ System${msg.messageKind ? ` (${msg.messageKind})` : ''}${time}\n`)
+      if (msg.content) {
+        lines.push(msg.content + '\n')
+      }
+    }
+  }
+
+  return lines.join('\n')
+}
+
+export function downloadFile(content: string, filename: string, mimeType = 'text/markdown;charset=utf-8'): void {
+  const blob = new Blob([content], { type: mimeType })
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.href = url
+  link.download = filename
+  document.body.appendChild(link)
+  link.click()
+  document.body.removeChild(link)
+  URL.revokeObjectURL(url)
+}
+
+export async function exportConversation(
+  sessionId: string,
+  fallbackSession?: Partial<Session> | null,
+  fallbackMessages?: Message[],
+): Promise<void> {
+  let session = fallbackSession ?? null
+  let messages = fallbackMessages ?? []
+
+  try {
+    const res = await authFetch(`/api/sessions/${sessionId}?full=true`)
+    if (res.ok) {
+      const data = await res.json()
+      if (data.session) session = data.session
+      if (data.messages && Array.isArray(data.messages)) messages = data.messages
+    }
+  } catch (err) {
+    console.warn('Failed to fetch full session history, using local fallback:', err)
+  }
+
+  const markdown = formatConversationMarkdown(session, messages)
+  const rawTitle = session?.metadata?.title || sessionId
+  const dateStr = new Date().toISOString().slice(0, 10)
+  const filename = `${sanitizeFilename(rawTitle)}_${dateStr}.md`
+
+  downloadFile(markdown, filename)
+}

--- a/web/src/lib/export-conversation.ts
+++ b/web/src/lib/export-conversation.ts
@@ -43,21 +43,63 @@ function formatThinking(thinking: string): string {
   )
 }
 
+function formatUserMessage(msg: Message, time: string): string[] {
+  const lines: string[] = [`### 👤 User${time}\n`]
+  if (msg.content) {
+    lines.push(msg.content)
+  }
+  if (msg.attachments && msg.attachments.length > 0) {
+    lines.push('\n**Attachments:**')
+    for (const att of msg.attachments) {
+      lines.push(`- ${att.filename || 'Attachment'} (${att.mimeType || 'unknown'})`)
+    }
+  }
+  lines.push('\n')
+  return lines
+}
+
+function formatAssistantMessage(msg: Message, label: string, time: string, suffix = ''): string[] {
+  const lines: string[] = [`### 🤖 ${label}${suffix}${time}\n`]
+  if (msg.thinkingContent) {
+    lines.push(formatThinking(msg.thinkingContent))
+  }
+  if (msg.content) {
+    lines.push(msg.content + '\n')
+  }
+  if (msg.toolCalls && msg.toolCalls.length > 0) {
+    lines.push(...formatToolCalls(msg.toolCalls))
+  }
+  return lines
+}
+
+function formatSystemMessage(msg: Message, time: string): string[] {
+  const lines: string[] = [`### ⚙️ System${msg.messageKind ? ` (${msg.messageKind})` : ''}${time}\n`]
+  if (msg.content) {
+    lines.push(msg.content + '\n')
+  }
+  return lines
+}
+
+function formatSessionMetaLines(session: Partial<Session> | null): string[] {
+  const meta: string[] = []
+  if (session?.id) meta.push(`- **Session ID:** \`${session.id}\``)
+  if (session?.createdAt) meta.push(`- **Created:** ${session.createdAt}`)
+  if (session?.projectId) meta.push(`- **Project:** \`${session.projectId}\``)
+  if (session?.workdir) meta.push(`- **Workdir:** \`${session.workdir}\``)
+  if (session?.providerModel) {
+    meta.push(`- **Model:** \`${session.providerModel}\`${session.providerId ? ` (${session.providerId})` : ''}`)
+  }
+  if (session?.mode) meta.push(`- **Mode:** \`${session.mode}\``)
+  meta.push(`- **Exported At:** ${new Date().toISOString()}`)
+  return meta
+}
+
 export function formatConversationMarkdown(session: Partial<Session> | null, messages: Message[]): string {
   const lines: string[] = []
 
-  // Header
   const title = session?.metadata?.title || session?.id || 'Conversation'
   lines.push(`# ${title}\n`)
-  if (session?.id) lines.push(`- **Session ID:** \`${session.id}\``)
-  if (session?.createdAt) lines.push(`- **Created:** ${session.createdAt}`)
-  if (session?.projectId) lines.push(`- **Project:** \`${session.projectId}\``)
-  if (session?.workdir) lines.push(`- **Workdir:** \`${session.workdir}\``)
-  if (session?.providerModel) {
-    lines.push(`- **Model:** \`${session.providerModel}\`${session.providerId ? ` (${session.providerId})` : ''}`)
-  }
-  if (session?.mode) lines.push(`- **Mode:** \`${session.mode}\``)
-  lines.push(`- **Exported At:** ${new Date().toISOString()}`)
+  lines.push(...formatSessionMetaLines(session))
   lines.push('\n---\n')
 
   let currentWindowId: string | undefined
@@ -65,7 +107,6 @@ export function formatConversationMarkdown(session: Partial<Session> | null, mes
   for (const msg of messages) {
     if (msg.role === 'tool') continue
 
-    // Context window divider
     if (msg.contextWindowId && currentWindowId && msg.contextWindowId !== currentWindowId) {
       lines.push('\n---\n*Context Compaction / Window Transition*\n---\n')
     }
@@ -74,46 +115,15 @@ export function formatConversationMarkdown(session: Partial<Session> | null, mes
     const time = msg.timestamp ? ` *(${msg.timestamp})*` : ''
 
     if (msg.role === 'user') {
-      lines.push(`### 👤 User${time}\n`)
-      if (msg.content) {
-        lines.push(msg.content)
-      }
-      if (msg.attachments && msg.attachments.length > 0) {
-        lines.push('\n**Attachments:**')
-        for (const att of msg.attachments) {
-          lines.push(`- ${att.filename || 'Attachment'} (${att.mimeType || 'unknown'})`)
-        }
-      }
-      lines.push('\n')
+      lines.push(...formatUserMessage(msg, time))
     } else if (msg.subAgentId || msg.subAgentType) {
       const agentLabel = msg.subAgentType ? `Sub-Agent [${msg.subAgentType}]` : 'Sub-Agent'
-      lines.push(`### 🤖 ${agentLabel}${msg.subAgentId ? ` (\`${msg.subAgentId}\`)` : ''}${time}\n`)
-
-      if (msg.thinkingContent) {
-        lines.push(formatThinking(msg.thinkingContent))
-      }
-      if (msg.content) {
-        lines.push(msg.content + '\n')
-      }
-      if (msg.toolCalls && msg.toolCalls.length > 0) {
-        lines.push(...formatToolCalls(msg.toolCalls))
-      }
+      const suffix = msg.subAgentId ? ` (\`${msg.subAgentId}\`)` : ''
+      lines.push(...formatAssistantMessage(msg, agentLabel, time, suffix))
     } else if (msg.role === 'assistant') {
-      lines.push(`### 🤖 Assistant${time}\n`)
-      if (msg.thinkingContent) {
-        lines.push(formatThinking(msg.thinkingContent))
-      }
-      if (msg.content) {
-        lines.push(msg.content + '\n')
-      }
-      if (msg.toolCalls && msg.toolCalls.length > 0) {
-        lines.push(...formatToolCalls(msg.toolCalls))
-      }
+      lines.push(...formatAssistantMessage(msg, 'Assistant', time))
     } else if (msg.role === 'system' || msg.isSystemGenerated) {
-      lines.push(`### ⚙️ System${msg.messageKind ? ` (${msg.messageKind})` : ''}${time}\n`)
-      if (msg.content) {
-        lines.push(msg.content + '\n')
-      }
+      lines.push(...formatSystemMessage(msg, time))
     }
   }
 
@@ -155,6 +165,66 @@ export async function exportConversation(
   const rawTitle = session?.metadata?.title || sessionId
   const dateStr = new Date().toISOString().slice(0, 10)
   const filename = `${sanitizeFilename(rawTitle)}_${dateStr}.md`
+
+  downloadFile(markdown, filename)
+}
+
+export function formatSubAgentConversationMarkdown(
+  session: Partial<Session> | null,
+  options: {
+    subAgentType: string
+    subAgentId?: string
+    subAgentName?: string
+    messages: Message[]
+  },
+): string {
+  const { subAgentType, subAgentId, subAgentName, messages } = options
+  const lines: string[] = []
+
+  const agentLabel = subAgentName || subAgentType
+  lines.push(`# Sub-Agent: ${agentLabel}\n`)
+  if (subAgentId) lines.push(`- **Sub-Agent ID:** \`${subAgentId}\``)
+  lines.push(`- **Sub-Agent Type:** \`${subAgentType}\``)
+  if (session?.metadata?.title) lines.push(`- **Session Title:** ${session.metadata.title}`)
+  lines.push(...formatSessionMetaLines(session))
+  lines.push('\n---\n')
+
+  for (const msg of messages) {
+    if (msg.role === 'tool') continue
+
+    const time = msg.timestamp ? ` *(${msg.timestamp})*` : ''
+
+    if (msg.role === 'user') {
+      lines.push(...formatUserMessage(msg, time))
+    } else if (msg.role === 'assistant' || msg.subAgentId || msg.subAgentType) {
+      lines.push(...formatAssistantMessage(msg, agentLabel, time))
+    } else if (msg.role === 'system' || msg.isSystemGenerated) {
+      lines.push(...formatSystemMessage(msg, time))
+    }
+  }
+
+  return lines.join('\n')
+}
+
+export function exportSubAgentConversation(options: {
+  session?: Partial<Session> | null
+  subAgentType: string
+  subAgentId?: string
+  subAgentName?: string
+  messages: Message[]
+}): void {
+  const { session = null, subAgentType, subAgentId, subAgentName, messages } = options
+  const markdown = formatSubAgentConversationMarkdown(session, {
+    subAgentType,
+    subAgentId,
+    subAgentName,
+    messages,
+  })
+
+  const rawTitle = session?.metadata?.title || session?.id || 'session'
+  const agentLabel = subAgentName || subAgentType
+  const dateStr = new Date().toISOString().slice(0, 10)
+  const filename = `${sanitizeFilename(rawTitle)}_${sanitizeFilename(agentLabel)}_${dateStr}.md`
 
   downloadFile(markdown, filename)
 }


### PR DESCRIPTION
### Summary

Add an "Export all conversation" button under "Compact" and "Rebase system prompt" in the context popover and sidebar menus. It fetches the full session history (`/api/sessions/:id?full=true`) and triggers a client-side Markdown file download containing all conversation data (user messages, assistant replies, thinking blocks, tool calls & results, sub-agent runs, attachments, and context window transitions).

### AI-Enhanced Development

Tell what models helped shape this PR:

- **AI Models:** Gemini 3.7 Flash

### Cache Impact

Does this PR affect anything cached — system prompts, tool definitions, skills, or other context?

- **No**