### PR TITLE
Option to skip git init on non-git projects.

### DIFF
--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -100,6 +100,7 @@ const databaseSchema = z.object({
 
 const workspaceSchema = z.object({
   workdir: z.string().default(process.cwd()),
+  autoGitInit: z.boolean().optional(),
 })
 
 const visionFallbackSchema = z.object({

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -405,8 +405,10 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
       return res.status(400).json({ error: 'name and workdir are required' })
     }
     const { createProjectDirectory } = await import('./utils/project-creator.js')
+    const { loadGlobalConfig } = await import('../cli/config.js')
+    const globalConfig = await loadGlobalConfig(config.mode ?? 'production', config.globalConfigPath)
     try {
-      const project = await createProjectDirectory(name, workdir)
+      const project = await createProjectDirectory(name, workdir, globalConfig.workspace?.autoGitInit ?? true)
       res.status(201).json({ project })
     } catch (err) {
       const eaccError = err as Error & { code?: string; cause?: unknown }
@@ -3680,7 +3682,9 @@ export async function createServerHandle(config: Config): Promise<ServerHandle> 
     listProjects: () => listProjects(),
     createProject: async (name, workdir) => {
       const { createProjectDirectory } = await import('./utils/project-creator.js')
-      return createProjectDirectory(name, workdir)
+      const { loadGlobalConfig } = await import('../cli/config.js')
+      const globalConfig = await loadGlobalConfig(config.mode ?? 'production', config.globalConfigPath)
+      return createProjectDirectory(name, workdir, globalConfig.workspace?.autoGitInit ?? true)
     },
     deleteProject: (projectId) => {
       const project = getProject(projectId)

--- a/src/server/mcp/server/tools.ts
+++ b/src/server/mcp/server/tools.ts
@@ -198,7 +198,7 @@ export function createOpenFoxMcpTools(deps: OpenFoxMcpToolDeps): OpenFoxMcpTool[
     {
       name: 'openfox_create_project',
       description:
-        'Create a new OpenFox project at the given directory. Creates the directory and initializes git if missing, then registers the project.',
+        'Create a new OpenFox project at the given directory. Creates the directory and registers the project, initializing git if missing (unless auto git init is disabled in config).',
       inputSchema: {
         name: z.string().describe('Project name (letters, numbers, hyphens, underscores, dots, spaces)'),
         workdir: z.string().describe('Absolute path of the project directory'),

--- a/src/server/mcp/server/types.ts
+++ b/src/server/mcp/server/types.ts
@@ -15,7 +15,7 @@ export interface WorkflowListItem {
 export interface OpenFoxMcpToolDeps {
   sessionManager: SessionManager
   listProjects(): Project[]
-  /** Create a project at the given directory (creates the dir + git init, then registers it). */
+  /** Create a project at the given directory (creates the dir, initializes git if enabled, then registers it). */
   createProject(name: string, workdir: string): Promise<Project>
   /** Delete a project and all its sessions. Returns whether a project was found and removed. */
   deleteProject(projectId: string): boolean

--- a/src/server/utils/project-creator.test.ts
+++ b/src/server/utils/project-creator.test.ts
@@ -106,6 +106,20 @@ describe('project-creator', () => {
       expect(await checkExists(join(fullPath, '.git'))).toBe(false)
     })
 
+    it('creates the project without git when autoGitInit is disabled', async () => {
+      const fullPath = join(testDir, 'no-auto-git-project')
+      vi.mocked(execSync).mockImplementation(() => {
+        throw new Error('git must not be called when autoGitInit is disabled')
+      })
+
+      const project = await createProjectDirectory('no-auto-git-project', fullPath, false)
+
+      expect(project.name).toBe('no-auto-git-project')
+      expect(project.workdir).toBe(fullPath)
+      expect(await checkExists(fullPath)).toBe(true)
+      expect(await checkExists(join(fullPath, '.git'))).toBe(false)
+    })
+
     it('fails and cleans up when git init fails for a non-missing reason', async () => {
       const fullPath = join(testDir, 'git-fail-project')
       vi.mocked(execSync).mockImplementation(() => {

--- a/src/server/utils/project-creator.ts
+++ b/src/server/utils/project-creator.ts
@@ -39,7 +39,7 @@ function isGitMissing(err: unknown): boolean {
   return /is not recognized as an internal or external command/i.test(e.message)
 }
 
-export async function createProjectDirectory(projectName: string, workdir: string): Promise<Project> {
+export async function createProjectDirectory(projectName: string, workdir: string, autoGitInit = true): Promise<Project> {
   const validation = validateProjectName(projectName)
   if (!validation.valid) {
     throw new Error(validation.error)
@@ -84,7 +84,7 @@ export async function createProjectDirectory(projectName: string, workdir: strin
     }
   }
 
-  if (!(await directoryExists(join(fullPath, '.git')))) {
+  if (autoGitInit && !(await directoryExists(join(fullPath, '.git')))) {
     const cleanExecEnv = (): Record<string, string | undefined> => {
       const env = { ...process.env }
       delete env['GIT_DIR']


### PR DESCRIPTION
### Summary

Attempted correction for #185 (/!\ no tests were run because no vitest available - though very little impact on code)

### AI-Enhanced Development

Tell what models helped shape this PR:

- **AI Models:** <!-- e.g., DeepSeek V4 Flash, Qwen 3.5 122B, GPT 5.6, etc. -->

Qwen3.8-27b on OpenFox 2.0.143

### Cache Impact

Does this PR affect anything cached — system prompts, tool definitions, skills, or other context?

- **No**
