### PR TITLE
fix: support Bearer token authentication for Ollama behind OpenWebUI

### DIFF
--- a/src/server/llm/client.ts
+++ b/src/server/llm/client.ts
@@ -73,6 +73,7 @@ export function createLLMClient(
   // options.num_ctx). Dispatched per request based on the current backend.
   const ollamaHttpClient = new OllamaHttpClient({
     baseURL: stripVersionPrefix(baseURL),
+    apiKey: config.llm.apiKey,
   })
   // Some models (OpenCode Go: gpt-5.6-luna, grok-4.6, muse-spark-1.2-…; OpenAI
   // gpt-5 family) are served through OpenAI's Responses API rather than

--- a/src/server/llm/ollama-native.ts
+++ b/src/server/llm/ollama-native.ts
@@ -28,6 +28,8 @@ import './proxy.js'
 export interface OllamaClientOptions {
   /** Base URL WITHOUT the /v1 prefix (e.g. http://localhost:11434). */
   baseURL: string
+  /** Optional API key for authentication (e.g., for OpenWebUI proxy). */
+  apiKey?: string
 }
 
 interface OllamaToolCall {
@@ -317,20 +319,27 @@ export function parseOllamaChatChunk(data: OllamaChatResponse): ChatCompletionCh
  */
 export class OllamaHttpClient extends ChatHttpClient {
   private baseURL: string
+  private apiKey?: string
 
   constructor(options: OllamaClientOptions) {
     super()
     this.baseURL = options.baseURL
+    this.apiKey = options.apiKey
   }
 
   protected buildRequest(
     params: ChatCompletionCreateParamsNonStreaming | ChatCompletionCreateParamsStreaming,
   ): ChatRequest {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    }
+    if (this.apiKey) {
+      headers['Authorization'] = `Bearer ${this.apiKey}`
+    }
+
     return {
       url: `${this.baseURL}/api/chat`,
-      headers: {
-        'Content-Type': 'application/json',
-      },
+      headers,
       body: JSON.stringify(buildOllamaChatRequest(params)),
     }
   }


### PR DESCRIPTION
- Add optional apiKey parameter to OllamaClientOptions
- Pass Authorization header with Bearer token when apiKey is provided
- Pass apiKey to OllamaHttpClient constructor in createLLMClient
- Enables usage with OpenWebUI proxy (https://openwebui.domain/ollama)

This allows Ollama to work with authentication providers like OpenWebUI that require Bearer token authentication.

### Summary

<!-- What does this PR do? Why? -->

### AI-Enhanced Development

Tell what models helped shape this PR:

- **AI Models:** <!-- e.g., DeepSeek V4 Flash, Qwen 3.5 122B, GPT 5.6, etc. -->

_No AI used? Enter 'none'_

### Cache Impact

Does this PR affect anything cached — system prompts, tool definitions, skills, or other context?

- **Yes** <!-- describe what changed and why -->
- **No**
