### PR TITLE
feat: add openfox-opencode-go plugin to registry and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Restart OpenFox after installing or updating a plugin.
 - To authenticate with an X (xAI) SuperGrok subscription, you can install the [`openfox-xai-supergrok`](https://github.com/Olgean-Group/openfox-xai-supergrok) plugin.
 - To use free OpenRouter models, you can install the [`openfox-openrouter-free`](https://github.com/JamesDAdams/openfox-openrouter-free) plugin.
 - To use free OpenCode models, you can install the [`openfox-opencode-free`](https://github.com/JamesDAdams/openfox-opencode-free) plugin.
+- To use OpenCode Go models, you can install the [`openfox-opencode-go`](https://github.com/JamesDAdams/openfox-opencode-go) plugin.
 
 ## Screenshots
 

--- a/plugins-registry.json
+++ b/plugins-registry.json
@@ -34,5 +34,11 @@
     "displayName": "OpenCode (Free Models)",
     "description": "OpenCode provider filtered to free models only (-free suffix), with automatic hourly model updates (1x/hour) and API key auth.",
     "githubUrl": "https://github.com/JamesDAdams/openfox-opencode-free"
+  },
+  {
+    "name": "openfox-opencode-go",
+    "displayName": "OpenCode Go",
+    "description": "OpenCode Go provider plugin for OpenFox.",
+    "githubUrl": "https://github.com/JamesDAdams/openfox-opencode-go"
   }
 ]


### PR DESCRIPTION
### Summary

Adds the `openfox-opencode-go` provider plugin to `plugins-registry.json` and documents it in `README.md`. This allows users to discover, install, and use OpenCode Go models via the OpenFox plugin ecosystem.

### AI-Enhanced Development

Tell what models helped shape this PR:

- **AI Models:** Gemini 3.7 Flash

_No AI used? Enter 'none'_

### Cache Impact

Does this PR affect anything cached — system prompts, tool definitions, skills, or other context?

- **No**