### PR TITLE
Fix / Feat - add unsloth provider, fix buttons in provider pick

### DIFF
--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -26,6 +26,7 @@ const backendSchema = z.enum([
   'ollama',
   'llamacpp',
   'lmstudio',
+  'unsloth',
   'openai',
   'anthropic',
   'opencode-go',

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -2169,7 +2169,7 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
       const models = await fetchModelsWithContext(
         url,
         apiKey,
-        backend as 'ollama' | 'vllm' | 'sglang' | 'llamacpp' | 'lmstudio' | 'unknown' | undefined,
+        backend as 'ollama' | 'vllm' | 'sglang' | 'llamacpp' | 'lmstudio' | 'unsloth' | 'unknown' | undefined,
       )
       if (models.length === 0) {
         return res.status(404).json({ error: `No models found at ${buildModelsUrl(url)}`, url })

--- a/src/server/llm/backend.test.ts
+++ b/src/server/llm/backend.test.ts
@@ -103,7 +103,16 @@ describe('backend', () => {
     })
 
     it('does not route effort via chat_template_kwargs for other backends', () => {
-      for (const backend of ['vllm', 'sglang', 'openai', 'anthropic', 'ollama', 'lmstudio', 'opencode-go'] as const) {
+      for (const backend of [
+        'vllm',
+        'sglang',
+        'openai',
+        'anthropic',
+        'ollama',
+        'lmstudio',
+        'unsloth',
+        'opencode-go',
+      ] as const) {
         expect(getBackendCapabilities(backend).routesEffortViaChatTemplateKwargs).toBe(false)
       }
     })
@@ -117,6 +126,7 @@ describe('backend', () => {
         ollama: 'Ollama',
         llamacpp: 'llama.cpp',
         lmstudio: 'LM Studio',
+        unsloth: 'Unsloth Studio',
         'opencode-go': 'OpenCode Go',
         openai: 'OpenAI',
         anthropic: 'Anthropic',

--- a/src/server/llm/backend.ts
+++ b/src/server/llm/backend.ts
@@ -4,7 +4,16 @@
  */
 
 export type Backend =
-  'vllm' | 'sglang' | 'ollama' | 'llamacpp' | 'lmstudio' | 'opencode-go' | 'openai' | 'anthropic' | 'unknown'
+  | 'vllm'
+  | 'sglang'
+  | 'ollama'
+  | 'llamacpp'
+  | 'lmstudio'
+  | 'unsloth'
+  | 'opencode-go'
+  | 'openai'
+  | 'anthropic'
+  | 'unknown'
 
 export interface BackendCapabilities {
   /** Whether chat_template_kwargs with enable_thinking works (vLLM/SGLang) */
@@ -70,6 +79,14 @@ const BACKEND_CAPABILITIES: Record<Backend, BackendCapabilities> = {
     usesMaxCompletionTokens: false,
   },
   lmstudio: {
+    supportsChatTemplateKwargs: false,
+    supportsTopK: true,
+    supportsNumCtx: false,
+    routesEffortViaChatTemplateKwargs: false,
+    usesMaxCompletionTokens: false,
+  },
+  // Unsloth Studio serves an OpenAI-compatible API on a local port.
+  unsloth: {
     supportsChatTemplateKwargs: false,
     supportsTopK: true,
     supportsNumCtx: false,
@@ -158,6 +175,8 @@ export function getBackendDisplayName(backend: Backend): string {
       return 'llama.cpp'
     case 'lmstudio':
       return 'LM Studio'
+    case 'unsloth':
+      return 'Unsloth Studio'
     case 'opencode-go':
       return 'OpenCode Go'
     case 'openai':

--- a/src/server/provider-manager.ts
+++ b/src/server/provider-manager.ts
@@ -642,7 +642,8 @@ export function createProviderManager(config: Config, options: ProviderManagerOp
         clearModelCache(cacheUrl)
 
         // Refetch models from backend when switching providers
-        const backend = provider.backend as 'ollama' | 'vllm' | 'sglang' | 'llamacpp' | 'lmstudio' | 'unknown'
+        const backend = provider.backend as
+          'ollama' | 'vllm' | 'sglang' | 'llamacpp' | 'lmstudio' | 'unsloth' | 'unknown'
         logger.info('activateProvider fetching models', {
           providerId,
           providerName: provider.name,
@@ -1022,7 +1023,7 @@ export function createProviderManager(config: Config, options: ProviderManagerOp
         return { success: false, error: 'Provider not found' }
       }
 
-      const backend = provider.backend as 'ollama' | 'vllm' | 'sglang' | 'llamacpp' | 'lmstudio' | 'unknown'
+      const backend = provider.backend as 'ollama' | 'vllm' | 'sglang' | 'llamacpp' | 'lmstudio' | 'unsloth' | 'unknown'
       logger.info('refreshProviderModels fetching models', {
         providerId,
         providerName: provider.name,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -652,7 +652,16 @@ export interface Diagnostic {
 
 /** Supported LLM inference backends */
 export type LlmBackend =
-  'vllm' | 'sglang' | 'ollama' | 'llamacpp' | 'lmstudio' | 'opencode-go' | 'openai' | 'anthropic' | 'unknown'
+  | 'vllm'
+  | 'sglang'
+  | 'ollama'
+  | 'llamacpp'
+  | 'lmstudio'
+  | 'unsloth'
+  | 'opencode-go'
+  | 'openai'
+  | 'anthropic'
+  | 'unknown'
 
 /** Extended backend type including cloud providers */
 export type ProviderBackend = LlmBackend

--- a/web/src/components/settings/ProviderSelector.test.tsx
+++ b/web/src/components/settings/ProviderSelector.test.tsx
@@ -66,6 +66,7 @@ vi.mock('../../stores/config', () => ({
       ollama: 'Ollama',
       llamacpp: 'llama.cpp',
       lmstudio: 'LM Studio',
+      unsloth: 'Unsloth Studio',
       openai: 'OpenAI',
       anthropic: 'Anthropic',
       'opencode-go': 'OpenCode Go',

--- a/web/src/components/shared/ProviderModal.test.tsx
+++ b/web/src/components/shared/ProviderModal.test.tsx
@@ -59,6 +59,8 @@ function clickSave() {
 
 const savedProvider = (): ProviderFormData => onSaveMock.mock.calls[0]![0]!
 
+const jsonResponse = (body: unknown) => new Response(JSON.stringify(body), { status: 200 })
+
 const buttonByText = (text: string) =>
   Array.from(document.body.querySelectorAll('button')).find((button) => button.textContent?.trim() === text) as
     HTMLButtonElement | undefined
@@ -434,6 +436,56 @@ describe('ProviderModal - thinkingLevel persistence', () => {
     expect(savedData.backend).toBe(expectedBackend)
     expect(savedData.authAdapter).toBeUndefined()
     expect(savedData.transportAdapter).toBeUndefined()
+  })
+
+  it('re-applies URL and name when switching between engine cards', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input)
+        if (url.includes('/api/provider-presets')) return jsonResponse({ presets: [] })
+        return jsonResponse({ models: [] })
+      }),
+    )
+
+    // Step 1 only: the engine picker lives there.
+    await renderProviderModal({ initialStep: undefined }, 100)
+
+    buttonByText('Ollama')?.click()
+    await tick(0)
+
+    const urlInput = document.body.querySelector('[data-testid="provider-modal-url"]') as HTMLInputElement
+    const nameInput = document.body.querySelector('input[placeholder="My LLM Server"]') as HTMLInputElement
+    expect(urlInput.value).toBe('http://localhost:11434')
+    expect(nameInput.value).toBe('Ollama')
+
+    // Regression: clicking a second card must overwrite the pre-filled values.
+    buttonByText('LM Studio')?.click()
+    await tick(0)
+
+    expect(urlInput.value).toBe('http://localhost:1234')
+    expect(nameInput.value).toBe('LM Studio')
+  })
+
+  it('prefills Unsloth URL and name when its card is clicked', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input)
+        if (url.includes('/api/provider-presets')) return jsonResponse({ presets: [] })
+        return jsonResponse({ models: [] })
+      }),
+    )
+
+    await renderProviderModal({ initialStep: undefined }, 100)
+
+    buttonByText('Unsloth')?.click()
+    await tick(0)
+
+    const urlInput = document.body.querySelector('[data-testid="provider-modal-url"]') as HTMLInputElement
+    const nameInput = document.body.querySelector('input[placeholder="My LLM Server"]') as HTMLInputElement
+    expect(urlInput.value).toBe('http://localhost:8888')
+    expect(nameInput.value).toBe('Unsloth')
   })
 
   it('disables reasoning messages when auto-config detects a rejected history field', async () => {

--- a/web/src/components/shared/ProviderModal.tsx
+++ b/web/src/components/shared/ProviderModal.tsx
@@ -14,7 +14,7 @@ import { REASONING_EFFORT_VALUES } from '../../lib/model-value'
 import { isSmallContext } from '../../lib/context-warning'
 import { groupModeFamilies, MODE_SUFFIXES, splitModeSuffix } from '@shared/reasoning-effort.js'
 
-const COMMON_PORTS = [8080, 11434, 8000, 1234]
+const COMMON_PORTS = [8080, 11434, 8000, 1234, 8888]
 
 interface ProviderPreset {
   id: string
@@ -1458,7 +1458,7 @@ export function ProviderModal({
             ? t({ en: 'Edit Provider', fr: 'Modifier le fournisseur' })
             : t({ en: 'Add Provider', fr: 'Ajouter un fournisseur' })
         }
-        size="lg"
+        size="xl"
         footer={footer}
         closeOnBackdropClick={false}
         closeOnEscape={!showDefaults && !rawModalData}
@@ -1482,7 +1482,9 @@ export function ProviderModal({
               <label className="block text-sm text-text-secondary mb-2">
                 {t({ en: 'Inference engine', fr: 'Moteur d’inférence' })}
               </label>
-              <div className="grid grid-cols-5 gap-2">
+              {/* Engine cards share one row on wide screens and wrap into equal-width
+                  rows when the viewport narrows, so labels never truncate. */}
+              <div className="flex flex-wrap gap-2">
                 {providerPresets.map((preset) => (
                   <button
                     key={preset.id}
@@ -1498,7 +1500,7 @@ export function ProviderModal({
                       setFetchError(null)
                       resetStep2()
                     }}
-                    className={`p-2 rounded border text-center text-sm transition-colors ${
+                    className={`flex-1 min-w-fit px-2 py-2 whitespace-nowrap rounded border text-center text-sm transition-colors ${
                       formTransportAdapter && formTransportAdapter === preset.transportAdapter
                         ? 'border-accent-primary bg-accent-primary/10 text-accent-primary'
                         : 'border-border hover:border-text-muted text-text-secondary'
@@ -1518,7 +1520,7 @@ export function ProviderModal({
                     setFetchError(null)
                     resetStep2()
                   }}
-                  className={`p-2 rounded border text-center text-sm transition-colors ${
+                  className={`flex-1 min-w-fit px-2 py-2 whitespace-nowrap rounded border text-center text-sm transition-colors ${
                     formBackend === 'unknown'
                       ? 'border-accent-primary bg-accent-primary/10 text-accent-primary'
                       : 'border-border hover:border-text-muted text-text-secondary'
@@ -1532,20 +1534,22 @@ export function ProviderModal({
                     11434: 'ollama',
                     8080: 'llamacpp',
                     1234: 'lmstudio',
+                    8888: 'unsloth',
                   }
                   const nameMap: Record<number, string> = {
                     8000: 'vLLM',
                     11434: 'Ollama',
                     8080: 'llama.cpp',
                     1234: 'LM Studio',
+                    8888: 'Unsloth',
                   }
                   return (
                     <button
                       key={port}
                       type="button"
                       onClick={() => {
-                        setFormName((prev) => prev || (nameMap[port] ?? ''))
-                        setFormUrl((prev) => prev || `http://localhost:${port}`)
+                        setFormName(nameMap[port] ?? '')
+                        setFormUrl(`http://localhost:${port}`)
                         setFormBackend(backendMap[port] ?? '')
                         setFormIsLocal(true)
                         setFormAuthAdapter(undefined)
@@ -1553,7 +1557,7 @@ export function ProviderModal({
                         setFetchError(null)
                         resetStep2()
                       }}
-                      className={`p-2 rounded border text-center text-sm transition-colors ${
+                      className={`flex-1 min-w-fit px-2 py-2 whitespace-nowrap rounded border text-center text-sm transition-colors ${
                         formBackend === backendMap[port]
                           ? 'border-accent-primary bg-accent-primary/10 text-accent-primary'
                           : 'border-border hover:border-text-muted text-text-secondary'

--- a/web/src/stores/config.ts
+++ b/web/src/stores/config.ts
@@ -6,7 +6,16 @@ import type { ModelConfig } from '@shared/types.js'
 type LlmStatus = 'connected' | 'disconnected' | 'unknown'
 
 type Backend =
-  'vllm' | 'sglang' | 'ollama' | 'llamacpp' | 'lmstudio' | 'openai' | 'anthropic' | 'opencode-go' | 'unknown'
+  | 'vllm'
+  | 'sglang'
+  | 'ollama'
+  | 'llamacpp'
+  | 'lmstudio'
+  | 'unsloth'
+  | 'openai'
+  | 'anthropic'
+  | 'opencode-go'
+  | 'unknown'
 type ProviderStatus = 'connected' | 'disconnected' | 'unknown'
 
 interface Provider {
@@ -46,6 +55,8 @@ function getBackendDisplayName(backend: Backend): string {
       return 'llama.cpp'
     case 'lmstudio':
       return 'LM Studio'
+    case 'unsloth':
+      return 'Unsloth Studio'
     case 'openai':
       return 'OpenAI'
     case 'anthropic':


### PR DESCRIPTION
### Summary

- Fix the buttons from the providers pick, in the current version, if you pick a provider, you cannot click the other anymore.
<img width="1388" height="786" alt="chrome_4Np050YIhZ" src="https://github.com/user-attachments/assets/4c06ed18-efe9-4e4d-973e-0ca73c869990" />

- Add Unsloth provider : 
<img width="723" height="406" alt="chrome_7VexQlwfMo" src="https://github.com/user-attachments/assets/dfe93c6c-ff62-493d-ae44-efeeecbf5321" />
<img width="338" height="423" alt="chrome_7gO3QW9vuj" src="https://github.com/user-attachments/assets/8544fd50-f4c3-427e-90ce-183d52f56e85" />
<img width="230" height="466" alt="chrome_SUheZj0G5I" src="https://github.com/user-attachments/assets/8b09d54a-184e-4dcb-a949-d57057d8065b" />

### AI-Enhanced Development

Tell what models helped shape this PR:

- **AI Models:** Qwen 3.8 Flash Next 110b Q4XL

### Cache Impact

Does this PR affect anything cached — system prompts, tool definitions, skills, or other context?

- **No**


