### PR TITLE
feat: add plugins and corporate proxy informational banners to Provider page

### DIFF
--- a/web/src/components/layout/Header.test.tsx
+++ b/web/src/components/layout/Header.test.tsx
@@ -761,4 +761,17 @@ describe('Header mobile menu', () => {
     const tasksItem = Array.from(menu!.querySelectorAll('button')).find((b) => b.textContent?.includes('Tasks'))
     expect(tasksItem?.textContent).toContain('3')
   })
+
+  it('opens GlobalSettingsModal on OPEN_SETTINGS_EVENT with target tab', async () => {
+    const { Header } = await import('./Header')
+    const { OPEN_SETTINGS_EVENT } = await import('../settings/GlobalSettingsModal')
+    render(<Header />)
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent(OPEN_SETTINGS_EVENT, { detail: { tab: 'plugins' } }))
+    })
+
+    const settingsModal = document.querySelector('[data-global-settings]')
+    expect(settingsModal).toBeTruthy()
+  })
 })

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -24,7 +24,7 @@ import { useUpdateStore } from '../../stores/update'
 import { useKeybindings, useBinding } from '../../hooks/useKeybindings'
 import { formatKeybinding } from '../../lib/keybindings'
 import { authFetch, hasStoredToken } from '../../lib/api'
-import { GlobalSettingsModal } from '../settings/GlobalSettingsModal'
+import { GlobalSettingsModal, OPEN_SETTINGS_EVENT, type SettingsTab } from '../settings/GlobalSettingsModal'
 import { TerminalDrawer } from '../terminal/TerminalDrawer'
 import { ProjectDropdown } from './ProjectDropdown'
 import { SessionDropdown } from './SessionDropdown'
@@ -42,6 +42,7 @@ interface HeaderProps {
 export function Header({ onMenuClick, onCriteriaToggle }: HeaderProps) {
   const t = useT()
   const [showSettings, setShowSettings] = useState(false)
+  const [initialSettingsTab, setInitialSettingsTab] = useState<SettingsTab | undefined>(undefined)
   const [sessionDropdownOpen, setSessionDropdownOpen] = useState(false)
   const [isFullscreen, setIsFullscreen] = useState(!!document.fullscreenElement)
   const [location, setLocation] = useLocation()
@@ -81,6 +82,16 @@ export function Header({ onMenuClick, onCriteriaToggle }: HeaderProps) {
     const handler = () => setSessionDropdownOpen(true)
     window.addEventListener('open-session-dropdown', handler)
     return () => window.removeEventListener('open-session-dropdown', handler)
+  }, [])
+
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const customEvent = e as CustomEvent<{ tab?: SettingsTab }>
+      setInitialSettingsTab(customEvent.detail?.tab)
+      setShowSettings(true)
+    }
+    window.addEventListener(OPEN_SETTINGS_EVENT, handler)
+    return () => window.removeEventListener(OPEN_SETTINGS_EVENT, handler)
   }, [])
 
   const connectionStatus = useSessionStore((state) => state.connectionStatus)
@@ -353,7 +364,14 @@ export function Header({ onMenuClick, onCriteriaToggle }: HeaderProps) {
         )}
       </div>
 
