### PR TITLE
fix: support Bearer token authentication for Ollama behind OpenWebUI

### DIFF
--- a/src/server/llm/client.ts
+++ b/src/server/llm/client.ts
@@ -73,6 +73,7 @@ export function createLLMClient(
   // options.num_ctx). Dispatched per request based on the current backend.
   const ollamaHttpClient = new OllamaHttpClient({
     baseURL: stripVersionPrefix(baseURL),
+    apiKey: config.llm.apiKey,
   })
   // Some models (OpenCode Go: gpt-5.6-luna, grok-4.6, muse-spark-1.2-…; OpenAI
   // gpt-5 family) are served through OpenAI's Responses API rather than

--- a/src/server/llm/client.ts
+++ b/src/server/llm/client.ts
@@ -73,7 +73,7 @@ export function createLLMClient(
   // options.num_ctx). Dispatched per request based on the current backend.
   const ollamaHttpClient = new OllamaHttpClient({
     baseURL: stripVersionPrefix(baseURL),
-    apiKey: config.llm.apiKey,
+    ...(config.llm.apiKey ? { apiKey: config.llm.apiKey } : {}),
   })
   // Some models (OpenCode Go: gpt-5.6-luna, grok-4.6, muse-spark-1.2-…; OpenAI
   // gpt-5 family) are served through OpenAI's Responses API rather than

--- a/src/server/llm/ollama-native.test.ts
+++ b/src/server/llm/ollama-native.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, it } from 'vitest'
-import { buildOllamaChatRequest, parseOllamaChatResponse, parseOllamaChatChunk } from './ollama-native.js'
-import type { ChatCompletionCreateParamsStreaming, ChatCompletionMessageParam } from './openai-types.js'
+import {
+  OllamaHttpClient,
+  buildOllamaChatRequest,
+  parseOllamaChatResponse,
+  parseOllamaChatChunk,
+} from './ollama-native.js'
+import type {
+  ChatCompletionCreateParamsNonStreaming,
+  ChatCompletionCreateParamsStreaming,
+  ChatCompletionMessageParam,
+} from './openai-types.js'
 
 function streamParams(
   overrides: Partial<ChatCompletionCreateParamsStreaming> = {},
@@ -12,6 +21,36 @@ function streamParams(
     ...overrides,
   }
 }
+
+function requestHeaders(client: OllamaHttpClient, params: ChatCompletionCreateParamsNonStreaming) {
+  const request = (
+    client as unknown as {
+      buildRequest(p: ChatCompletionCreateParamsNonStreaming): { headers: Record<string, string> }
+    }
+  ).buildRequest(params)
+  return request.headers
+}
+
+describe('OllamaHttpClient auth headers', () => {
+  const params: ChatCompletionCreateParamsNonStreaming = {
+    model: 'qwen3.5:0.8b',
+    messages: [{ role: 'user', content: 'hi' }],
+  }
+
+  it('sends Authorization: Bearer when an apiKey is provided', () => {
+    const client = new OllamaHttpClient({ baseURL: 'http://localhost:11434', apiKey: 'secret-token' })
+    const headers = requestHeaders(client, params)
+    expect(headers['Authorization']).toBe('Bearer secret-token')
+    expect(headers['Content-Type']).toBe('application/json')
+  })
+
+  it('does not send Authorization when no apiKey is provided', () => {
+    const client = new OllamaHttpClient({ baseURL: 'http://localhost:11434' })
+    const headers = requestHeaders(client, params)
+    expect(headers['Authorization']).toBeUndefined()
+    expect(headers['Content-Type']).toBe('application/json')
+  })
+})
 
 describe('buildOllamaChatRequest', () => {
   it('maps sampling params and num_ctx into options', () => {

--- a/src/server/llm/ollama-native.ts
+++ b/src/server/llm/ollama-native.ts
@@ -28,6 +28,8 @@ import './proxy.js'
 export interface OllamaClientOptions {
   /** Base URL WITHOUT the /v1 prefix (e.g. http://localhost:11434). */
   baseURL: string
+  /** Optional API key for authentication (e.g., for OpenWebUI proxy). */
+  apiKey?: string
 }
 
 interface OllamaToolCall {
@@ -317,20 +319,27 @@ export function parseOllamaChatChunk(data: OllamaChatResponse): ChatCompletionCh
  */
 export class OllamaHttpClient extends ChatHttpClient {
   private baseURL: string
+  private apiKey?: string
 
   constructor(options: OllamaClientOptions) {
     super()
     this.baseURL = options.baseURL
+    this.apiKey = options.apiKey
   }
 
   protected buildRequest(
     params: ChatCompletionCreateParamsNonStreaming | ChatCompletionCreateParamsStreaming,
   ): ChatRequest {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    }
+    if (this.apiKey) {
+      headers['Authorization'] = `Bearer ${this.apiKey}`
+    }
+
     return {
       url: `${this.baseURL}/api/chat`,
-      headers: {
-        'Content-Type': 'application/json',
-      },
+      headers,
       body: JSON.stringify(buildOllamaChatRequest(params)),
     }
   }

--- a/src/server/llm/ollama-native.ts
+++ b/src/server/llm/ollama-native.ts
@@ -319,7 +319,7 @@ export function parseOllamaChatChunk(data: OllamaChatResponse): ChatCompletionCh
  */
 export class OllamaHttpClient extends ChatHttpClient {
   private baseURL: string
-  private apiKey?: string
+  private apiKey: string | undefined
 
   constructor(options: OllamaClientOptions) {
     super()


### PR DESCRIPTION
### Summary

This allows Ollama to work with authentication providers like OpenWebUI that require Bearer token authentication.

- Use optional apiKey parameter to OllamaClientOptions
- Pass Authorization header with Bearer token when apiKey is provided
- Pass apiKey to OllamaHttpClient constructor in createLLMClient
- Enables usage with OpenWebUI proxy (https://openwebui.domain/ollama)

### AI-Enhanced Development

Tell what models helped shape this PR:

- Claude Haiku4.5

### Cache Impact

Does this PR affect anything cached — system prompts, tool definitions, skills, or other context?

- **No**
