### PR TITLE
Fix tool output expand

### DIFF
--- a/web/src/components/shared/ToolCallDisplay.test.tsx
+++ b/web/src/components/shared/ToolCallDisplay.test.tsx
@@ -363,6 +363,125 @@ describe('ToolCallDisplay — default expansion', () => {
   })
 })
 
+describe('ToolCallDisplay — forceCompact (Show expanded tool output)', () => {
+  beforeEach(() => {
+    useSessionStore.setState({ pendingPathConfirmations: [], focusedSessionId: null, panes: {} })
+    clearCache()
+  })
+
+  afterEach(cleanup)
+
+  it('collapses when forceCompact flips on after mount (async setting arrival)', () => {
+    const { container, rerender } = render(
+      <ToolCallDisplay
+        tool="custom_tool"
+        args={{}}
+        status="success"
+        result="output"
+        variant="expandable"
+        forceCompact={false}
+      />,
+    )
+
+    expect(container.querySelector('pre')?.textContent).toContain('output')
+
+    rerender(
+      <ToolCallDisplay
+        tool="custom_tool"
+        args={{}}
+        status="success"
+        result="output"
+        variant="expandable"
+        forceCompact
+      />,
+    )
+
+    expect(container.querySelector('pre')).toBeNull()
+  })
+
+  it('starts collapsed when forceCompact is set from the first render', () => {
+    const { container } = render(
+      <ToolCallDisplay
+        tool="custom_tool"
+        args={{}}
+        status="success"
+        result="output"
+        variant="expandable"
+        forceCompact
+      />,
+    )
+
+    expect(container.querySelector('pre')).toBeNull()
+  })
+
+  it('does not clobber a manual expand once the setting has settled', () => {
+    const { container, rerender } = render(
+      <ToolCallDisplay
+        tool="custom_tool"
+        args={{}}
+        status="success"
+        result="output"
+        variant="expandable"
+        forceCompact
+      />,
+    )
+
+    fireEvent.click(container.querySelector('button') as HTMLElement)
+    expect(container.querySelector('pre')?.textContent).toContain('output')
+
+    rerender(
+      <ToolCallDisplay
+        tool="custom_tool"
+        args={{}}
+        status="success"
+        result="output"
+        variant="expandable"
+        forceCompact
+      />,
+    )
+
+    expect(container.querySelector('pre')?.textContent).toContain('output')
+  })
+
+  it('forces expansion when a pending confirmation matches even with forceCompact', () => {
+    useSessionStore.setState({ pendingPathConfirmations: [pendingConfirmation] })
+
+    const { container } = render(
+      <ToolCallDisplay
+        tool="run_command"
+        args={{ command: 'echo hello' }}
+        status="pending"
+        variant="expandable"
+        forceCompact
+        callId="call-run-1"
+      />,
+    )
+
+    expect(container.textContent).toContain('Allow')
+    expect(container.textContent).toContain('Deny')
+  })
+
+  it('expands when a confirmation arrives mid-turn on a collapsed card', async () => {
+    const { container } = render(
+      <ToolCallDisplay
+        tool="run_command"
+        args={{ command: 'echo hello' }}
+        status="pending"
+        variant="expandable"
+        forceCompact
+        callId="call-run-1"
+      />,
+    )
+
+    expect(container.textContent).not.toContain('Allow')
+
+    useSessionStore.setState({ pendingPathConfirmations: [pendingConfirmation] })
+
+    await waitFor(() => expect(container.textContent).toContain('Allow'))
+    expect(container.textContent).toContain('Deny')
+  })
+})
+
 describe('ToolCallDisplay — truncated path tooltip', () => {
   const LONG_PATH = '/home/user/very/long/project/path/to/a/source/file.ts'
 

--- a/web/src/components/shared/ToolCallDisplay.tsx
+++ b/web/src/components/shared/ToolCallDisplay.tsx
@@ -1,4 +1,4 @@
-import { memo, useState, type ComponentType } from 'react'
+import { memo, useEffect, useRef, useState, type ComponentType } from 'react'
 import { OptionalScrollArea } from './OptionalScrollArea'
 import { useDisplaySettings } from '../../hooks/useDisplaySettings'
 import type { Diagnostic, EditContextRegion } from '@shared/types.js'
@@ -124,20 +124,51 @@ export const ToolCallDisplay = memo(function ToolCallDisplay({
   callId,
 }: ToolCallDisplayProps) {
   const t = useT()
+
+  // Check if there's a pending path confirmation matching this tool call.
+  // Confirmations use composite callIds: `${toolCallId}-${seq}` so we match by prefix.
+  // In split view confirmations live on the owning pane, not the flat focused
+  // state — read them from the scoped pane so they appear instantly.
+  const scopeId = useSessionScope()
+  const pendingPathConfirmations = useScopedPaneState(
+    scopeId,
+    (pane) => pane.pendingPathConfirmations,
+    (state) => state.pendingPathConfirmations,
+    EMPTY_CONFIRMATIONS,
+  )
+  const pendingConfirmation: PendingPathConfirmation | null = callId
+    ? (pendingPathConfirmations.find((pc) => pc.callId === callId || pc.callId.startsWith(callId + '-')) ?? null)
+    : null
+
   // Expand by default for parity — a call seen streaming stays visible once it
   // finishes and a reload shows the same content. When the collapseLargeToolCalls
   // performance setting is on, large finished calls start collapsed (pending
-  // calls still expand, so a live stream never collapses mid-run). `expanded`
-  // is initialized once at mount; the component remounts when the tool call
-  // identity changes, and forceCompact comes from a display setting stable
-  // during the message's lifetime.
+  // calls still expand, so a live stream never collapses mid-run).
+  // A tool call waiting for user authorization (pendingConfirmation) is always
+  // expanded so the user sees and can interact with the action buttons.
   const { collapseLargeToolCalls } = useDisplaySettings()
   const shouldAutoExpand =
-    !forceCompact &&
-    (!collapseLargeToolCalls ||
-      status === 'pending' ||
-      getContentSize(result, streamingOutput, args) < COLLAPSE_THRESHOLD)
+    Boolean(pendingConfirmation) ||
+    (!forceCompact &&
+      (!collapseLargeToolCalls ||
+        status === 'pending' ||
+        getContentSize(result, streamingOutput, args) < COLLAPSE_THRESHOLD))
   const [expanded, setExpanded] = useState(shouldAutoExpand)
+
+  // React to async arrival of forceCompact setting or pending confirmation.
+  const prevForceCompact = useRef(forceCompact)
+  useEffect(() => {
+    if (prevForceCompact.current !== forceCompact) {
+      prevForceCompact.current = forceCompact
+      setExpanded(shouldAutoExpand)
+    }
+  }, [forceCompact, shouldAutoExpand])
+
+  useEffect(() => {
+    if (pendingConfirmation) {
+      setExpanded(true)
+    }
+  }, [pendingConfirmation])
   const config = statusConfig[status]
   const remoteProtocol = detectRemoteExecution(tool, args)
   const showEditorLink = useSetting(SETTINGS_KEYS.DISPLAY_SHOW_OPEN_IN_EDITOR).value === 'true'
@@ -154,20 +185,6 @@ export const ToolCallDisplay = memo(function ToolCallDisplay({
           })()
         : undefined
 
-  // Check if there's a pending path confirmation matching this tool call.
-  // Confirmations use composite callIds: `${toolCallId}-${seq}` so we match by prefix.
-  // In split view confirmations live on the owning pane, not the flat focused
-  // state — read them from the scoped pane so they appear instantly.
-  const scopeId = useSessionScope()
-  const pendingPathConfirmations = useScopedPaneState(
-    scopeId,
-    (pane) => pane.pendingPathConfirmations,
-    (state) => state.pendingPathConfirmations,
-    EMPTY_CONFIRMATIONS,
-  )
-  const pendingConfirmation: PendingPathConfirmation | null = callId
-    ? (pendingPathConfirmations.find((pc) => pc.callId === callId || pc.callId.startsWith(callId + '-')) ?? null)
-    : null
   // step_done is a simple completion signal — minimal inline pill, no collapsible, no args
   if (tool === 'step_done') {
     return (


### PR DESCRIPTION
### Summary
<!-- What does this PR do? Why? -->
- **Fix tool output collapse on page reload (F5)**: Resolves an issue where disabling the "Show expanded tool output" setting would still render tool calls expanded upon refreshing the page due to an initial render race condition with async settings loading.
- **Auto-expand pending confirmations**: Ensures tool calls requiring user authorization or path confirmation (with Allow/Deny buttons) always expand automatically (both on mount and mid-turn) regardless of the collapse setting so users can review and respond.
- Added comprehensive unit tests in `ToolCallDisplay.test.tsx` covering initial collapsed rendering, asynchronous settings arrival, manual toggle preservation, and forced expansion on pending confirmations.

### AI-Enhanced Development
Tell us what models helped shape this PR:
- **AI Models:** DeepSeek V4 Flash, Gemini 2.5 Flash

### Cache Impact
Does this PR affect anything cached — system prompts, tool definitions, skills, or other context?
- **No**