-      <GlobalSettingsModal isOpen={showSettings} onClose={() => setShowSettings(false)} />
+      <GlobalSettingsModal
+        isOpen={showSettings}
+        initialTab={initialSettingsTab}
+        onClose={() => {
+          setShowSettings(false)
+          setInitialSettingsTab(undefined)
+        }}
+      />
       <TerminalDrawer isOpen={terminalIsOpen} onClose={() => setTerminalOpen(false)} />
       {project && (
         <TasksModal isOpen={tasksModalOpen} onClose={() => setTasksModalOpen(false)} projectId={project.id} />

--- a/web/src/components/settings/GlobalSettingsModal.tsx
+++ b/web/src/components/settings/GlobalSettingsModal.tsx
@@ -1,5 +1,5 @@
 import { ScrollArea } from '../shared/ScrollArea'
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { Modal } from '../shared/SelfContainedModal'
 import { useT } from '../../hooks/useT'
 import { NotificationSettings } from './NotificationSettings'
@@ -13,19 +13,33 @@ import { PluginsTab } from './tabs/PluginsTab'
 import { useUpdateStore } from '../../stores/update'
 import { wsClient } from '../../lib/ws'
 
+export type SettingsTab =
+  'instructions' | 'skills' | 'plugins' | 'notifications' | 'display' | 'keybindings' | 'advanced' | 'tools'
+
+export const OPEN_SETTINGS_EVENT = 'open-global-settings'
+
+export function openSettings(tab?: SettingsTab) {
+  window.dispatchEvent(new CustomEvent(OPEN_SETTINGS_EVENT, { detail: { tab } }))
+}
+
 interface GlobalSettingsModalProps {
   isOpen: boolean
   onClose: () => void
+  initialTab?: SettingsTab
 }
 
-type Tab = 'instructions' | 'skills' | 'plugins' | 'notifications' | 'display' | 'keybindings' | 'advanced' | 'tools'
+export function GlobalSettingsModal({ isOpen, onClose, initialTab }: GlobalSettingsModalProps) {
+  const [activeTab, setActiveTab] = useState<SettingsTab>(initialTab ?? 'instructions')
 
-export function GlobalSettingsModal({ isOpen, onClose }: GlobalSettingsModalProps) {
-  const [activeTab, setActiveTab] = useState<Tab>('instructions')
+  useEffect(() => {
+    if (isOpen && initialTab) {
+      setActiveTab(initialTab)
+    }
+  }, [isOpen, initialTab])
   const updateAvailable = useUpdateStore((state) => state.status === 'available')
   const t = useT()
 
-  const tabs: { id: Tab; label: string; showDot?: boolean }[] = [
+  const tabs: { id: SettingsTab; label: string; showDot?: boolean }[] = [
     { id: 'instructions', label: t({ en: 'Instructions', fr: 'Instructions' }) },
     { id: 'tools', label: t({ en: 'Tools', fr: 'Outils' }) },
     { id: 'skills', label: t({ en: 'Skills', fr: 'Compétences' }) },

--- a/web/src/components/shared/ProviderModal.test.tsx
+++ b/web/src/components/shared/ProviderModal.test.tsx
@@ -34,7 +34,7 @@ async function renderProviderModal(props: Partial<ComponentProps<typeof Provider
       isOpen={true}
       onClose={vi.fn()}
       onSave={onSaveMock as (provider: ProviderFormData) => void}
-      initialStep={2}
+      initialStep={props.initialStep ?? 2}
       {...props}
     />,
   )
@@ -1561,5 +1561,94 @@ describe('ProviderModal - model mode merge', () => {
     expect(savedData.models.length).toBe(1)
     expect(savedData.models[0]?.id).toBe('model-kept')
     expect(savedData.models[0]?.selected).toBe(true)
+  })
+})
+
+describe('ProviderModal - plugins and proxy informational banners (Step 1)', () => {
+  setupRoot()
+
+  beforeEach(() => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input)
+        if (url.includes('/api/provider-presets')) {
+          return new Response(JSON.stringify({ presets: [] }), { status: 200 })
+        }
+        return new Response(JSON.stringify({}), { status: 200 })
+      }),
+    )
+  })
+
+  it('renders plugins banner and dispatches open-settings event on click', async () => {
+    const dispatchSpy = vi.spyOn(window, 'dispatchEvent')
+    const onCloseMock = vi.fn()
+
+    await renderProviderModal({ initialStep: 1, onClose: onCloseMock }, 100)
+
+    const pluginsBanner = document.body.querySelector('[data-testid="provider-modal-plugins-banner"]')
+    expect(pluginsBanner).toBeTruthy()
+    expect(pluginsBanner?.textContent).toContain("Can't find your AI provider?")
+
+    const pluginsBtn = pluginsBanner?.querySelector('button')
+    expect(pluginsBtn).toBeTruthy()
+    pluginsBtn?.click()
+
+    expect(onCloseMock).toHaveBeenCalledTimes(1)
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'open-global-settings',
+        detail: { tab: 'plugins' },
+      }),
+    )
+  })
+
+  it('renders proxy banner when no providers are configured', async () => {
+    const dispatchSpy = vi.spyOn(window, 'dispatchEvent')
+    const onCloseMock = vi.fn()
+
+    await renderProviderModal({ initialStep: 1, onClose: onCloseMock }, 100)
+
+    const proxyBanner = document.body.querySelector('[data-testid="provider-modal-proxy-banner"]')
+    expect(proxyBanner).toBeTruthy()
+    expect(proxyBanner?.textContent).toContain('Behind a corporate proxy?')
+
+    const proxyBtn = proxyBanner?.querySelector('button')
+    expect(proxyBtn).toBeTruthy()
+    proxyBtn?.click()
+
+    expect(onCloseMock).toHaveBeenCalledTimes(1)
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'open-global-settings',
+        detail: { tab: 'advanced' },
+      }),
+    )
+  })
+
+  it('hides proxy banner when at least one provider is configured', async () => {
+    const { providersResource } = await import('../../lib/resources')
+    providersResource.write({
+      providers: [
+        {
+          id: 'existing-provider',
+          name: 'Existing Provider',
+          url: 'http://localhost:8000',
+          backend: 'vllm',
+          models: [],
+          isActive: true,
+          createdAt: new Date().toISOString(),
+        },
+      ],
+      activeProviderId: 'existing-provider',
+    })
+
+    await renderProviderModal({ initialStep: 1 }, 100)
+
+    const proxyBanner = document.body.querySelector('[data-testid="provider-modal-proxy-banner"]')
+    expect(proxyBanner).toBeNull()
+
+    // Reset providers resource cache after test
+    providersResource.write({ providers: [], activeProviderId: null })
   })
 })

--- a/web/src/components/shared/ProviderModal.tsx
+++ b/web/src/components/shared/ProviderModal.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useRef, useMemo } from 'react'
 import { authFetch } from '../../lib/api'
 import type { Backend } from '../../stores/config'
 import type { ModelConfig as SharedModelConfig } from '@shared/types.js'
