### PR TITLE
fix(llm): send x-opencode-session headers to opencode providers

### DIFF
--- a/src/server/chat/agent-loop.test.ts
+++ b/src/server/chat/agent-loop.test.ts
@@ -622,6 +622,46 @@ describe('maxTokens clamping', () => {
     expect(callArgs.modelSettings?.maxTokens).toBe(2952)
   })
 
+  it('passes the sessionId to streamLLMPure for opencode session affinity', async () => {
+    mockSessionManager = {
+      enterPauseGate: vi.fn().mockResolvedValue('released'),
+      requireSession: vi.fn().mockReturnValue({
+        workdir: '/test',
+        projectId: 'test-project',
+        executionState: null,
+        criteria: [],
+        isRunning: false,
+      }),
+      getEffectiveWorkdir: vi.fn().mockReturnValue('/test'),
+      getProjectWorkdir: vi.fn().mockReturnValue('/test'),
+      getContextState: vi.fn().mockReturnValue({
+        currentTokens: 0,
+        maxTokens: 200000,
+        compactionCount: 0,
+        dangerZone: false,
+        canCompact: false,
+        dynamicContextChanged: false,
+      }),
+      getCurrentModelContext: vi.fn().mockReturnValue(200000),
+      getCurrentModelSettings: vi.fn().mockReturnValue({ maxTokens: 16384 }),
+      setCurrentContextSize: vi.fn(),
+      getDynamicContextChanged: vi.fn().mockReturnValue(false),
+      setDynamicContextChanged: vi.fn(),
+      getCachedPrompt: vi.fn().mockReturnValue(undefined),
+      setCachedPrompt: vi.fn(),
+      getLspManager: vi.fn(),
+      drainAsapMessages: vi.fn().mockReturnValue([]),
+      getCurrentWindowMessages: vi.fn().mockReturnValue([]),
+      updateMessage: vi.fn(),
+    } as any
+
+    await runTopLevelAgentLoop(makeConfig(), mockTurnMetrics).catch(() => {})
+
+    const callArgs = (streamLLMPure as any).mock.calls[0]?.[0]
+    expect(callArgs).toBeDefined()
+    expect(callArgs.sessionId).toBe('test-session')
+  })
+
   it('uses the profile defaultMaxTokens when no user maxTokens is configured', async () => {
     mockLLMClient = {
       getModel: vi.fn().mockReturnValue('qwen3.8-27b'),

--- a/src/server/chat/agent-loop.ts
+++ b/src/server/chat/agent-loop.ts
@@ -252,6 +252,7 @@ export async function runTopLevelAgentLoop(
       const modelSettings = sessionManager.getCurrentModelSettings(sessionId, config.mode)
 
       await resolveClient().complete({
+        sessionId,
         messages: [{ role: 'system', content: assembledRequest.systemPrompt }],
         tools: assembledRequest.tools,
         maxTokens: 1,
@@ -392,6 +393,7 @@ export async function runTopLevelAgentLoop(
         messageId: assistantMsgId,
         systemPrompt: assembledRequest.systemPrompt,
         llmClient: attemptClient,
+        sessionId,
         messages: assembledRequest.messages,
         tools: assembledRequest.tools,
         toolChoice: 'auto',

--- a/src/server/chat/stream-pure.ts
+++ b/src/server/chat/stream-pure.ts
@@ -41,6 +41,8 @@ export interface PureStreamOptions {
   messageId: string
   systemPrompt: string
   llmClient: LLMClientWithModel
+  /** Stable session id, forwarded as x-opencode-session to opencode.ai endpoints. */
+  sessionId?: string
   messages: Array<{
     role: 'system' | 'user' | 'assistant' | 'tool'
     content: string
@@ -219,6 +221,7 @@ export async function* streamLLMPure(options: PureStreamOptions): AsyncGenerator
     reasoningEffort,
     signal: combinedSignal,
     modelSettings: options.modelSettings,
+    sessionId: options.sessionId,
   })
 
   // Track tool call indices we've emitted preparing events for

--- a/src/server/chat/stream-utils.ts
+++ b/src/server/chat/stream-utils.ts
@@ -8,8 +8,9 @@ function buildStreamRequestObject(params: {
   reasoningEffort?: ReasoningEffort | undefined
   signal?: AbortSignal | undefined
   modelSettings?: LLMCompletionRequest['modelSettings']
+  sessionId?: string | undefined
 }): LLMCompletionRequest {
-  const { messages, tools, toolChoice, reasoningEffort, signal, modelSettings } = params
+  const { messages, tools, toolChoice, reasoningEffort, signal, modelSettings, sessionId } = params
   return {
     messages,
     ...(tools && { tools }),
@@ -17,6 +18,7 @@ function buildStreamRequestObject(params: {
     ...(reasoningEffort && { reasoningEffort }),
     ...(signal && { signal }),
     ...(modelSettings && { modelSettings }),
+    ...(sessionId && { sessionId }),
   }
 }
 

--- a/src/server/llm/client.test.ts
+++ b/src/server/llm/client.test.ts
@@ -1,9 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { httpClientCreateMock, httpClientCreateStreamMock, httpClientCtorArgs } = vi.hoisted(() => ({
+const {
+  httpClientCreateMock,
+  httpClientCreateStreamMock,
+  httpClientCtorArgs,
+  responsesCreateMock,
+  responsesStreamMock,
+} = vi.hoisted(() => ({
   httpClientCreateMock: vi.fn(),
   httpClientCreateStreamMock: vi.fn(),
   httpClientCtorArgs: [] as Array<Record<string, unknown>>,
+  responsesCreateMock: vi.fn(),
+  responsesStreamMock: vi.fn(),
 }))
 
 vi.mock('./http-client.js', () => ({
@@ -14,6 +22,13 @@ vi.mock('./http-client.js', () => ({
     constructor(args: Record<string, unknown>) {
       httpClientCtorArgs.push(args)
     }
+  },
+}))
+
+vi.mock('./responses-native.js', () => ({
+  OpenAIResponsesHttpClient: class MockOpenAIResponsesHttpClient {
+    createChatCompletion = responsesCreateMock
+    createChatCompletionStream = responsesStreamMock
   },
 }))
 
@@ -44,6 +59,8 @@ describe('llm client', () => {
     httpClientCtorArgs.length = 0
     httpClientCreateMock.mockReset()
     httpClientCreateStreamMock.mockReset()
+    responsesCreateMock.mockReset()
+    responsesStreamMock.mockReset()
   })
 
   it('defaults the backend from config.llm.backend when no initial backend is given', () => {
@@ -970,5 +987,96 @@ describe('llm client', () => {
         },
       },
     ])
+  })
+})
+
+describe('opencode session headers', () => {
+  beforeEach(() => {
+    httpClientCreateMock.mockReset()
+    httpClientCreateStreamMock.mockReset()
+    responsesCreateMock.mockReset()
+    responsesStreamMock.mockReset()
+  })
+
+  const openCodeConfig = () => createConfig({ baseUrl: 'https://opencode.ai/zen/go/v1', backend: 'opencode-go' })
+
+  it('sends session headers on complete for opencode targets when a sessionId is given', async () => {
+    httpClientCreateMock.mockResolvedValueOnce({
+      id: 'resp-1',
+      choices: [{ finish_reason: 'stop', message: { content: 'ok' } }],
+      usage: {},
+    })
+
+    const client = createLLMClient(openCodeConfig(), 'opencode-go')
+    await client.complete({ messages: [{ role: 'user', content: 'hello' }], sessionId: 'sess-1' })
+
+    expect(httpClientCreateMock.mock.calls[0]?.[1]?.headers).toEqual({
+      'x-opencode-session': 'sess-1',
+      'x-opencode-client': 'openfox',
+      'User-Agent': 'openfox',
+    })
+  })
+
+  it('sends session headers on stream for opencode targets', async () => {
+    httpClientCreateStreamMock.mockReturnValueOnce(
+      (async function* () {
+        yield createChunk({ choices: [{ delta: { content: 'ok' }, finish_reason: 'stop' }], usage: {} })
+      })(),
+    )
+
+    const client = createLLMClient(openCodeConfig(), 'opencode-go')
+    for await (const _event of client.stream({ messages: [{ role: 'user', content: 'hi' }], sessionId: 'sess-2' })) {
+      // consume
+    }
+
+    expect(httpClientCreateStreamMock.mock.calls[0]?.[1]?.headers).toEqual({
+      'x-opencode-session': 'sess-2',
+      'x-opencode-client': 'openfox',
+      'User-Agent': 'openfox',
+    })
+  })
+
+  it('sends session headers on the responses path for opencode targets', async () => {
+    responsesCreateMock.mockResolvedValueOnce({
+      id: 'resp-1',
+      choices: [{ finish_reason: 'stop', message: { content: 'ok' } }],
+      usage: {},
+    })
+
+    const client = createLLMClient(openCodeConfig(), 'opencode-go')
+    client.setModel('gpt-5.6-luna')
+    await client.complete({ messages: [{ role: 'user', content: 'hello' }], sessionId: 'sess-3' })
+
+    expect(responsesCreateMock.mock.calls[0]?.[1]?.headers).toEqual({
+      'x-opencode-session': 'sess-3',
+      'x-opencode-client': 'openfox',
+      'User-Agent': 'openfox',
+    })
+  })
+
+  it('sends no session headers without a sessionId', async () => {
+    httpClientCreateMock.mockResolvedValueOnce({
+      id: 'resp-1',
+      choices: [{ finish_reason: 'stop', message: { content: 'ok' } }],
+      usage: {},
+    })
+
+    const client = createLLMClient(openCodeConfig(), 'opencode-go')
+    await client.complete({ messages: [{ role: 'user', content: 'hello' }] })
+
+    expect(httpClientCreateMock.mock.calls[0]?.[1]?.headers).toBeUndefined()
+  })
+
+  it('sends no session headers for non-opencode targets', async () => {
+    httpClientCreateMock.mockResolvedValueOnce({
+      id: 'resp-1',
+      choices: [{ finish_reason: 'stop', message: { content: 'ok' } }],
+      usage: {},
+    })
+
+    const client = createLLMClient(createConfig(), 'vllm')
+    await client.complete({ messages: [{ role: 'user', content: 'hello' }], sessionId: 'sess-4' })
+
+    expect(httpClientCreateMock.mock.calls[0]?.[1]?.headers).toBeUndefined()
   })
 })

--- a/src/server/llm/client.ts
+++ b/src/server/llm/client.ts
@@ -58,11 +58,33 @@ export interface LLMClientWithModel extends LLMClient {
   getReasoningEffort?(): string | undefined
 }
 
+/**
+ * opencode.ai endpoints (Zen / Go) require a stable per-conversation
+ * x-opencode-session header; see https://opencode.ai/docs/go/.
+ */
+function isOpenCodeEndpoint(baseUrl: string): boolean {
+  try {
+    const url = new URL(baseUrl)
+    return url.protocol === 'https:' && url.hostname.replace(/\.$/, '') === 'opencode.ai'
+  } catch {
+    return false
+  }
+}
+
+function openCodeSessionHeaders(sessionId: string): Record<string, string> {
+  return {
+    'x-opencode-session': sessionId,
+    'x-opencode-client': 'openfox',
+    'User-Agent': 'openfox',
+  }
+}
+
 export function createLLMClient(
   config: Config,
   initialBackend: Backend = config.llm.backend ?? 'unknown',
 ): LLMClientWithModel {
   const baseURL = ensureVersionPrefix(config.llm.baseUrl)
+  const isOpencode = isOpenCodeEndpoint(baseURL)
 
   const httpClient = new OpenAIHttpClient({
     baseURL,
@@ -174,6 +196,7 @@ export function createLLMClient(
           createParams,
           {
             signal: request.signal,
+            ...(request.sessionId && isOpencode && { headers: openCodeSessionHeaders(request.sessionId) }),
           },
           request.returnRaw,
         )
@@ -281,6 +304,7 @@ export function createLLMClient(
 
         const stream = httpFor(backend).createChatCompletionStream(streamingParams, {
           signal: streamSignal,
+          ...(request.sessionId && isOpencode && { headers: openCodeSessionHeaders(request.sessionId) }),
         })
 
         let fullContent = ''

--- a/src/server/llm/http-shared.ts
+++ b/src/server/llm/http-shared.ts
@@ -9,6 +9,8 @@ import { LLMError } from '../utils/errors.js'
 
 export interface RequestOptions {
   signal?: AbortSignal | null | undefined
+  /** Extra headers merged over the client's default headers (e.g. opencode session affinity). */
+  headers?: Record<string, string>
 }
 
 export interface ChatRequest {
@@ -44,7 +46,7 @@ export abstract class ChatHttpClient {
   ): Promise<Response> {
     const { url, headers, body } = this.buildRequest(params)
     logger.debug('HTTP request to LLM', { url, bodyKeys: Object.keys(params) })
-    return postJson(url, headers, body, options)
+    return postJson(url, { ...headers, ...options?.headers }, body, options)
   }
 
   async createChatCompletion(

--- a/src/server/llm/types.ts
+++ b/src/server/llm/types.ts
@@ -49,6 +49,8 @@ export interface LLMCompletionRequest {
   /** When true, the client-level reasoningEffort (from thinkingLevel) is NOT applied.
    *  Used by non-thinking callers (e.g. title generation) that want to opt out. */
   skipClientReasoningEffort?: boolean
+  /** Stable per-conversation id, sent as x-opencode-session to opencode.ai endpoints. */
+  sessionId?: string
 }
 
 export interface LLMCompletionResponse {

--- a/src/server/session/name-generator.ts
+++ b/src/server/session/name-generator.ts
@@ -353,6 +353,7 @@ export async function generateSessionNameForSession(
     const composedSignal = signal ? AbortSignal.any([timeoutSignal, signal]) : timeoutSignal
 
     const response = await client.complete({
+      sessionId,
       messages: [{ role: 'user', content: prompt }],
       tools: [],
       ...(modelSettings ? { modelSettings } : {}),


### PR DESCRIPTION
## What

Since 2026-09-06, the Opencode Go & Zen providers require specific HTTP headers.

This PR makes OpenFox  send the headers OpenCode Go/Zen expects on inference requests to `opencode.ai` endpoints:

- `x-opencode-session: <session id>` — OpenFox's own stable session id, so Go routes same-session requests to the same provider and prompt caching stays effective
- `x-opencode-client: openfox`
- `User-Agent: openfox` (Go asks clients to identify themselves rather than the default HTTP-library UA)

Headers are sent on both the chat-completions and the OpenAI Responses paths.

## Why

OpenCode Go requires a stable `x-opencode-session` per conversation and started erroring on requests without it as of 2026-09-05 (https://opencode.ai/docs/go/ — 'Send a stable session ID in x-opencode-session'; vendor notice echoed in https://github.com/vercel/ai/issues/20271). 

Other harnesses had also to fix it, e.g:
- pi https://github.com/earendil-works/pi/issues/4847
- openclaw https://download.plaud.ai/openclaw/openclaw/issues/137165

## How

- `LLMCompletionRequest` gains an optional `sessionId`; the shared HTTP layer merges extra request headers (single merge point for all clients)
- `createLLMClient` detects opencode.ai targets (https + hostname match) and injects the headers
- The agent loop (chat turns, warmup, compaction, sub-agents) and session title generation pass their session id

Non-opencode providers are untouched.

### AI-Enhanced Development

Tell what models helped shape this PR:

- **AI Models:** GLM-5.3-Flash (via opencode) — code and PR text, human-reviewed and human-tested before submission.

### Cache Impact

Does this PR affect anything cached — system prompts, tool definitions, skills, or other context?

- No

