### PR TITLE
Feat/display subagent model

### DIFF
--- a/web/src/components/plan/SubAgentContainer.test.tsx
+++ b/web/src/components/plan/SubAgentContainer.test.tsx
@@ -4,18 +4,44 @@ import { cleanup, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { ContextState, Message } from '@shared/types.js'
 
-const { contextStateFixture } = vi.hoisted(() => ({
+const { contextStateFixture, agentsFixture, configFixture, sessionFixture } = vi.hoisted(() => ({
   contextStateFixture: { subAgentContextStates: {} as Record<string, ContextState | undefined> },
+  agentsFixture: {
+    agents: [{ id: 'code_reviewer', name: 'Code Reviewer' }],
+    modelOverrides: {} as Record<string, string>,
+  },
+  configFixture: {
+    defaultModelSelection: null as string | null,
+  },
+  sessionFixture: {
+    currentSession: { id: 'sess-123' } as Record<string, unknown>,
+  },
 }))
 
 vi.mock('../../hooks/useAgents', () => ({
-  useAgents: () => ({ agents: [{ id: 'code_reviewer', name: 'Code Reviewer' }], refresh: vi.fn() }),
+  useAgents: () => ({
+    agents: agentsFixture.agents,
+    modelOverrides: agentsFixture.modelOverrides,
+    refresh: vi.fn(),
+  }),
+}))
+
+vi.mock('../../hooks/useConfig', () => ({
+  useConfig: () => ({
+    config: configFixture,
+    refresh: vi.fn(),
+    loading: false,
+  }),
 }))
 
 vi.mock('../../stores/session', () => ({
   useSessionStore: (
     selector: (state: { subAgentContextStates: Record<string, ContextState | undefined> }) => unknown,
   ) => selector(contextStateFixture),
+}))
+
+vi.mock('../../stores/session/session-scope', () => ({
+  useScopedContext: () => ({ sessionId: 'sess-123', currentSession: sessionFixture.currentSession }),
 }))
 
 vi.mock('../../hooks/useDisplaySettings', () => ({
@@ -114,5 +140,86 @@ describe('SubAgentContainer', () => {
     renderContainer()
 
     expect(screen.getByText('4x')).toBeInTheDocument()
+  })
+
+  it('renders model badge when message has stats', () => {
+    const messagesWithStats: Message[] = [
+      {
+        id: 'm1',
+        role: 'assistant',
+        content: 'Review findings',
+        timestamp: new Date().toISOString(),
+        subAgentId: 'code-reviewer-run-1',
+        subAgentType: 'code_reviewer',
+        stats: {
+          providerId: 'google',
+          providerName: 'Google',
+          backend: 'openai',
+          model: 'google/gemini-3.7-flash-medium',
+          reasoningEffort: 'medium',
+          mode: 'code_reviewer',
+          totalTime: 10,
+          toolTime: 2,
+          prefillTokens: 100,
+          prefillSpeed: 10,
+          generationTokens: 50,
+          generationSpeed: 5,
+        },
+      },
+    ]
+
+    render(
+      <SubAgentContainer
+        messages={messagesWithStats}
+        subAgentType="code_reviewer"
+        subAgentId="code-reviewer-run-1"
+        isStreaming={false}
+      />,
+    )
+
+    const badge = screen.getByTestId('subagent-model-badge')
+    expect(badge).toBeInTheDocument()
+    expect(badge).toHaveTextContent('gemini-3.7-flash-medium:medium')
+  })
+
+  it('renders model badge from agent model override when messages have no stats', () => {
+    agentsFixture.modelOverrides = {
+      code_reviewer: 'anthropic/claude-3-5-sonnet:high',
+    }
+
+    render(
+      <SubAgentContainer
+        messages={messages}
+        subAgentType="code_reviewer"
+        subAgentId="code-reviewer-run-1"
+        isStreaming={false}
+      />,
+    )
+
+    const badge = screen.getByTestId('subagent-model-badge')
+    expect(badge).toBeInTheDocument()
+    expect(badge).toHaveTextContent('claude-3-5-sonnet:high')
+  })
+
+  it('renders model badge from session provider model when no stats or agent override exist', () => {
+    agentsFixture.modelOverrides = {}
+    sessionFixture.currentSession = {
+      id: 'sess-123',
+      providerModel: 'openai/o3-mini',
+      providerReasoningEffort: 'low',
+    }
+
+    render(
+      <SubAgentContainer
+        messages={messages}
+        subAgentType="code_reviewer"
+        subAgentId="code-reviewer-run-1"
+        isStreaming={false}
+      />,
+    )
+
+    const badge = screen.getByTestId('subagent-model-badge')
+    expect(badge).toBeInTheDocument()
+    expect(badge).toHaveTextContent('o3-mini:low')
   })
 })

--- a/web/src/components/plan/SubAgentContainer.tsx
+++ b/web/src/components/plan/SubAgentContainer.tsx
@@ -4,8 +4,11 @@ import { AssistantMessage } from './AssistantMessage'
 import { ChatMessage } from './ChatMessage'
 import { useT } from '../../hooks/useT'
 import { useAgents } from '../../hooks/useAgents'
+import { useConfig } from '../../hooks/useConfig'
 import { getAgentColor } from '../../lib/agents-actions'
+import { resolveSubAgentModelLabel } from '../../lib/model-value'
 import { useSessionStore } from '../../stores/session'
+import { useScopedContext } from '../../stores/session/session-scope'
 import { useDisplaySettings } from '../../hooks/useDisplaySettings'
 import { formatTokens } from '../../lib/format-stats'
 import { useAutoScroll } from '../../hooks/useAutoScroll'
@@ -73,13 +76,29 @@ export const SubAgentContainer = memo(function SubAgentContainer({
   const containerRef = useRef<HTMLDivElement>(null)
   const scrollRef = useRef<OverlayScrollbarsComponentRef<'div'>>(null)
   const [expanded, setExpanded] = useState(false)
-  const { agents } = useAgents()
+  const { currentSession } = useScopedContext()
+  const { agents, modelOverrides } = useAgents(currentSession?.workdir)
+  const { config } = useConfig()
   const contextState = useSessionStore((state) => state.subAgentContextStates[subAgentId])
   const { showThinking, showVerboseToolOutput } = useDisplaySettings()
 
   const getViewport = useViewport(scrollRef)
 
   const { isAutoScrollActive, setAutoScroll, handleScrollbarGesture } = useAutoScroll(scrollRef, null, getViewport)
+
+  const agentInfo = agents.find((a) => a.id === subAgentType)
+  const label = agentInfo?.name ?? (LABELS[subAgentType] ? t(LABELS[subAgentType]) : subAgentType)
+  const color = getAgentColor(agents, subAgentType)
+  const hStyle = headerStyle(color)
+
+  const modelLabel = resolveSubAgentModelLabel({
+    messages,
+    subAgentType,
+    modelOverrides,
+    sessionProviderModel: currentSession?.providerModel,
+    sessionReasoningEffort: currentSession?.providerReasoningEffort,
+    defaultModelSelection: config?.defaultModelSelection,
+  })
 
   const handleToggleExpand = useCallback(() => {
     const willExpand = !expanded
@@ -92,11 +111,6 @@ export const SubAgentContainer = memo(function SubAgentContainer({
     }
   }, [expanded])
 
-  const agentInfo = agents.find((a) => a.id === subAgentType)
-  const label = agentInfo?.name ?? (LABELS[subAgentType] ? t(LABELS[subAgentType]) : subAgentType)
-  const color = getAgentColor(agents, subAgentType)
-  const hStyle = headerStyle(color)
-
   const displayMessages = messages.filter((m) => m.role !== 'tool')
 
   return (
@@ -108,6 +122,14 @@ export const SubAgentContainer = memo(function SubAgentContainer({
       >
         <div className="order-1 flex items-center gap-2 min-w-0 flex-1 basis-0 @sm:basis-auto @sm:flex-none">
           <span className="text-xs font-medium truncate">{label}</span>
+          {modelLabel && (
+            <span
+              data-testid="subagent-model-badge"
+              className="text-[10px] px-1.5 py-0.5 rounded bg-bg-tertiary text-text-secondary font-mono truncate"
+            >
+              {modelLabel}
+            </span>
+          )}
         </div>
         {contextState && (
           <div

--- a/web/src/hooks/useAgents.ts
+++ b/web/src/hooks/useAgents.ts
@@ -10,5 +10,6 @@ import { agentsResource } from '../lib/resources'
 export function useAgents(workdir?: string) {
   const { data, refresh } = useResource(agentsResource, workdir)
   const agents = data ? [...data.defaults, ...data.userItems, ...data.projectItems] : []
-  return { agents, refresh }
+  const modelOverrides = data?.modelOverrides ?? {}
+  return { agents, modelOverrides, refresh }
 }

--- a/web/src/lib/model-value.test.ts
+++ b/web/src/lib/model-value.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest'
-import { formatModelValue, parseModelValue, isReasoningEffortValue, REASONING_EFFORT_VALUES } from './model-value'
+import {
+  formatModelValue,
+  parseModelValue,
+  formatShortModelLabel,
+  resolveSubAgentModelLabel,
+  isReasoningEffortValue,
+  REASONING_EFFORT_VALUES,
+} from './model-value'
 
 describe('isReasoningEffortValue', () => {
   it('recognizes known effort values', () => {
@@ -82,5 +89,101 @@ describe('parseModelValue', () => {
     expect(parseModelValue('')).toBeUndefined()
     expect(parseModelValue('no-slash')).toBeUndefined()
     expect(parseModelValue('/model')).toBeUndefined()
+  })
+})
+
+describe('formatShortModelLabel', () => {
+  it('strips provider prefixes and formats model name', () => {
+    expect(formatShortModelLabel('gemini-3.7-flash-medium')).toBe('gemini-3.7-flash-medium')
+    expect(formatShortModelLabel('provider-1/gemini-3.7-flash-medium')).toBe('gemini-3.7-flash-medium')
+    expect(formatShortModelLabel('openrouter/anthropic/claude-3.5-haiku')).toBe('claude-3.5-haiku')
+  })
+
+  it('appends reasoning effort when present', () => {
+    expect(formatShortModelLabel('gemini-3.7-flash-medium', 'high')).toBe('gemini-3.7-flash-medium:high')
+    expect(formatShortModelLabel('provider-1/deepseek-v4-flash', 'max')).toBe('deepseek-v4-flash:max')
+  })
+})
+
+describe('resolveSubAgentModelLabel', () => {
+  it('prioritizes message stats from executed turns', () => {
+    const messages = [
+      {
+        id: 'm1',
+        role: 'assistant' as const,
+        content: 'done',
+        timestamp: new Date().toISOString(),
+        stats: {
+          providerId: 'p1',
+          providerName: 'P1',
+          backend: 'openai' as const,
+          model: 'provider-1/gemini-3.7-flash-medium',
+          reasoningEffort: 'medium',
+          mode: 'verifier' as const,
+          totalTime: 10,
+          toolTime: 2,
+          prefillTokens: 100,
+          prefillSpeed: 10,
+          generationTokens: 50,
+          generationSpeed: 5,
+        },
+      },
+    ]
+
+    const result = resolveSubAgentModelLabel({
+      messages,
+      subAgentType: 'verifier',
+      modelOverrides: { verifier: 'other-provider/other-model' },
+      sessionProviderModel: 'session-model',
+      defaultModelSelection: 'default-provider/default-model',
+    })
+
+    expect(result).toBe('gemini-3.7-flash-medium:medium')
+  })
+
+  it('uses agent model override when no message stats exist', () => {
+    const result = resolveSubAgentModelLabel({
+      messages: [],
+      subAgentType: 'code_reviewer',
+      modelOverrides: { code_reviewer: 'custom-provider/deepseek-v4-flash:high' },
+      sessionProviderModel: 'session-model',
+      defaultModelSelection: 'default-provider/default-model',
+    })
+
+    expect(result).toBe('deepseek-v4-flash:high')
+  })
+
+  it('uses session provider model when no message stats and no agent override exist', () => {
+    const result = resolveSubAgentModelLabel({
+      messages: [],
+      subAgentType: 'explorer',
+      modelOverrides: {},
+      sessionProviderModel: 'my-org/claude-3.5-sonnet',
+      sessionReasoningEffort: 'low',
+      defaultModelSelection: 'default-provider/default-model',
+    })
+
+    expect(result).toBe('claude-3.5-sonnet:low')
+  })
+
+  it('uses default model selection when no stats, override, or session model exist', () => {
+    const result = resolveSubAgentModelLabel({
+      messages: [],
+      subAgentType: 'explorer',
+      modelOverrides: {},
+      sessionProviderModel: null,
+      defaultModelSelection: 'ollama/qwen2.5-coder:32b',
+    })
+
+    expect(result).toBe('qwen2.5-coder:32b')
+  })
+
+  it('returns undefined when no model can be resolved', () => {
+    const result = resolveSubAgentModelLabel({
+      messages: [],
+      subAgentType: 'explorer',
+    })
+
+    expect(result).toBeUndefined()
   })
 })

--- a/web/src/lib/model-value.ts
+++ b/web/src/lib/model-value.ts
@@ -12,6 +12,7 @@
  */
 
 import { REASONING_EFFORT_VALUES, isReasoningEffortValue } from '@shared/reasoning-effort.js'
+import type { Message } from '@shared/types.js'
 
 export { REASONING_EFFORT_VALUES, isReasoningEffortValue }
 
@@ -44,4 +45,69 @@ export function parseModelValue(value: string | undefined | null): ModelValue | 
     }
   }
   return { providerId, model: rest }
+}
+
+/**
+ * Format a model ID and optional reasoning effort into a short display label.
+ * Strips any provider prefixes ("provider/model" -> "model") and appends ":effort" if present.
+ */
+export function formatShortModelLabel(model: string, reasoningEffort?: string | null): string {
+  const shortModel = model.split('/').pop() ?? model
+  return reasoningEffort ? `${shortModel}:${reasoningEffort}` : shortModel
+}
+
+/**
+ * Resolves the display model label for a sub-agent execution context.
+ * Priority order:
+ * 1. Last assistant message stats from executed turns (most authoritative runtime source).
+ * 2. Agent-specific model override (configured per-agent override).
+ * 3. Session provider model override (active session model).
+ * 4. Global default model selection.
+ */
+export function resolveSubAgentModelLabel({
+  messages,
+  subAgentType,
+  modelOverrides,
+  sessionProviderModel,
+  sessionReasoningEffort,
+  defaultModelSelection,
+}: {
+  messages?: Message[]
+  subAgentType: string
+  modelOverrides?: Record<string, string>
+  sessionProviderModel?: string | null
+  sessionReasoningEffort?: string | null
+  defaultModelSelection?: string | null
+}): string | undefined {
+  // 1. Message stats from executed turns (runtime stats)
+  if (messages && messages.length > 0) {
+    const lastStats = messages.findLast((m) => m.role === 'assistant' && m.stats && !('error' in m.stats))?.stats
+    if (lastStats?.model) {
+      return formatShortModelLabel(lastStats.model, lastStats.reasoningEffort)
+    }
+  }
+
+  // 2. Agent model override
+  const override = modelOverrides?.[subAgentType]
+  if (override) {
+    const parsed = parseModelValue(override)
+    if (parsed?.model) {
+      return formatShortModelLabel(parsed.model, parsed.reasoningEffort)
+    }
+  }
+
+  // 3. Session provider model override
+  if (sessionProviderModel) {
+    return formatShortModelLabel(sessionProviderModel, sessionReasoningEffort)
+  }
+
+  // 4. Global default model selection
+  if (defaultModelSelection) {
+    const parsedDefault = parseModelValue(defaultModelSelection)
+    if (parsedDefault?.model) {
+      return formatShortModelLabel(parsedDefault.model, parsedDefault.reasoningEffort)
+    }
+  }
+
+  return undefined
 }


### PR DESCRIPTION
### Summary
- **Display AI Model in Sub-Agent Headers**: Added a compact monospace badge (`text-[10px]`) in the `SubAgentContainer` header right next to the agent/sub-agent name (e.g. `gemini-3.7-flash-medium:medium`, `claude-3-5-sonnet:high`, `o3-mini:low`).
- **Accurate Model Resolution Precedence**:
  1. Executed turn stats from sub-agent messages (authoritative runtime truth).
  2. Agent-specific model override (`modelOverrides`).
  3. Active session provider model.
  4. Global default model selection.
- **Provider Prefix Stripping**: Provider namespaces (e.g. `google/`, `openai/`) are stripped for clean, concise badge rendering on all screen sizes.
- **Hook Ergonomics**: `useAgents` now exposes `modelOverrides` alongside `agents` for clean consumer access without manual cache queries.

### AI-Enhanced Development
- **AI Models:** Gemini 3.7 Flash

### Cache Impact
- **No**

<img width="1077" height="94" alt="image" src="https://github.com/user-attachments/assets/281f4f1d-e330-434d-b8b3-29ff8b081a9e" />