-import { ChevronDownIcon, EyeIcon, ReloadIcon, SettingsIcon } from './icons'
+import { ChevronDownIcon, EyeIcon, InfoIcon, ReloadIcon, SettingsIcon } from './icons'
 import { QueryParamsInput } from './QueryParamsInput'
 import { formatTokens } from '../../lib/format-stats'
 import { getLocale } from '@shared/i18n/index.js'
@@ -13,6 +13,8 @@ import { shouldAutofocus } from '../../lib/device'
 import { REASONING_EFFORT_VALUES } from '../../lib/model-value'
 import { isSmallContext } from '../../lib/context-warning'
 import { groupModeFamilies, MODE_SUFFIXES, splitModeSuffix } from '@shared/reasoning-effort.js'
+import { openSettings } from '../settings/GlobalSettingsModal'
+import { useProviders } from '../../hooks/useProviders'
 
 const COMMON_PORTS = [8080, 11434, 8000, 1234, 8888]
 
@@ -759,7 +761,8 @@ export function ProviderModal({
   const urlInputRef = useRef<HTMLInputElement>(null)
   const manualModelInputRef = useRef<HTMLInputElement>(null)
 
-  // Models that were already merged into mode chips (have a `modes` map).
+  const { providers } = useProviders()
+  const hasConfiguredProviders = providers.length > 0
   const mergedModeModels = useMemo(() => models.filter((m) => m.modes?.length), [models])
   // Families of suffixed variants still present in the list — only non-empty
   // after an Unmerge re-expands a merged model, so a Merge button appears then
@@ -1568,6 +1571,61 @@ export function ProviderModal({
                   )
                 })}
               </div>
+            </div>
+
+            {/* Informational banners */}
+            <div className="space-y-2">
+              <div
+                data-testid="provider-modal-plugins-banner"
+                className="flex items-center justify-between gap-3 p-3 rounded-lg border border-border bg-bg-secondary text-sm text-text-secondary"
+              >
+                <div className="flex items-center gap-2.5 min-w-0">
+                  <InfoIcon className="w-4 h-4 text-accent-primary flex-shrink-0" />
+                  <span className="leading-snug">
+                    {t({
+                      en: "Can't find your AI provider? Check OpenFox plugins to see if one is available.",
+                      fr: "Vous ne trouvez pas votre fournisseur d'IA ? Consultez les plugins OpenFox qui pourraient le proposer.",
+                    })}
+                  </span>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => {
+                    handleClose()
+                    openSettings('plugins')
+                  }}
+                  className="flex-shrink-0 px-3 py-1 rounded border border-border text-xs text-text-primary hover:border-accent-primary hover:text-accent-primary hover:bg-accent-primary/10 transition-colors"
+                >
+                  {t({ en: 'Plugins', fr: 'Plugins' })}
+                </button>
+              </div>
+
+              {!hasConfiguredProviders && (
+                <div
+                  data-testid="provider-modal-proxy-banner"
+                  className="flex items-center justify-between gap-3 p-3 rounded-lg border border-border bg-bg-secondary text-sm text-text-secondary"
+                >
+                  <div className="flex items-center gap-2.5 min-w-0">
+                    <InfoIcon className="w-4 h-4 text-accent-primary flex-shrink-0" />
+                    <span className="leading-snug">
+                      {t({
+                        en: 'Behind a corporate proxy? Remember to configure it in settings.',
+                        fr: 'Vous utilisez un proxy d’entreprise ? Pensez à le configurer dans les paramètres.',
+                      })}
+                    </span>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      handleClose()
+                      openSettings('advanced')
+                    }}
+                    className="flex-shrink-0 px-3 py-1 rounded border border-border text-xs text-text-primary hover:border-accent-primary hover:text-accent-primary hover:bg-accent-primary/10 transition-colors"
+                  >
+                    {t({ en: 'Configure proxy', fr: 'Configurer le proxy' })}
+                  </button>
+                </div>
+              )}
             </div>
 
             {!formAuthAdapter && (


### PR DESCRIPTION
### Summary

- **Plugins Info Banner**: Added an informational banner above "Provider URL" in `ProviderModal` (Step 1) letting users know they can check OpenFox plugins if their AI provider is not listed, with a direct CTA button opening Settings on the **Plugins** tab.
- **Corporate Proxy Banner**: Added a dedicated informational banner above "Provider URL" prompting users behind enterprise firewalls to configure their network proxy in Settings > Advanced, with a CTA button opening the **Advanced** tab. This banner is conditionally rendered only when 0 providers are configured.
- **Global Settings Navigation**: Added programmatic navigation to open `GlobalSettingsModal` focused on a target tab (`openSettings(tab)` event), cleanly dismissing `ProviderModal`.
- **i18n & Tests**: Added full English and French localization and comprehensive unit test coverage in `ProviderModal.test.tsx` and `Header.test.tsx`.

### AI-Enhanced Development

Tell what models helped shape this PR:

- **AI Models:** Gemini 3.7 Flash

### Cache Impact

Does this PR affect anything cached — system prompts, tool definitions, skills, or other context?

- **No**