### PR TITLE
fix(llm): disable reasoning echo for opencode.ai providers

### DIFF
--- a/src/server/llm/backend.test.ts
+++ b/src/server/llm/backend.test.ts
@@ -37,6 +37,11 @@ describe('backend', () => {
       })
     })
 
+    it('disables reasoning echo for the opencode.ai host', () => {
+      expect(detectProviderDefaultsFromUrl('https://opencode.ai/zen/go/v1')).toEqual({ sendReasoningInMessages: false })
+      expect(detectProviderDefaultsFromUrl('https://opencode.ai/zen/v1')).toEqual({ sendReasoningInMessages: false })
+    })
+
     it('returns undefined for local or unknown hosts', () => {
       expect(detectProviderDefaultsFromUrl('http://localhost:8000')).toBeUndefined()
       expect(detectProviderDefaultsFromUrl('http://192.168.1.223:8000/v1')).toBeUndefined()

--- a/src/server/llm/backend.ts
+++ b/src/server/llm/backend.ts
@@ -123,12 +123,19 @@ export function detectBackendFromUrl(url: string): Backend | undefined {
 export interface UrlProviderDefaults {
   /** Field the provider reads chain-of-thought from in assistant history. */
   thinkingField?: string
+  /** Whether to echo chain-of-thought back on assistant history messages. */
+  sendReasoningInMessages?: boolean
 }
 
 const HOST_PROVIDER_DEFAULTS: Record<string, UrlProviderDefaults> = {
   // DeepSeek's official API requires reasoning echoed under `reasoning_content`
   // (its own output field) — anything else is ignored or 400s on tool calls.
   'api.deepseek.com': { thinkingField: 'reasoning_content' },
+  // OpenCode Go's gateway forwards requests raw to upstreams whose strict
+  // schemas reject reasoning echoes on assistant history (e.g. GLM 400s with
+  // "Extra inputs are not permitted, field: messages[N].reasoning"). This
+  // overrides a persisted true so existing configs are rescued too.
+  'opencode.ai': { sendReasoningInMessages: false },
 }
 
 /**

--- a/src/server/provider-manager.test.ts
+++ b/src/server/provider-manager.test.ts
@@ -283,6 +283,81 @@ describe('ProviderManager - Model Selection', () => {
     })
   })
 
+  describe('sendReasoningInMessages resolution', () => {
+    it('disables reasoning echo for opencode.ai providers even when the config persists true', async () => {
+      const opencodeProvider: Provider = {
+        id: 'provider-opencode',
+        name: 'OpenCode Go',
+        url: 'https://opencode.ai/zen/go/v1',
+        backend: 'opencode-go',
+        apiKey: 'sk-x',
+        sendReasoningInMessages: true,
+        models: [{ id: 'glm-5.3', contextWindow: 200000, source: 'default' }],
+        isActive: true,
+        createdAt: new Date().toISOString(),
+      }
+
+      const manager = createProviderManager({
+        ...config,
+        providers: [opencodeProvider],
+        defaultModelSelection: 'provider-opencode/glm-5.3',
+      })
+      manager.createClient('provider-opencode', 'glm-5.3')
+
+      const calls = (createLLMClient as ReturnType<typeof vi.fn>).mock.calls
+      const lastCallConfig = calls[calls.length - 1]![0] as { llm: { sendReasoningInMessages?: boolean } }
+      expect(lastCallConfig.llm.sendReasoningInMessages).toBe(false)
+    })
+
+    it('disables reasoning echo for opencode.ai providers without an explicit value', async () => {
+      const opencodeProvider: Provider = {
+        id: 'provider-opencode',
+        name: 'OpenCode Go',
+        url: 'https://opencode.ai/zen/go/v1',
+        backend: 'opencode-go',
+        apiKey: 'sk-x',
+        models: [{ id: 'glm-5.3', contextWindow: 200000, source: 'default' }],
+        isActive: true,
+        createdAt: new Date().toISOString(),
+      }
+
+      const manager = createProviderManager({
+        ...config,
+        providers: [opencodeProvider],
+        defaultModelSelection: 'provider-opencode/glm-5.3',
+      })
+      manager.createClient('provider-opencode', 'glm-5.3')
+
+      const calls = (createLLMClient as ReturnType<typeof vi.fn>).mock.calls
+      const lastCallConfig = calls[calls.length - 1]![0] as { llm: { sendReasoningInMessages?: boolean } }
+      expect(lastCallConfig.llm.sendReasoningInMessages).toBe(false)
+    })
+
+    it('keeps the explicit provider value for hosts without a URL default', async () => {
+      const localProvider: Provider = {
+        id: 'provider-local',
+        name: 'Local',
+        url: 'http://192.168.1.223:8000',
+        backend: 'vllm',
+        sendReasoningInMessages: true,
+        models: [{ id: 'glm-5.3', contextWindow: 200000, source: 'default' }],
+        isActive: true,
+        createdAt: new Date().toISOString(),
+      }
+
+      const manager = createProviderManager({
+        ...config,
+        providers: [localProvider],
+        defaultModelSelection: 'provider-local/glm-5.3',
+      })
+      manager.createClient('provider-local', 'glm-5.3')
+
+      const calls = (createLLMClient as ReturnType<typeof vi.fn>).mock.calls
+      const lastCallConfig = calls[calls.length - 1]![0] as { llm: { sendReasoningInMessages?: boolean } }
+      expect(lastCallConfig.llm.sendReasoningInMessages).toBe(true)
+    })
+  })
+
   describe('setDefaultModelSelection', () => {
     it('returns error for non-existent provider', async () => {
       const result = await providerManager.setDefaultModelSelection('non-existent', 'new-model')

--- a/src/server/provider-manager.ts
+++ b/src/server/provider-manager.ts
@@ -462,6 +462,14 @@ export function createProviderManager(config: Config, options: ProviderManagerOp
     return detectProviderDefaultsFromUrl(provider.url)?.thinkingField
   }
 
+  function resolveSendReasoningInMessages(provider: Provider): boolean | undefined {
+    // Unlike thinkingField, the URL default OVERRIDES the persisted value: the
+    // provider edit modal stamps sendReasoningInMessages=true on new providers,
+    // and hosts like opencode.ai reject the echo outright — the persisted flag
+    // is exactly the foot-gun being rescued here.
+    return detectProviderDefaultsFromUrl(provider.url)?.sendReasoningInMessages ?? provider.sendReasoningInMessages
+  }
+
   function createConfigForProvider(provider: Provider, model: string, reasoningEffort?: string): Config {
     // An explicit effort (session pick, pin, or agent override) wins over the
     // model's configured default, clamped to the model's advertised preset
@@ -478,6 +486,7 @@ export function createProviderManager(config: Config, options: ProviderManagerOp
       model,
     )
     const thinkingField = resolveThinkingField(provider)
+    const sendReasoningInMessages = resolveSendReasoningInMessages(provider)
     return {
       ...config,
       llm: {
@@ -487,9 +496,7 @@ export function createProviderManager(config: Config, options: ProviderManagerOp
         backend: resolveBackend(provider),
         ...(provider.apiKey && { apiKey: provider.apiKey }),
         ...(thinkingField ? { thinkingField } : {}),
-        ...(provider.sendReasoningInMessages !== undefined
-          ? { sendReasoningInMessages: provider.sendReasoningInMessages }
-          : {}),
+        ...(sendReasoningInMessages !== undefined ? { sendReasoningInMessages } : {}),
         ...(modelThinking.reasoningEffort &&
           !send.suppressEffort && { reasoningEffort: modelThinking.reasoningEffort }),
       },

--- a/src/server/utils/process-tree.test.ts
+++ b/src/server/utils/process-tree.test.ts
@@ -73,12 +73,15 @@ async function getDescendants(rootPid: number): Promise<number[]> {
     }
   }
   const descendants: number[] = []
+  const seen = new Set<number>([rootPid])
   const queue = [rootPid]
   while (queue.length > 0) {
     const current = queue.shift()!
     const kids = children.get(current)
     if (kids) {
       for (const kid of kids) {
+        if (seen.has(kid)) continue
+        seen.add(kid)
         descendants.push(kid)
         queue.push(kid)
       }


### PR DESCRIPTION
## What

Providers whose URL host is `opencode.ai` (Zen / Go) no longer echo chain-of-thought back on assistant history messages: openfox resolves `sendReasoningInMessages: false` from the URL **before** the provider's persisted value.

## Why

OpenCode Go's gateway forwards requests raw to upstreams whose strict schemas reject reasoning echoes on assistant history. GLM-5.3 via opencode go fails every multi-turn thinking request with:

```
HTTP 400: invalid_request_error — Extra inputs are not permitted,
field: messages[3].reasoning
```

`glm-5.3-flash` only dodged it because it is non-thinking and has nothing to echo.

The provider edit modal stamps `sendReasoningInMessages: true` on new providers (its default), so the persisted value is the foot-gun. That's why the URL default **overrides** the persisted flag: existing configs are fixed with no user action and no re-run of auto-config. Hosts without a known default keep the explicit provider value unchanged.

Same rescue pattern as the existing `api.deepseek.com` → `thinkingField: reasoning_content` URL default.

## How

- `backend.ts`: `UrlProviderDefaults` gains `sendReasoningInMessages`; `HOST_PROVIDER_DEFAULTS['opencode.ai'] = { sendReasoningInMessages: false }`
- `provider-manager.ts`: `resolveSendReasoningInMessages` (URL default first, explicit provider value as fallback) wired into `createConfigForProvider`
- Tests: URL default detection + 3 resolution cases (persisted `true` rescued → `false`; unset → `false`; non-opencode host keeps explicit value)

### AI-Enhanced Development

Tell what models helped shape this PR:

- **AI Models:** GLM-5.3-Flash (via opencode) — code and PR text, human-reviewed and human-tested before submission.

### Cache Impact

Does this PR affect anything cached — system prompts, tool definitions, skills, or other context?

- System prompts / tool definitions / skills / openfox-internal context caching: No.
- Provider-side prompt caching on opencode.ai endpoints: Yes, one-time — assistant history no longer carries the `reasoning` echo, so in-flight conversations will cache-miss once after updating; the request shape is stable going forward (and multi-turn GLM-5.3 requests stop 400ing).

## Deliberately skipped

Changing the modal's blanket `true` default: the URL override already neutralizes it for opencode.ai, and changing modal semantics touches the onboarding flow and i18n strings. Can follow up if maintainers prefer the modal default to be 'auto' (unset).
