### PR TITLE
fix(settings): persist search engine api keys across page reloads

### DIFF
--- a/web/src/components/settings/tabs/ToolsTab.test.tsx
+++ b/web/src/components/settings/tabs/ToolsTab.test.tsx
@@ -196,6 +196,10 @@ describe('ToolsTab RTK shell hint (Windows)', () => {
     cleanup()
     delete mockSettings['tools.useRtk']
     delete mockSettings['tools.shell']
+    delete mockSettings['search.engine']
+    delete mockSettings['search.tavilyApiKey']
+    delete mockSettings['search.searxngUrl']
+    delete mockSettings['search.searxngApiKey']
   })
 
   it('shows the hint when RTK is enabled with cmd.exe', async () => {
@@ -240,5 +244,40 @@ describe('ToolsTab RTK shell hint (Windows)', () => {
     render(<ToolsTab />)
     await screen.findByText('Enable RTK auto-rewrite')
     expect(screen.queryByText(HINT_PATTERN)).toBeNull()
+  })
+})
+
+describe('ToolsTab Search Engine settings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    delete mockSettings['search.engine']
+    delete mockSettings['search.tavilyApiKey']
+    delete mockSettings['search.searxngUrl']
+    delete mockSettings['search.searxngApiKey']
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+    cleanup()
+  })
+
+  it('loads Tavily API key from settings even if search engine is not selected', async () => {
+    mockSettings['search.tavilyApiKey'] = 'tvly-saved-key-123'
+    mockSettings['search.engine'] = 'tavily'
+    render(<ToolsTab />)
+    const input = screen.getByPlaceholderText('tvly-...') as HTMLInputElement
+    expect(input.value).toBe('tvly-saved-key-123')
+  })
+
+  it('persists typed Tavily API key via debounced save', async () => {
+    mockSettings['search.engine'] = 'tavily'
+    const { fireEvent } = await import('@testing-library/react')
+    render(<ToolsTab />)
+    const input = screen.getByPlaceholderText('tvly-...') as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'tvly-new-key-456' } })
+
+    expect(mockSetSetting).not.toHaveBeenCalledWith('search.tavilyApiKey', 'tvly-new-key-456')
+    vi.advanceTimersByTime(300)
+    expect(mockSetSetting).toHaveBeenCalledWith('search.tavilyApiKey', 'tvly-new-key-456')
   })
 })

--- a/web/src/components/settings/tabs/ToolsTab.tsx
+++ b/web/src/components/settings/tabs/ToolsTab.tsx
@@ -306,14 +306,21 @@ function useDebouncedSave(
   delay = 250,
 ): void {
   const isInitialMount = useRef(true)
+  const lastSavedValue = useRef(value)
 
   useEffect(() => {
     if (isInitialMount.current) {
       isInitialMount.current = false
+      lastSavedValue.current = value
+      return
+    }
+
+    if (value === lastSavedValue.current) {
       return
     }
 
     const timer = setTimeout(() => {
+      lastSavedValue.current = value
       setSetting(settingsKey, value)
     }, delay)
 
@@ -359,10 +366,10 @@ export function ToolsTab() {
   const perSessionMcpSetting = useSetting(SETTINGS_KEYS.FEATURES_PER_SESSION_MCP).value
 
   // ── Search Engine state ──
-  const [searchEngine, setSearchEngine] = useState('')
-  const [tavilyKey, setTavilyKey] = useState('')
-  const [searxngUrl, setSearxngUrl] = useState('')
-  const [searxngKey, setSearxngKey] = useState('')
+  const [searchEngine, setSearchEngine] = useState(searchEngineSetting)
+  const [tavilyKey, setTavilyKey] = useState(tavilyKeySetting)
+  const [searxngUrl, setSearxngUrl] = useState(searxngUrlSetting)
+  const [searxngKey, setSearxngKey] = useState(searxngKeySetting)
 
   useDebouncedSave(tavilyKey, SETTINGS_KEYS.SEARCH_TAVILY_API_KEY, setSetting)
   useDebouncedSave(searxngUrl, SETTINGS_KEYS.SEARCH_SEARXNG_URL, setSetting)
@@ -372,13 +379,20 @@ export function ToolsTab() {
   const [searxngTestText, searxngTestError, searxngTestSuccess, testSearxng] = useTestButton()
 
   useEffect(() => {
-    if (searchEngineSetting !== '') {
-      setSearchEngine(searchEngineSetting)
-      setTavilyKey(tavilyKeySetting)
-      setSearxngUrl(searxngUrlSetting)
-      setSearxngKey(searxngKeySetting)
-    }
-  }, [searchEngineSetting, tavilyKeySetting, searxngUrlSetting, searxngKeySetting])
+    setSearchEngine(searchEngineSetting)
+  }, [searchEngineSetting])
+
+  useEffect(() => {
+    setTavilyKey(tavilyKeySetting)
+  }, [tavilyKeySetting])
+
+  useEffect(() => {
+    setSearxngUrl(searxngUrlSetting)
+  }, [searxngUrlSetting])
+
+  useEffect(() => {
+    setSearxngKey(searxngKeySetting)
+  }, [searxngKeySetting])
 
   function handleEngineChange(engine: string) {
     setSearchEngine(engine)


### PR DESCRIPTION
### Summary
<!-- What does this PR do? Why? -->
Fixes an issue where the Tavily API key (and SearXNG settings) were not loaded or persisted properly upon refreshing the page (F5) or restarting the application. 
- Decoupled search engine credentials synchronization from `searchEngineSetting !== ''` so loaded settings populate the local state independently.
- Added a `lastSavedValue` ref guard in `useDebouncedSave` to prevent redundant debounced saves.
- Added unit tests in `ToolsTab.test.tsx` verifying key loading and debounced persistence.

### AI-Enhanced Development
Tell us what models helped shape this PR:
- **AI Models:** Gemini 2.5 Flash

### Cache Impact
Does this PR affect anything cached — system prompts, tool definitions, skills, or other context?
- **No**